### PR TITLE
chore(storybook): fix server start and warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@lerna/filter-options": "^4.0.0",
     "babel-loader": "^8.2.3",
     "better-docs": "^2.3.2",
-    "cross-env": "^7.0.3",
     "css-loader": "^6.5.1",
     "file-loader": "^6.2.0",
     "jsdoc": "^3.6.7",

--- a/packages/html/.storybook/main.js
+++ b/packages/html/.storybook/main.js
@@ -6,5 +6,6 @@ module.exports = {
   "addons": [
     "@storybook/addon-links",
     "@storybook/addon-essentials"
-  ]
+  ],
+  staticDirs: ['../public'],
 }

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "cross-env NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 8901 -s ./public"
+    "dev": "start-storybook -p 8901"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
Remove the extra NODE_OPTIONS in storybook server start script that generated an
error.
Remove cross-env devDependency which is then not used anymore.
Fix storybook deprecation warning (static dirs)

**Notes**
The NODE_OPTIONS had been added as a workaround to try to make the storybook start work with node 17 (see  bd70a740)
See also https://github.com/maxGraph/maxGraph/discussions/64#discussioncomment-1968936
For the configuration warning fix, I followed https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated---static-dir-cli-flag

I have tested the changes with node v16.13.1, npm 8.3.0 on Ubuntu 20.04.3 LTS
