### PR TITLE
fix: edge handlers use style.edgeStyle

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,3 @@
-import { EDGESTYLE } from './util/Constants';
 import type Cell from './view/cell/Cell';
 import type CellState from './view/cell/CellState';
 import EventSource from './view/event/EventSource';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -42,7 +42,6 @@ export type CellStateStyles = {
   defaultVertex?: CellStateStyles;
   deletable?: boolean;
   direction?: DirectionValue;
-  edge?: string;
   edgeStyle?: string;
   editable?: boolean;
   elbow?: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,3 +1,4 @@
+import { EDGESTYLE } from './util/Constants';
 import type Cell from './view/cell/Cell';
 import type CellState from './view/cell/CellState';
 import EventSource from './view/event/EventSource';
@@ -42,6 +43,7 @@ export type CellStateStyles = {
   defaultVertex?: CellStateStyles;
   deletable?: boolean;
   direction?: DirectionValue;
+  edge?: string;
   edgeStyle?: string;
   editable?: boolean;
   elbow?: string;
@@ -220,7 +222,7 @@ export type GradientMap = {
 };
 
 export interface GraphPluginConstructor {
-  new (graph: Graph): GraphPlugin;
+  new(graph: Graph): GraphPlugin;
   pluginId: string;
 }
 

--- a/packages/core/src/view/handler/EdgeHandler.ts
+++ b/packages/core/src/view/handler/EdgeHandler.ts
@@ -415,8 +415,8 @@ class EdgeHandler {
   isVirtualBendsEnabled(evt?: Event) {
     return (
       this.virtualBendsEnabled &&
-      (this.state.style.edge == null ||
-        this.state.style.edge === NONE ||
+      (this.state.style.edgeStyle == null ||
+        this.state.style.edgeStyle === NONE ||
         this.state.style.noEdgeStyle) &&
       this.state.style.shape !== 'arrow'
     );
@@ -958,12 +958,12 @@ class EdgeHandler {
    * Hook for subclassers do show details while the handler is active.
    */
 
-  updateHint(me: InternalMouseEvent, point: Point) {}
+  updateHint(me: InternalMouseEvent, point: Point) { }
 
   /**
    * Hooks for subclassers to hide details when the handler gets inactive.
    */
-  removeHint() {}
+  removeHint() { }
 
   /**
    * Hook for rounding the unscaled width or height. This uses Math.round.

--- a/packages/core/src/view/handler/ElbowEdgeHandler.ts
+++ b/packages/core/src/view/handler/ElbowEdgeHandler.ts
@@ -107,8 +107,8 @@ class ElbowEdgeHandler extends EdgeHandler {
    * Returns the cursor to be used for the bend.
    */
   getCursorForBend() {
-    return this.state.style.edge === EDGESTYLE.TOPTOBOTTOM ||
-      (this.state.style.edge === EDGESTYLE.ELBOW &&
+    return this.state.style.edgeStyle === EDGESTYLE.TOPTOBOTTOM ||
+      (this.state.style.edgeStyle === EDGESTYLE.ELBOW &&
         this.state.style.elbow === ELBOW.VERTICAL)
       ? 'row-resize'
       : 'col-resize';
@@ -179,9 +179,9 @@ class ElbowEdgeHandler extends EdgeHandler {
     } else {
       pt = new Point(
         this.graph.getView().scale *
-          (pt.x + this.graph.getView().translate.x + this.state.origin.x),
+        (pt.x + this.graph.getView().translate.x + this.state.origin.x),
         this.graph.getView().scale *
-          (pt.y + this.graph.getView().translate.y + this.state.origin.y)
+        (pt.y + this.graph.getView().translate.y + this.state.origin.y)
       );
     }
 


### PR DESCRIPTION
**Summary**
Property 'edge' does not exist on type 'CellStateStyles', which is used in file 'ElbowEdgeHandler' and 'EdgeHandler'

**Description for the changelog**
~Added 'edge' property to 'CellStateStyles'.~
Use the `edgeStyle` property of `CellStateStyles` in `ElbowEdgeHandler` and `EdgeHandler`.
