### PR TITLE
chore: improve vite config in ts-example

### DIFF
--- a/packages/ts-example/README.md
+++ b/packages/ts-example/README.md
@@ -5,7 +5,7 @@ Initialized from https://github.com/vitejs/vite/tree/v2.9.8/packages/create-vite
 Do not forget to initialize all packages (you may also need to build the maxgraph@core package)
 > From the repository root, run `npm install`.
 
-Run `npm run dev` and go to http://localhost:3000/
+Run `npm run dev` and go to http://localhost:5173/
 
 If you want to bundle the application, run `npm run build` and then run `npm run preview` to access to a preview of the
 bundle application.

--- a/packages/ts-example/package.json
+++ b/packages/ts-example/package.json
@@ -12,6 +12,6 @@
     "@maxgraph/core": "*"
   },
   "devDependencies": {
-    "vite": "~2.9.12"
+    "vite": "~3.1.0"
   }
 }

--- a/packages/ts-example/vite.config.js
+++ b/packages/ts-example/vite.config.js
@@ -1,0 +1,33 @@
+/*
+Copyright 2022-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { defineConfig } from 'vite';
+
+export default defineConfig(({ mode }) => {
+  return {
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            // put the maxgraph code in a dedicated file. It lets know the size the produced bundle in an external application and if tree shaking works
+            maxgraph: ['@maxgraph/core'],
+          },
+        },
+      },
+      // chunkSizeWarningLimit: 553, // maxgraph
+    },
+  };
+});


### PR DESCRIPTION
bump vite from 2.9.12 to 3.1.0
add vite config to generate a dedicated chunk for maxgraph@core. It lets know the size the produced bundle in an external application and if tree shaking works.