### PR TITLE
Add section about Apache 2.0 license transition to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ git remote set-head origin -a
 # Transition to Apache 2.0 license
 
 This project is published under the terms of a [Modified-Apache-2.0](LICENSE) license and currently preparing to move back to the standard Apache 2.0 license.  
-From now on, all contributions to this project must be under the terms of the Apaches 2.0 license as stated in https://www.apache.org/licenses/LICENSE-2.0 .
+From now on, all contributions to this project must be under the terms of the Apaches 2.0 license as stated in https://www.apache.org/licenses/LICENSE-2.0.  
+See https://github.com/maxGraph/maxGraph/issues/89 for more details.
 
 # Original Readme below
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ git branch -u origin/main main
 git remote set-head origin -a
 ```
 
+# Transition to Apache 2.0 license
+
+This project is published under the terms of a [Modified-Apache-2.0](LICENSE) license and currently preparing to move back to the standard Apache 2.0 license.  
+From now on, all contributions to this project must be under the terms of the Apaches 2.0 license as stated in https://www.apache.org/licenses/LICENSE-2.0 .
+
 # Original Readme below
 
 _NOTE 09.11.2020_ : Development on mxGraph has now stopped, this repo is effectively end of life.


### PR DESCRIPTION
**Summary**

This PR adds a section in the README.md file related to the Apache 2.0 license transition proposed discussed in #89.

**Description for the changelog**

Announce Apache 2.0 license transition process #89

