### PR TITLE
fix: correctly manage the markers fill style

### DIFF
--- a/packages/core/src/view/geometry/edge/ConnectorShape.ts
+++ b/packages/core/src/view/geometry/edge/ConnectorShape.ts
@@ -113,7 +113,7 @@ class ConnectorShape extends PolylineShape {
 
       // Allow for stroke width in the end point used and the
       // orthogonal vectors describing the direction of the marker
-      const filled = !(source ? this.style.startFill : this.style.endFill);
+      const filled = (source ? this.style.startFill : this.style.endFill) ?? true;
 
       result = MarkerShape.createMarker(
         c,

--- a/packages/html/stories/Markers.stories.js
+++ b/packages/html/stories/Markers.stories.js
@@ -135,15 +135,14 @@ const Template = ({ label, ...args }) => {
   style.fillColor = '#FFFFFF';
   style.strokeColor = '#000000';
   style.fontColor = '#000000';
-  style.fontStyle = '1';
+  style.fontStyle = 1;
 
   style = graph.getStylesheet().getDefaultEdgeStyle();
   style.strokeColor = '#000000';
   style.fontColor = '#000000';
-  style.fontStyle = '0';
-  style.fontStyle = '0';
-  style.startSize = '8';
-  style.endSize = '8';
+  style.fontStyle = 0;
+  style.startSize = 8;
+  style.endSize = 8;
 
   // Populates the graph
   const parent = graph.getDefaultParent();
@@ -156,8 +155,8 @@ const Template = ({ label, ...args }) => {
       startArrow: 'oval',
       endArrow: 'block',
       sourcePerimeterSpacing: 4,
-      startFill: 0,
-      endFill: 0,
+      startFill: false,
+      endFill: false,
     });
     const e11 = graph.insertVertex(e1, null, 'Label', 0, 0, 20, 14, {
       shape: 'message',


### PR DESCRIPTION
**Summary**
<!--
What existing issue does the pull request solve?
Please provide enough information so that others can review your pull request
-->
Previously, when setting startFill/endFill, the display was inverted comparing to the configuration.
The marker was filled when set to false, not filled when set to true.
When not set, the marker was filled, which is the expected default.

The issue came from a wrong condition to manage the default value and was reproduced with the Markers Story.

In addition to the code fix, update the Markers.stories.js to fix style configurations
  - use number instead of string for markers size
  - use boolean instead of number for start/end fill

**Other info**
<!--
Thanks for submitting a pull request!

All contributions to this project are done under the terms of the Apache 2.0 license as stated in https://www.apache.org/licenses/LICENSE-2.0

Please make sure you read github's contributing guidelines;
https://docs.github.com/en/desktop/installing-and-configuring-github-desktop/getting-started-with-github-desktop#part-3-contributing-to-projects-with-github-desktop
-->

prior the fix | now (with fix)
---- | ----
![maxGraph_markers_01_before](https://user-images.githubusercontent.com/27200110/207604886-ff7d5977-1e3e-4993-ac66-8c3ff2cd6642.png) | ![maxGraph_markers_02_now](https://user-images.githubusercontent.com/27200110/207604889-a1043d71-cfcb-4f46-8cb9-faca59465ef0.png)

**Note**:
- the envelope and its label are not positioned at the right place. See #158
- the background color of the label is not displayed correctly. The configuration of the style has been done in the same way as in the past with `mxGraph`. See #165.

Here is what we see with mxGraph: https://jgraph.github.io/mxgraph/javascript/examples/markers.html

![mxGraph@4 2 2](https://user-images.githubusercontent.com/27200110/207604893-f545db6f-6369-42f5-9c9a-14ccc5524c16.png)
