### PR TITLE
refactor(type)!: do not return 'undefined' in getDefaultXXXStyle methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # `maxGraph` Change Log
 
+## Unreleased
+
+Breaking Changes
+- `Stylesheet.getDefaultVertexStyle` and `Stylesheet.getDefaultEdgeStyle` no longer return `undefined`.
+
 ## 0.2.1
 
 This is a bug fix release.

--- a/packages/core/src/view/GraphDataModel.ts
+++ b/packages/core/src/view/GraphDataModel.ts
@@ -210,7 +210,7 @@ import type { CellStyle, FilterFunction } from '../types';
  * Event: mxEvent.BEFORE_UNDO
  *
  * Fires before the change is dispatched after the update level has reached 0
- * in {@link endUpdate}. The `edit` property contains the {@link curreneEdit}.
+ * in {@link endUpdate}. The `edit` property contains the {@link currentEdit}.
  *
  * Event: mxEvent.UNDO
  *

--- a/packages/core/src/view/style/Stylesheet.ts
+++ b/packages/core/src/view/style/Stylesheet.ts
@@ -100,8 +100,7 @@ export class Stylesheet {
   }
 
   /**
-   * Sets the default style for vertices using defaultVertex as the
-   * stylename.
+   * Sets the default style for vertices using defaultVertex as the style name.
    * @param style Key, value pairs that define the style.
    */
   putDefaultVertexStyle(style: CellStateStyle) {
@@ -109,7 +108,7 @@ export class Stylesheet {
   }
 
   /**
-   * Sets the default style for edges using defaultEdge as the stylename.
+   * Sets the default style for edges using defaultEdge as the style name.
    */
   putDefaultEdgeStyle(style: CellStateStyle) {
     this.putCellStyle('defaultEdge', style);
@@ -118,49 +117,48 @@ export class Stylesheet {
   /**
    * Returns the default style for vertices.
    */
-  getDefaultVertexStyle() {
-    return this.styles.get('defaultVertex');
+  getDefaultVertexStyle(): CellStateStyle {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the style is set in the constructor
+    return this.styles.get('defaultVertex')!;
   }
 
   /**
    * Sets the default style for edges.
    */
-  getDefaultEdgeStyle() {
-    return this.styles.get('defaultEdge');
+  getDefaultEdgeStyle(): CellStateStyle {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the style is set in the constructor
+    return this.styles.get('defaultEdge')!;
   }
 
   /**
-   * Stores the given map of key, value pairs under the given name in
-   * {@link styles}.
+   * Stores the given {@link CellStateStyle} under the given name in {@link styles}.
    *
-   * Example:
+   * ### Example
    *
-   * The following example adds a new style called 'rounded' into an
-   * existing stylesheet:
+   * The following example adds a new style called `rounded` into an existing stylesheet:
    *
    * ```javascript
-   * var style = new Object();
-   * style.shape = mxConstants.SHAPE_RECTANGLE;
-   * style.perimiter = mxPerimeter.RectanglePerimeter;
+   * const style = {} as CellStateStyle;
+   * style.shape = SHAPE.RECTANGLE;
+   * style.perimeter = PERIMETER.RECTANGLE;
    * style.rounded = true;
    * graph.getStylesheet().putCellStyle('rounded', style);
    * ```
    *
-   * In the above example, the new style is an object. The possible keys of
-   * the object are all the constants in {@link mxConstants} that start with STYLE
-   * and the values are either JavaScript objects, such as
-   * {@link Perimeter.RightAngleRectanglePerimeter} (which is in fact a function)
-   * or expressions, such as true. Note that not all keys will be
-   * interpreted by all shapes (eg. the line shape ignores the fill color).
-   * The final call to this method associates the style with a name in the
-   * stylesheet. The style is used in a cell with the following code:
+   * ### Description
    *
+   * Note that not all properties will be interpreted by all shapes. For example, the 'line' shape ignores the fill color.
+   * The final call to this method associates the style with a name in the stylesheet.
+   *
+   * The style is used in a cell with the following code:
    * ```javascript
-   * model.setStyle(cell, 'rounded');
+   * // model is an instance of GraphDataModel
+   * // style is an instance of CellStyle
+   * model.setStyle(cell, { baseStyleNames: ['rounded'] });
    * ```
    *
    * @param name Name for the style to be stored.
-   * @param style Key, value pairs that define the style.
+   * @param style The instance of the style to be stored.
    */
   putCellStyle(name: string, style: CellStateStyle) {
     this.styles.set(name, style);

--- a/packages/core/src/view/style/Stylesheet.ts
+++ b/packages/core/src/view/style/Stylesheet.ts
@@ -100,15 +100,16 @@ export class Stylesheet {
   }
 
   /**
-   * Sets the default style for vertices using defaultVertex as the style name.
-   * @param style Key, value pairs that define the style.
+   * Sets the default style for vertices using `defaultVertex` as the style name.
+   * @param style The style to be stored.
    */
   putDefaultVertexStyle(style: CellStateStyle) {
     this.putCellStyle('defaultVertex', style);
   }
 
   /**
-   * Sets the default style for edges using defaultEdge as the style name.
+   * Sets the default style for edges using `defaultEdge` as the style name.
+   * @param style The style to be stored.
    */
   putDefaultEdgeStyle(style: CellStateStyle) {
     this.putCellStyle('defaultEdge', style);
@@ -123,7 +124,7 @@ export class Stylesheet {
   }
 
   /**
-   * Sets the default style for edges.
+   * Returns the default style for edges.
    */
   getDefaultEdgeStyle(): CellStateStyle {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the style is set in the constructor

--- a/packages/ts-example/package.json
+++ b/packages/ts-example/package.json
@@ -5,13 +5,13 @@
   "version": "0.0.0",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc --version && tsc && vite build",
     "preview": "vite preview"
   },
   "dependencies": {
     "@maxgraph/core": "*"
   },
   "devDependencies": {
-    "vite": "~3.2.3"
+    "vite": "~4.3.1"
   }
 }

--- a/packages/ts-example/src/main.ts
+++ b/packages/ts-example/src/main.ts
@@ -25,6 +25,7 @@ import {
 import { registerCustomShapes } from './custom-shapes';
 
 // display the maxGraph version in the footer
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the footer is present in index.html
 const footer = document.querySelector<HTMLElement>('footer')!;
 footer.innerText = `Built with maxGraph ${Client.VERSION}`;
 
@@ -40,8 +41,10 @@ new RubberBandHandler(graph); // Enables rubber band selection
 
 // shapes and styles
 registerCustomShapes();
-// @ts-ignore TODO fix TS2532: Object is possibly 'undefined'.
-graph.getStylesheet().getDefaultEdgeStyle().edgeStyle = 'orthogonalEdgeStyle'; // TODO use constants.EDGESTYLE instead of 'orthogonalEdgeStyle'
+// TODO cannot use constants.EDGESTYLE.ORTHOGONAL
+// TS2748: Cannot access ambient const enums when the '--isolatedModules' flag is provided.
+// See https://github.com/maxGraph/maxGraph/issues/205
+graph.getStylesheet().getDefaultEdgeStyle().edgeStyle = 'orthogonalEdgeStyle';
 
 // Gets the default parent for inserting new cells. This
 // is normally the first child of the root (ie. layer 0).
@@ -71,7 +74,6 @@ graph.batchUpdate(() => {
   graph.insertEdge(parent, null, 'a regular edge', vertex01, vertex02);
 
   // insert vertices using custom shapes
-  // TODO type issue in CellStyle type, shape should allow string to manage custom implementation
   const vertex11 = graph.insertVertex(
     parent,
     null,
@@ -80,7 +82,7 @@ graph.batchUpdate(() => {
     200,
     100,
     100,
-    /*<CellStyle>*/ { shape: 'customRectangle' }
+    <CellStyle>{ shape: 'customRectangle' }
   );
   const vertex12 = graph.insertVertex(
     parent,
@@ -90,7 +92,7 @@ graph.batchUpdate(() => {
     350,
     70,
     70,
-    /*<CellStyle>*/ { shape: 'customEllipse' }
+    <CellStyle>{ shape: 'customEllipse' }
   );
   graph.insertEdge(parent, null, 'another edge', vertex11, vertex12);
 });

--- a/packages/ts-example/vite.config.js
+++ b/packages/ts-example/vite.config.js
@@ -27,7 +27,7 @@ export default defineConfig(({ mode }) => {
           },
         },
       },
-      // chunkSizeWarningLimit: 553, // maxgraph
+      chunkSizeWarningLimit: 562, // maxgraph
     },
   };
 });


### PR DESCRIPTION
The default edge and vertex styles are always defined. Updating the signature of the two methods returning default styles simplifies the code for callers, who don't have to deal with "undefined" values.

Improve the ts-example
  - rely on no `undefined` style
  - bump vite from 3.2.3 to 4.3.1 and increase the file size warning
  - improve the use of types
  - better explain why we cannot use enum to define the 'edgeStyle' CellStyle property

BREAKING CHANGE: `Stylesheet.getDefaultVertexStyle` and `Stylesheet.getDefaultEdgeStyle` no longer return `undefined`.