### PR TITLE
Fixed `Visibility` story

### DIFF
--- a/packages/html/stories/Visibility.stories.js
+++ b/packages/html/stories/Visibility.stories.js
@@ -60,7 +60,7 @@ const Template = ({ label, ...args }) => {
   const isVisible = function () {
     // TODO super cannot be used here
     // let result = super.isVisible();
-    let result;
+    let result = true;
     if (result && this.value != null) {
       result =
         (showOne && this.value == '1') ||


### PR DESCRIPTION
**Summary**
Fixed Visibility story. When porting from examples, `result` variable in overriden function `isVisible()` left undefined, so function always return `undefined`, hence all cells are invisible. 
https://github.com/maxGraph/maxGraph/blob/02ea6f1ceb398c2a6c08df7ecc52ee3d5efe46cc/packages/html/stories/Visibility.stories.js#L60-L71

Init `result` with `true` for story begin to work.

**Description for the changelog**
Fixed bug in Visibility story in Storybook
