### PR TITLE
Fixes the 'Anchors' example.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ javascript/dist
 .jshintrc
 javascript/examples/**/dist
 .idea/
+.vscode/
 *.iml
 dist
 package-lock.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.formatOnSave": true
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true
+}

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -1,0 +1,1 @@
+declare module '*.gif';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -42,7 +42,7 @@ export type CellStateStyles = {
   defaultVertex?: CellStateStyles;
   deletable?: boolean;
   direction?: DirectionValue;
-  edge?: string;
+  edgeStyle?: string;
   editable?: boolean;
   elbow?: string;
   endArrow?: ArrowType;

--- a/packages/core/src/view/GraphView.ts
+++ b/packages/core/src/view/GraphView.ts
@@ -14,17 +14,8 @@ import RectangleShape from './geometry/node/RectangleShape';
 import { ALIGN } from '../util/Constants';
 import Client from '../Client';
 import InternalEvent from './event/InternalEvent';
-import {
-  convertPoint,
-  getCurrentStyle,
-  getOffset,
-} from '../util/styleUtils';
-import {
-  getRotatedPoint,
-  ptSegDistSq,
-  relativeCcw,
-  toRadians,
-} from '../util/mathUtils';
+import { convertPoint, getCurrentStyle, getOffset } from '../util/styleUtils';
+import { getRotatedPoint, ptSegDistSq, relativeCcw, toRadians } from '../util/mathUtils';
 import MaxLog from '../gui/MaxLog';
 import Translations from '../util/Translations';
 import CellState from './cell/CellState';
@@ -48,7 +39,6 @@ import { MouseEventListener } from '../types';
 
 import ObjectCodec from '../serialization/ObjectCodec';
 import CodecRegistry from '../serialization/CodecRegistry';
-
 
 /**
  * @class GraphView
@@ -236,9 +226,7 @@ export class GraphView extends EventSource {
         this.viewStateChanged();
       }
     }
-    this.fireEvent(
-      new EventObject(InternalEvent.SCALE, { scale: value, previousScale })
-    );
+    this.fireEvent(new EventObject(InternalEvent.SCALE, { scale: value, previousScale }));
   }
 
   /**
@@ -415,10 +403,10 @@ export class GraphView extends EventSource {
     }
 
     this.fireEvent(
-      new EventObject(InternalEvent.SCALE_AND_TRANSLATE, { 
-        scale, 
-        previousScale, 
-        translate: this.translate, 
+      new EventObject(InternalEvent.SCALE_AND_TRANSLATE, {
+        scale,
+        previousScale,
+        translate: this.translate,
         previousTranslate: previousTranslate,
       })
     );
@@ -1320,15 +1308,17 @@ export class GraphView extends EventSource {
     let edgeStyle = this.isLoopStyleEnabled(edge, points, source, target)
       ? edge.style.loop ?? this.graph.defaultLoopStyle
       : !edge.style.noEdgeStyle ?? false
-      ? edge.style.edge
+      ? edge.style.edgeStyle
       : null;
 
     // Converts string values to objects
     if (typeof edgeStyle === 'string') {
       let tmp = StyleRegistry.getValue(edgeStyle);
+
       if (!tmp && this.isAllowEval()) {
         tmp = eval(edgeStyle);
       }
+
       edgeStyle = tmp;
     }
 
@@ -2267,11 +2257,11 @@ export class GraphView extends EventSource {
    */
   createHtml() {
     var container = this.graph.container;
-    
+
     if (container != null) {
       this.canvas = this.createHtmlPane('100%', '100%');
       this.canvas.style.overflow = 'hidden';
-    
+
       // Uses minimal size for inner DIVs on Canvas. This is required
       // for correct event processing in IE. If we have an overlapping
       // DIV then the events on the cells are only fired for labels.
@@ -2279,20 +2269,20 @@ export class GraphView extends EventSource {
       this.drawPane = this.createHtmlPane('1px', '1px');
       this.overlayPane = this.createHtmlPane('1px', '1px');
       this.decoratorPane = this.createHtmlPane('1px', '1px');
-      
+
       this.canvas.appendChild(this.backgroundPane);
       this.canvas.appendChild(this.drawPane);
       this.canvas.appendChild(this.overlayPane);
       this.canvas.appendChild(this.decoratorPane);
 
       container.appendChild(this.canvas);
-      this.updateContainerStyle(container);      
+      this.updateContainerStyle(container);
     }
-  };
+  }
 
   /**
    * Function: updateHtmlCanvasSize
-   * 
+   *
    * Updates the size of the HTML canvas.
    */
   updateHtmlCanvasSize(width: number, height: number) {
@@ -2312,16 +2302,16 @@ export class GraphView extends EventSource {
         this.canvas.style.height = '100%';
       }
     }
-  };
+  }
 
   /**
    * Function: createHtmlPane
-   * 
+   *
    * Creates and returns a drawing pane in HTML (DIV).
    */
   createHtmlPane(width: string, height: string) {
     var pane = document.createElement('DIV');
-    
+
     if (width != null && height != null) {
       pane.style.position = 'absolute';
       pane.style.left = '0px';
@@ -2329,12 +2319,11 @@ export class GraphView extends EventSource {
 
       pane.style.width = width;
       pane.style.height = height;
-
     } else {
       pane.style.position = 'relative';
     }
     return pane;
-  };
+  }
 
   /**
    * Updates the style of the container after installing the SVG DOM elements.
@@ -2357,8 +2346,8 @@ export class GraphView extends EventSource {
    * Destroys the view and all its resources.
    */
   destroy() {
-    let root: SVGElement | HTMLElement | null=null; 
-    
+    let root: SVGElement | HTMLElement | null = null;
+
     if (this.canvas && this.canvas instanceof SVGElement) {
       root = this.canvas.ownerSVGElement as SVGElement;
     }

--- a/packages/core/src/view/handler/ConnectionHandler.ts
+++ b/packages/core/src/view/handler/ConnectionHandler.ts
@@ -610,7 +610,6 @@ class ConnectionHandler extends EventSource implements GraphPlugin {
    * Starts a new connection for the given state and coordinates.
    */
   start(state: CellState, x: number, y: number, edgeState: CellState) {
-    console.log("ConnectionHandler start");
     this.previous = state;
     this.first = new Point(x, y);
     this.edgeState = edgeState ?? this.createEdgeState();
@@ -1191,9 +1190,8 @@ class ConnectionHandler extends EventSource implements GraphPlugin {
         // Uses edge state to compute the terminal points
         if (this.edgeState) {
           this.updateEdgeState(current, constraint);
-          current = this.edgeState.absolutePoints[
-            this.edgeState.absolutePoints.length - 1
-          ];
+          current =
+            this.edgeState.absolutePoints[this.edgeState.absolutePoints.length - 1];
           pt2 = this.edgeState.absolutePoints[0];
         } else {
           if (this.currentState) {
@@ -1225,9 +1223,8 @@ class ConnectionHandler extends EventSource implements GraphPlugin {
           let tmp = pt2;
 
           if (this.edgeState && this.edgeState.absolutePoints.length >= 2) {
-            const tmp2 = this.edgeState.absolutePoints[
-              this.edgeState.absolutePoints.length - 2
-            ];
+            const tmp2 =
+              this.edgeState.absolutePoints[this.edgeState.absolutePoints.length - 2];
 
             if (tmp2) {
               tmp = tmp2;

--- a/packages/core/src/view/mixins/CellsMixin.ts
+++ b/packages/core/src/view/mixins/CellsMixin.ts
@@ -577,6 +577,7 @@ export const CellsMixin: PartialType = {
     if (!style) {
       style = {} as CellStateStyles;
     }
+
     return style;
   },
 
@@ -2009,7 +2010,9 @@ export const CellsMixin: PartialType = {
           this.resetEdges(cells);
         }
 
-        this.fireEvent(new EventObject(InternalEvent.CELLS_MOVED, { cells, dx, dy, disconnect }));
+        this.fireEvent(
+          new EventObject(InternalEvent.CELLS_MOVED, { cells, dx, dy, disconnect })
+        );
       });
     }
   },
@@ -2755,9 +2758,8 @@ export const CellsMixin: PartialType = {
    */
   isCellResizable(cell) {
     const style = this.getCurrentCellStyle(cell);
-    const r = this.isCellsResizable() && 
-              !this.isCellLocked(cell) && 
-              (style.resizable ?? true);
+    const r =
+      this.isCellsResizable() && !this.isCellLocked(cell) && (style.resizable ?? true);
     return r;
   },
 

--- a/packages/core/src/view/style/EdgeStyle.ts
+++ b/packages/core/src/view/style/EdgeStyle.ts
@@ -113,7 +113,13 @@ class EdgeStyle {
    * @param result Array of <Point> that represent the actual points of the
    * edge.
    */
-  static EntityRelation(state: CellState, source: CellState, target: CellState, points: Point[], result: Point[]) {
+  static EntityRelation(
+    state: CellState,
+    source: CellState,
+    target: CellState,
+    points: Point[],
+    result: Point[]
+  ) {
     const { view } = state;
     const { graph } = view;
     const segment = getValue(state.style, 'segment', ENTITY_SEGMENT) * view.scale;
@@ -218,7 +224,13 @@ class EdgeStyle {
   /**
    * Implements a self-reference, aka. loop.
    */
-  static Loop(state: CellState, source: CellState, target: CellState, points: Point[], result: Point[]) {
+  static Loop(
+    state: CellState,
+    source: CellState,
+    target: CellState,
+    points: Point[],
+    result: Point[]
+  ) {
     const pts = state.absolutePoints;
 
     const p0 = pts[0];
@@ -295,7 +307,13 @@ class EdgeStyle {
    * unspecified. See <EntityRelation> for a description of the
    * parameters.
    */
-  static ElbowConnector(state: CellState, source: CellState, target: CellState, points: Point[], result: Point[]) {
+  static ElbowConnector(
+    state: CellState,
+    source: CellState,
+    target: CellState,
+    points: Point[],
+    result: Point[]
+  ) {
     let pt = points != null && points.length > 0 ? points[0] : null;
 
     let vertical = false;
@@ -312,7 +330,6 @@ class EdgeStyle {
         pt = <Point>state.view.transformControlPoint(state, pt);
         vertical = pt.y < top || pt.y > bottom;
         horizontal = pt.x < left || pt.x > right;
-
       } else {
         const left = Math.max(source.x, target.x);
         const right = Math.min(source.x + source.width, target.x + target.width);
@@ -338,7 +355,13 @@ class EdgeStyle {
    * Implements a vertical elbow edge. See <EntityRelation> for a description
    * of the parameters.
    */
-  static SideToSide(state: CellState, source: CellState, target: CellState, points: Point[], result: Point[]) {
+  static SideToSide(
+    state: CellState,
+    source: CellState,
+    target: CellState,
+    points: Point[],
+    result: Point[]
+  ) {
     const { view } = state;
     let pt = points != null && points.length > 0 ? points[0] : null;
     const pts = state.absolutePoints;
@@ -407,7 +430,13 @@ class EdgeStyle {
    * Implements a horizontal elbow edge. See <EntityRelation> for a
    * description of the parameters.
    */
-  static TopToBottom(state: CellState, source: CellState, target: CellState, points: Point[], result: Point[]) {
+  static TopToBottom(
+    state: CellState,
+    source: CellState,
+    target: CellState,
+    points: Point[],
+    result: Point[]
+  ) {
     const { view } = state;
     let pt = points != null && points.length > 0 ? points[0] : null;
     const pts = state.absolutePoints;
@@ -482,11 +511,23 @@ class EdgeStyle {
    * @param result Array of <Point> that represent the actual points of the
    * edge.
    */
-  static SegmentConnector(state: CellState, sourceScaled: CellState, targetScaled: CellState, controlHints: Point[], result: Point[]) {
-
+  static SegmentConnector(
+    state: CellState,
+    sourceScaled: CellState,
+    targetScaled: CellState,
+    controlHints: Point[],
+    result: Point[]
+  ) {
     // Creates array of all way- and terminalpoints
     // TODO: Figure out what to do when there are nulls in `pts`!
-    const pts = <Point[]><unknown>EdgeStyle.scalePointArray(<Point[]><unknown>state.absolutePoints, state.view.scale);
+    const pts = <Point[]>(
+      (<unknown>(
+        EdgeStyle.scalePointArray(
+          <Point[]>(<unknown>state.absolutePoints),
+          state.view.scale
+        )
+      ))
+    );
     const source = EdgeStyle.scaleCellState(sourceScaled, state.view.scale);
     const target = EdgeStyle.scaleCellState(targetScaled, state.view.scale);
     const tol = 1;
@@ -952,10 +993,19 @@ class EdgeStyle {
    * @param result Array of <Point> that represent the actual points of the
    * edge.
    */
-  static OrthConnector(state: CellState, sourceScaled: CellState, targetScaled: CellState, controlHints: Point[], result: Point[]) {
-
+  static OrthConnector(
+    state: CellState,
+    sourceScaled: CellState,
+    targetScaled: CellState,
+    controlHints: Point[],
+    result: Point[]
+  ) {
     // TODO: Figure out what to do when there are nulls in `pts`!
-    const pts = <Point[]><unknown>EdgeStyle.scalePointArray(<Point[]>state.absolutePoints, state.view.scale);
+    const pts = <Point[]>(
+      (<unknown>(
+        EdgeStyle.scalePointArray(<Point[]>state.absolutePoints, state.view.scale)
+      ))
+    );
     let source = EdgeStyle.scaleCellState(sourceScaled, state.view.scale);
     let target = EdgeStyle.scaleCellState(targetScaled, state.view.scale);
 
@@ -1022,9 +1072,11 @@ class EdgeStyle {
       // console.log('source rotation', rotation);
 
       if (rotation !== 0) {
-        const newRect = <Rectangle>getBoundingBox(
-          new Rectangle(sourceX, sourceY, sourceWidth, sourceHeight),
-          rotation
+        const newRect = <Rectangle>(
+          getBoundingBox(
+            new Rectangle(sourceX, sourceY, sourceWidth, sourceHeight),
+            rotation
+          )
         );
         sourceX = newRect.x;
         sourceY = newRect.y;
@@ -1040,9 +1092,11 @@ class EdgeStyle {
       // console.log('target rotation', rotation);
 
       if (rotation !== 0) {
-        const newRect = <Rectangle>getBoundingBox(
-          new Rectangle(targetX, targetY, targetWidth, targetHeight),
-          rotation
+        const newRect = <Rectangle>(
+          getBoundingBox(
+            new Rectangle(targetX, targetY, targetWidth, targetHeight),
+            rotation
+          )
         );
         targetX = newRect.x;
         targetY = newRect.y;
@@ -1464,7 +1518,12 @@ class EdgeStyle {
     }
   }
 
-  static getRoutePattern(dir: number[], quad: number, dx: number, dy: number): number[] | null {
+  static getRoutePattern(
+    dir: number[],
+    quad: number,
+    dx: number,
+    dy: number
+  ): number[] | null {
     let sourceIndex = dir[0] === DIRECTION_MASK.EAST ? 3 : dir[0];
     let targetIndex = dir[1] === DIRECTION_MASK.EAST ? 3 : dir[1];
 
@@ -1478,7 +1537,8 @@ class EdgeStyle {
       targetIndex += 4;
     }
 
-    let result: number[] | null = EdgeStyle.routePatterns[sourceIndex - 1][targetIndex - 1];
+    let result: number[] | null =
+      EdgeStyle.routePatterns[sourceIndex - 1][targetIndex - 1];
 
     if (dx === 0 || dy === 0) {
       if (EdgeStyle.inlineRoutePatterns[sourceIndex - 1][targetIndex - 1] != null) {

--- a/packages/html/stories/Anchors.stories.js
+++ b/packages/html/stories/Anchors.stories.js
@@ -44,16 +44,17 @@ const Template = ({ label, ...args }) => {
 
   class MyCustomGraph extends Graph {
     getAllConnectionConstraints(terminal, source) {
-      // Overridden to define per-shape connection points
-      if (terminal != null && terminal.shape != null) {
-        if (terminal.shape.stencil != null) {
-          if (terminal.shape.stencil.constraints != null) {
+      // Overridden to define per-geometry connection points
+      if (terminal && terminal.cell) {
+        if (terminal.shape.stencil) {
+          if (terminal.shape.stencil.constraints) {
             return terminal.shape.stencil.constraints;
           }
-        } else if (terminal.shape.constraints != null) {
-          return terminal.shape.constraints;
+        } else if (terminal.cell.geometry.constraints) {
+          return terminal.cell.geometry.constraints;
         }
       }
+
       return null;
     }
 
@@ -116,8 +117,8 @@ const Template = ({ label, ...args }) => {
     const e1 = graph.insertEdge({
       parent,
       value: '',
-      position: v1,
-      size: v2,
+      source: v1,
+      target: v2,
     });
   });
 


### PR DESCRIPTION
**Summary**
Fixed the 'Anchors' example.
 - point.gif is now loaded using `import`. Other images should follow, but I haven't modified them in this PR.
 - In the example, the connection constraints were per-shape basis, but during refactoring they were changed to per-geometry basis. So, the custom `getAllConnectionConstraints()` is now updated accordingly.
 - Applied prettier on the changed files, so this commit is larger than it actually is. (I think we should run prettier on pre-commit hook or something)

**Description for the changelog**
Fixed the 'Anchors' example.

**Other info**

covers #73
