### PR TITLE
fix: compute the current style of ShadowRoot element

### DIFF
--- a/packages/core/src/util/styleUtils.ts
+++ b/packages/core/src/util/styleUtils.ts
@@ -56,14 +56,15 @@ export const removeCursors = (element: HTMLElement) => {
 };
 
 /**
- * Function: getCurrentStyle
- *
  * Returns the current style of the specified element.
  *
  * @param element DOM node whose current style should be returned.
  */
 export const getCurrentStyle = (element: HTMLElement) => {
-  return element ? window.getComputedStyle(element, '') : null;
+  if (!element || element.toString() === '[object ShadowRoot]') {
+    return null;
+  }
+  return window.getComputedStyle(element, '');
 };
 
 /**

--- a/packages/core/src/util/styleUtils.ts
+++ b/packages/core/src/util/styleUtils.ts
@@ -61,10 +61,7 @@ export const removeCursors = (element: HTMLElement) => {
  * @param element DOM node whose current style should be returned.
  */
 export const getCurrentStyle = (element: HTMLElement) => {
-  if (!element || element.toString() === '[object ShadowRoot]') {
-    return null;
-  }
-  return window.getComputedStyle(element, '');
+  return !element || element.toString() === '[object ShadowRoot]' ? null : window.getComputedStyle(element, '');
 };
 
 /**


### PR DESCRIPTION
`ShadowRoot` element cannot be passed to the `window.getComputedStyle` method.
Otherwise, errors occur, in particular, it prevents the mouse and gesture events to be propagated.

The following error has been seen in an application creating Web Component with lit@2.7.5 and @maxgraph/core@0.2.1.
```
 TypeError: Window.getComputedStyle: Argument 1 does not implement interface Element.
    getCurrentStyle styleUtils.js:50
    getOffset styleUtils.js:163
    convertPoint styleUtils.js:245
    updateMouseEvent EventsMixin.js:360
    fireMouseEvent EventsMixin.js:539
    installListeners GraphView.js:1684
    addListener InternalEvent.js:58
    addGestureListeners InternalEvent.js:105
    installListeners GraphView.js:1672
    init GraphView.js:1644
    Graph Graph.js:352
    initializeGraph index.ts:12
    firstUpdated index.ts:43
    _$didUpdate reactive-element.ts:1378
    performUpdate reactive-element.ts:1345
    scheduleUpdate reactive-element.ts:1263
    __enqueueUpdate reactive-element.ts:1235
    requestUpdate reactive-element.ts:1210
    _initialize reactive-element.ts:948
    ReactiveElement reactive-element.ts:931
    LitElement lit.js:1870
```

fixes #68
fixes #208

### Tasks

- [x] reproduce the problem in https://github.com/maxGraph/maxgraph-integration-examples/: https://github.com/maxGraph/maxgraph-integration-examples/pull/38 with @maxgraph/core@0.2.1
- [x] ensure the problem is fixed in https://github.com/maxGraph/maxgraph-integration-examples/: using https://github.com/maxGraph/maxgraph-integration-examples/pull/38 with the fix in this PR