### PR TITLE
test(ts-support): only check maxGraph types

### DIFF
--- a/packages/ts-support/tsconfig.json
+++ b/packages/ts-support/tsconfig.json
@@ -8,7 +8,13 @@
     ],
     "moduleResolution": "Node",
     "strict": true,
-    "noEmit": true
+    "noEmit": true,
+    // By default, all visible ”@types” packages are included in your compilation. Packages in node_modules/@types of any enclosing folder are considered visible. For example, that
+    // means packages within ./node_modules/@types/, ../node_modules/@types/, ../../node_modules/@types/, and so on.
+    // ../../node_modules/@types includes types used to develop maxGraph.
+    // Here, we only want to check types used by maxGraph when it is included in applications.
+    // So, we don't want the development types to be part of the tests, especially because some of them may require a newer TypeScript version.
+//    "typeRoots": [],
   },
   "include": [
     "src/**/*"

--- a/packages/ts-support/tsconfig.json
+++ b/packages/ts-support/tsconfig.json
@@ -14,7 +14,7 @@
     // ../../node_modules/@types includes types used to develop maxGraph.
     // Here, we only want to check types used by maxGraph when it is included in applications.
     // So, we don't want the development types to be part of the tests, especially because some of them may require a newer TypeScript version.
-//    "typeRoots": [],
+    "typeRoots": [],
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
Previously, all types development types needed by maxGraph at development time were checked. Some of them require a newer version of TypeScript that the one used in the TS support test (to check the minimum version required to integrate maxGraph in applications). This made the checks fail. The configuration of the tests has been updated to only check the maxGraph types used by applications.

### Notes

Activate the `traceResolution` compiler option to confirm the configuration changes: https://www.typescriptlang.org/tsconfig/#traceResolution

The past error was
```
> @maxgraph/ts-support@0.0.0 test
> tsc --version && tsc

Version 3.8.2
Error: ../../node_modules/@types/node/ts4.8/buffer.d.ts(340,48): error TS2694: Namespace 'global.NodeJS' has no exported member 'ArrayBufferView'.
Error: Process completed with exit code 1.
```