### PR TITLE
Fixed `Guides` story

### DIFF
--- a/packages/html/stories/Guides.stories.js
+++ b/packages/html/stories/Guides.stories.js
@@ -18,8 +18,7 @@ limitations under the License.
 import {
   Graph,
   SelectionHandler,
-  InternalEvent,
-  constants,
+  eventUtils,
   EdgeHandler,
   EdgeStyle,
   RubberBandHandler,
@@ -47,12 +46,9 @@ const Template = ({ label, ...args }) => {
   container.style.background = 'url(/images/grid.gif)';
   container.style.cursor = 'default';
 
-  // Enables guides
-  SelectionHandler.prototype.guidesEnabled = true;
-
   // Alt disables guides
   SelectionHandler.prototype.useGuidesForEvent = function (me) {
-    return !InternalEvent.isAltDown(me.getEvent());
+    return !eventUtils.isAltDown(me.getEvent());
   };
 
   // Defines the guides to be red (default)
@@ -68,6 +64,11 @@ const Template = ({ label, ...args }) => {
   const graph = new Graph(container);
   graph.setConnectable(true);
   graph.gridSize = 30;
+
+  // Enables guides
+  const selectionHandler = graph.getPlugin('SelectionHandler');
+  if (selectionHandler)
+    selectionHandler.guidesEnabled = true;
 
   // Changes the default style for edges "in-place" and assigns
   // an alternate edge style which is applied in Graph.flip


### PR DESCRIPTION
**Summary**
There two bugs in story
- No guides are rendered. Because typescript code transpiled to class with constructor, overriding `SelectionHandler.prototype.guidesEnabled` to `true` no longer works. Extracting plugin instance and setting `guidesEnabled` for it works fine.
https://github.com/maxGraph/maxGraph/blob/02ea6f1ceb398c2a6c08df7ecc52ee3d5efe46cc/packages/html/stories/Guides.stories.js#L50-L51

- Alt key disabling guides feature not working. `isAltDown is not defined` error. `isAltDown` method is moved to `eventUtils`, simply fixing import.
 
**Description for the changelog**
Fixed `Guides` story 
