### PR TITLE
fix: update the signature of gestureUtils.makeDraggable

### DIFF
--- a/packages/core/src/util/gestureUtils.ts
+++ b/packages/core/src/util/gestureUtils.ts
@@ -88,7 +88,7 @@ export const makeDraggable = (
   element: Element,
   graphF: Graph | Function,
   funct: DropHandler,
-  dragElement: Element,
+  dragElement: Element | null = null,
   dx: number | null = null,
   dy: number | null = null,
   autoscroll: boolean | null = null,


### PR DESCRIPTION
**Summary**
The fourth argument of makeDraggable function was not optional as this [issue](https://github.com/maxGraph/maxGraph/issues/195) states.
fixed it by adding | null = null to the argument

closes #195 
