### PR TITLE
Fix stories with overlays usage

### DIFF
--- a/packages/html/stories/Overlays.stories.js
+++ b/packages/html/stories/Overlays.stories.js
@@ -62,7 +62,7 @@ const Template = ({ label, ...args }) => {
     if (cell != null) {
       const overlays = graph.getCellOverlays(cell);
 
-      if (overlays == null) {
+      if (overlays.length == 0) {
         // Creates a new overlay with an image and a tooltip
         const overlay = new CellOverlay(
           new ImageBox('/images/check.png', 16, 16),

--- a/packages/html/stories/Thread.stories.js
+++ b/packages/html/stories/Thread.stories.js
@@ -61,7 +61,7 @@ const Template = ({ label, ...args }) => {
   const f = () => {
     const overlays = graph.getCellOverlays(v1);
 
-    if (overlays == null) {
+    if (overlays.length == 0) {
       graph.removeCellOverlays(v2);
       graph.setCellWarning(v1, 'Tooltip');
     } else {


### PR DESCRIPTION
**Summary**
Because `overlays` field of `Cell` is now initialized with empty array instead of `undefined`, code from examples is broken. 

https://github.com/maxGraph/maxGraph/blob/02ea6f1ceb398c2a6c08df7ecc52ee3d5efe46cc/packages/core/src/view/cell/Cell.ts#L103-L104

https://github.com/maxGraph/maxGraph/blob/02ea6f1ceb398c2a6c08df7ecc52ee3d5efe46cc/packages/html/stories/Overlays.stories.js#L63-L65
This branch will never execute.

Changed check for `null` to check for empty array.

**Description for the changelog**
Fix stories with overlays usage