### PR TITLE
Add Apache 2.0 license note to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,9 @@ If this is a bug fix, your description should include "fixes #xxxx", or
 **Other info**
 <!--
 Thanks for submitting a pull request!
+
+All contributions to this project must be under the terms of the Apache 2.0 license as stated in https://www.apache.org/licenses/LICENSE-2.0
+
 Please make sure you read github's contributing guidelines;
 https://docs.github.com/en/desktop/installing-and-configuring-github-desktop/getting-started-with-github-desktop#part-3-contributing-to-projects-with-github-desktop
 -->


### PR DESCRIPTION
**Summary**

This PR adds a note the github PR template stating that any contribution to this project must be under the terms of the Apache 2.0 license.

**Description for the changelog**

Add Apache 2.0 license note to PR template
