### PR TITLE
Fix edge segment handles not being rendered

### DIFF
--- a/packages/core/src/view/mixins/CellsMixin.ts
+++ b/packages/core/src/view/mixins/CellsMixin.ts
@@ -2784,7 +2784,7 @@ export const CellsMixin: PartialType = {
    */
   isCellBendable(cell) {
     const style = this.getCurrentCellStyle(cell);
-    return this.isCellsBendable() && !this.isCellLocked(cell) && !!style.bendable;
+    return this.isCellsBendable() && !this.isCellLocked(cell) && style.bendable != false;
   },
 
   /**


### PR DESCRIPTION
**Summary**
Combination of side-effects when porting to typescript broke edge segment handles rendering, fixed some of them. 
Debugged on story `Anchors`, but basically it`s used in elbow and orthogonal edges and looking like this:
![image](https://user-images.githubusercontent.com/15244111/194104348-e79e0d25-83db-447b-a34b-9228a7e738c8.png)


**Description for the changelog**
Fixed rendering of handles on segments of edges