### PR TITLE
chore(tsconfig): add base tsconfig.json

### DIFF
--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "allowSyntheticDefaultImports": true,
     "declaration": true,
     "declarationDir": "./dist/types",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
     "allowSyntheticDefaultImports": true,
@@ -6,19 +7,12 @@
     "declarationDir": "./dist/types",
     "declarationMap": false,
     "emitDeclarationOnly": true,
-    "esModuleInterop": true,
-    "isolatedModules": true,
-    "module": "ES2020",
-    "lib": ["dom"],
-    "moduleResolution": "node",
     "outDir": "./dist/esm",
     "strict": true,
-    "target": "ES2020",
     "skipLibCheck": false,
     "forceConsistentCasingInFileNames": true
   },
-  "exclude": ["node_modules", "e2e", "**/*.json", "**/*.spec.ts"],
-  "include": ["src/**/*.ts", "./*.ts"],
+  "include": ["src/**/*.ts"],
   "typedocOptions": {
     "out": "../../docs/api",
     "readme": "none",

--- a/packages/ts-example/tsconfig.json
+++ b/packages/ts-example/tsconfig.json
@@ -1,19 +1,13 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "ESNext",
     "useDefineForClassFields": true,
-    "module": "ESNext",
-    "lib": ["ESNext", "DOM"],
-    "moduleResolution": "Node",
-    "strict": true,
     "sourceMap": true,
     "resolveJsonModule": true,
-    "isolatedModules": true,
-    "esModuleInterop": true,
     "noEmit": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true
   },
-  "include": ["src"]
+  "include": ["src/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "module": "es2020",
     "lib": ["dom", "es2020"],
     "target": "es2020",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "es2020",
+    "lib": ["dom", "es2020"],
+    "target": "es2020",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "isolatedModules": true
+  },
+  "paths": {
+    "@maxgraph/core": ["packages/core/src/index.ts"],
+    "@maxgraph/ts-example": ["packages/ts-example/src/main.ts"]
+  },
+  "exclude": ["node_modules", "**/*.spec.ts"],
+  "include": ["packages/*/src"]
+}


### PR DESCRIPTION
**Summary**
Add base `tsconfig.json` to root of repository and extend packages upon it. Refactoring `src` values of `tsconfig.json` of packages.

**Description for the changelog**
- Moved repeating declarations in base `tsconfig.json`
- Removed `ESNext` target/module/lib from `ts-example`, which will lead to use of `es2020` from base `tsconfig.json`
