### PR TITLE
fix: SwimlaneMixin handles the 'style.horizontal' `undefined` value

### DIFF
--- a/packages/core/src/view/mixins/SwimlaneMixin.ts
+++ b/packages/core/src/view/mixins/SwimlaneMixin.ts
@@ -210,7 +210,7 @@ const SwimlaneMixin: PartialType = {
     const style = this.getCurrentCellStyle(swimlane, ignoreState);
     const size = style.startSize ?? DEFAULT_STARTSIZE;
 
-    if (style.horizontal === true) {
+    if (style.horizontal ?? true) {
       result.height = size;
     } else {
       result.width = size;
@@ -225,7 +225,7 @@ const SwimlaneMixin: PartialType = {
     const dir = style.direction ?? DIRECTION.EAST;
     const flipH = style.flipH;
     const flipV = style.flipV;
-    const h = style.horizontal;
+    const h = style.horizontal ?? true;
     let n = h ? 0 : 3;
 
     if (dir === DIRECTION.NORTH) {


### PR DESCRIPTION
**Summary**
<!--
What existing issue does the pull request solve?
Please provide enough information so that others can review your pull request
-->
The horizontal value was considered as true only if was set to true.
It is now also considered as true when set to undefined, as everywhere else in maxGraph.

SwimLanes.stories.js: update configuration to display nodes.

**Description for the changelog**
<!--
A short (one line) summary that describes the changes in this
pull request for inclusion in the change log
If this is a bug fix, your description should include "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number
-->

covers #73

**Other info**
<!--
Thanks for submitting a pull request!

All contributions to this project are done under the terms of the Apache 2.0 license as stated in https://www.apache.org/licenses/LICENSE-2.0

Please make sure you read github's contributing guidelines;
https://docs.github.com/en/desktop/installing-and-configuring-github-desktop/getting-started-with-github-desktop#part-3-contributing-to-projects-with-github-desktop
-->

The SwimLanes.stories.js update is just a starting point. There is still a lot to do to match the previous example of mxGraph.

https://user-images.githubusercontent.com/27200110/207523280-7532b710-5c9c-4ac4-b39e-ce8b86acdf36.mp4

Here is what the mxGraph example provides: https://jgraph.github.io/mxgraph/javascript/examples/swimlanes.html
- on hover, an image is displayed and can be clicked to create an edge
- labels can be edited

https://user-images.githubusercontent.com/27200110/207523287-da004184-0009-42e6-a4ad-5c8487f2463c.mp4



