### PR TITLE
Fix wrong method signature in EdgeMixin

### DIFF
--- a/packages/core/src/view/mixins/EdgeMixin.ts
+++ b/packages/core/src/view/mixins/EdgeMixin.ts
@@ -29,7 +29,7 @@ import type { CellStyle } from '../../types';
 declare module '../Graph' {
   interface Graph {
     resetEdgesOnResize: boolean;
-    resetEdgesOnMove: false;
+    resetEdgesOnMove: boolean;
     resetEdgesOnConnect: boolean;
     connectableEdges: boolean;
     allowDanglingEdges: boolean;


### PR DESCRIPTION
**Summary**
There are clearly typo in type for `resetEdgesOnMove`, fixed it
https://github.com/maxGraph/maxGraph/blob/02ea6f1ceb398c2a6c08df7ecc52ee3d5efe46cc/packages/core/src/view/mixins/EdgeMixin.ts#L31-L33
