### PR TITLE
Changed the type of `cells` in `GraphDataModel`

### DIFF
--- a/packages/core/src/view/GraphDataModel.ts
+++ b/packages/core/src/view/GraphDataModel.ts
@@ -230,7 +230,7 @@ export class GraphDataModel extends EventSource {
   /**
    * Maps from Ids to cells.
    */
-  cells: any = {};
+  cells: {[key: string]: Cell} | null = {};
 
   /**
    * Specifies if edges should automatically be moved into the nearest common


### PR DESCRIPTION
**Summary**
`GraphDataModel.cells` variable were set to `any`, so method `getCell` are returning `any` too. After analyzing code, it's seems that type `{[key: string]: Cell} | null` is best fit.

**Description for the changelog**
Changed type of `cells` variable to `{[key: string]: Cell} | null`
