### PR TITLE
chore: clean tsconfig.json

### DIFF
--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "declaration": true,
     "declarationDir": "./dist",
@@ -9,14 +8,13 @@
     "emitDeclarationOnly": true,
     "esModuleInterop": true,
     "isolatedModules": true,
-    "jsx": "preserve",
     "module": "ES2020",
     "lib": ["dom"],
     "moduleResolution": "node",
     "outDir": "./dist",
     "strict": true,
     "target": "ES2020",
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "forceConsistentCasingInFileNames": true
   },
   "exclude": ["node_modules", "e2e", "**/*.json", "**/*.spec.ts"],


### PR DESCRIPTION
Remove `allowJs` (the whole code is now migrated to TypeScript) and `jsx` (we are not using it).
Don't `skipLibCheck` for stronger type checks.