### PR TITLE
fix: update type of the `labelPosition` property to restore "no align"

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -411,12 +411,13 @@ export type CellStateStyle = {
    * - `left` means that the entire label bounds is placed completely just to the left of the vertex.
    * - `right` means that the label bounds are adjusted to the right.
    * - `center` means that the label bounds are vertically aligned with the bounds of the vertex.
+   * - `ignore` means that there is no alignment
    *
    * Note that this value does not affect the positioning of label within the label bounds.
    * To move the label bounds horizontally within the label bounds, use {@link align}
    * @default 'center'
    */
-  labelPosition?: AlignValue;
+  labelPosition?: AlignValue | 'ignore';
   /**
    * The width of the label if the label position is not `center`.
    */


### PR DESCRIPTION
Allow a special value to be passed to avoid calculating the alignment.

### Notes

The code in maxGraph and mxGraph behave identically. The label position is handled with if/else if, and no offset if computed when a value which is not a "AlignValue" is passed.
The `labelPosition` style property only allowed "AlignValue" so it was not possible to pass a value producing a "no align" (except by forcing the type of the value set to the property).

`labelVerticalPosition` management is OK. All if/else if case can be accessed with the current type.

https://github.com/maxGraph/maxGraph/blob/7c696bb31f1ea1984b183fdc7bb44e7943830afc/packages/core/src/view/GraphView.ts#L1010-L1045
https://github.com/jgraph/mxgraph/blob/v4.2.2/javascript/src/js/view/mxGraphView.js#L1193-L1240