### PR TITLE
fix(mxClient) Fixes NO_FO (foreignObject support is not available) test

### DIFF
--- a/packages/core/src/mxClient.js
+++ b/packages/core/src/mxClient.js
@@ -366,7 +366,7 @@ const mxClient = {
       document.createElementNS(
         'http://www.w3.org/2000/svg',
         'foreignObject'
-      ) !== '[object SVGForeignObjectElement]' ||
+      ).toString() !== '[object SVGForeignObjectElement]' ||
       navigator.userAgent.indexOf('Opera/') >= 0),
 
   /**


### PR DESCRIPTION
We test a global config variable `mxClient.NO_FO` in one key area of the CellRenderer: https://github.com/maxGraph/maxGraph/blob/74b67a60a4bf1fb3ffe7710e52100c6c9668ffe9/packages/core/src/view/cell/CellRenderer.ts#L542

This variable is responsible for detecting if the current client supports the `<foreign-object />` svg element. The `<foreign-object />` element is the substrate used by HTML labels. If the `NO_FO` variable is set to false, the `<foreign-object />` element is not rendered in the SVG output and non-string labels are not rendered.

Currently, the initialization test for `mxClient.NO_FO` does the following comparison:

```javascript
     document.createElementNS(
        'http://www.w3.org/2000/svg',
        'foreignObject'
      ) !== '[object SVGForeignObjectElement]'
```

But the output of `document.createElementNS(...)` is an `SVGElement` which will always pass the condition above. This PR simply requests the stringified representation of this `SVGElement` which will match the RHS.