### PR TITLE
ci: use more recent OS versions when building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       # we want to run the full build on all os: don't cancel running jobs even if one fails
       fail-fast: false
       matrix:
-        os: ['ubuntu-20.04', 'macos-11', 'windows-2019']
+        os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
     steps:
       - uses: actions/checkout@v3
       - name: Setup node


### PR DESCRIPTION
macos: 11 to 12
ubuntu: 20.04 to 22.04
windows: 2019 to 2022