### PR TITLE
chore: force usage of a recent @types/node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
     "webpack": "^5.64.4",
     "webpack-cli": "^4.9.1",
     "webpack-merge": "^5.8.0"
+  },
+  "overrides": {
+    "@types/node": "^16.18.0"
   }
 }


### PR DESCRIPTION
**Summary**
<!--
What existing issue does the pull request solve?
Please provide enough information so that others can review your pull request
-->
Use a recent version of `@types/node` that works with TypeScript 4.9, older versions have types issues.

<!--
**Description for the changelog**
A short (one line) summary that describes the changes in this
pull request for inclusion in the change log
If this is a bug fix, your description should include "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number
-->

**Other info**
<!--
Thanks for submitting a pull request!

All contributions to this project are done under the terms of the Apache 2.0 license as stated in https://www.apache.org/licenses/LICENSE-2.0

Please make sure you read github's contributing guidelines;
https://docs.github.com/en/desktop/installing-and-configuring-github-desktop/getting-started-with-github-desktop#part-3-contributing-to-projects-with-github-desktop
-->
This wasn't detected by the GitHub Actions but the problem could happen locally depending on the content of the existing `node_modules` directory.

Fixed error
```
Error: node_modules/@types/node/globals.d.ts(72,13): error TS2403: Subsequent variable declarations must
have the same type.  Variable 'AbortSignal' must be of type '{ new (): AbortSignal;
prototype: AbortSignal; abort(reason?: any): AbortSignal; timeout(milliseconds: number): AbortSignal; }',
but here has type '{ new (): AbortSignal; prototype: AbortSignal; }'.
```