### PR TITLE
fix: export EditorToolbarCodec and StylesheetCodec

### DIFF
--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -23,7 +23,7 @@ import EventSource from '../view/event/EventSource';
 import Translations from '../util/Translations';
 import Client from '../Client';
 import CompactTreeLayout from '../view/layout/CompactTreeLayout';
-import EditorToolbar from './EditorToolbar';
+import { EditorToolbar } from './EditorToolbar';
 import StackLayout from '../view/layout/StackLayout';
 import EventObject from '../view/event/EventObject';
 import { getOffset } from '../util/styleUtils';

--- a/packages/core/src/editor/EditorToolbar.ts
+++ b/packages/core/src/editor/EditorToolbar.ts
@@ -742,4 +742,3 @@ export class EditorToolbarCodec extends ObjectCodec {
 }
 
 CodecRegistry.register(new EditorToolbarCodec());
-export default EditorToolbar;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/* Graph mixins */
+/* Graph mixins - side effects */
 import './view/mixins/PortsMixin';
 import './view/mixins/PanningMixin';
 import './view/mixins/ZoomMixin';
@@ -39,7 +39,6 @@ import './view/mixins/PageBreaksMixin';
 import './view/mixins/GroupingMixin';
 import './view/mixins/OrderMixin';
 
-// GraphCodec
 export { Graph } from './view/Graph';
 
 export { GraphDataModel, ModelCodec } from './view/GraphDataModel';
@@ -67,11 +66,7 @@ export { default as VisibleChange } from './view/undoable_changes/VisibleChange'
 
 export { EditorKeyHandler, EditorKeyHandlerCodec } from './editor/EditorKeyHandler';
 export { EditorPopupMenu, EditorPopupMenuCodec } from './editor/EditorPopupMenu';
-// TODO restore EditorToolbarCodec if needed
-// currently, the following error occurs when running vitejs build
-// [ERROR] No matching export in "../core/dist/esm/editor/EditorToolbar.js" for import "EditorToolbarCodec"
-// export { EditorToolbar, EditorToolbarCodec } from './editor/EditorToolbar';
-export { EditorToolbar } from './editor/EditorToolbar';
+export { EditorToolbar, EditorToolbarCodec } from './editor/EditorToolbar';
 export { Editor, EditorCodec } from './editor/Editor';
 
 export { default as CellHighlight } from './view/cell/CellHighlight';
@@ -180,11 +175,7 @@ export { default as Rectangle } from './view/geometry/Rectangle';
 export { default as EdgeStyle } from './view/style/EdgeStyle';
 export { default as Perimeter } from './view/style/Perimeter';
 export { default as StyleRegistry } from './view/style/StyleRegistry';
-// TODO restore StylesheetCodec if needed
-// currently, the following error occurs when running vitejs build
-// [ERROR] No matching export in "../core/dist/esm/view/style/Stylesheet.js" for import "StylesheetCodec"
-// export { Stylesheet, StylesheetCodec } from './view/style/Stylesheet';
-export { Stylesheet } from './view/style/Stylesheet';
+export { Stylesheet, StylesheetCodec } from './view/style/Stylesheet';
 
 export * as DomHelpers from './util/domHelpers';
 

--- a/packages/core/src/view/Graph.ts
+++ b/packages/core/src/view/Graph.ts
@@ -35,7 +35,7 @@ import Point from './geometry/Point';
 import { getCurrentStyle, hasScrollbars, parseCssNumber } from '../util/styleUtils';
 import Cell from './cell/Cell';
 import GraphDataModel from './GraphDataModel';
-import Stylesheet from './style/Stylesheet';
+import { Stylesheet } from './style/Stylesheet';
 import { PAGE_FORMAT_A4_PORTRAIT } from '../util/Constants';
 
 import ChildChange from './undoable_changes/ChildChange';
@@ -51,9 +51,6 @@ import EdgeHandler from './handler/EdgeHandler';
 import VertexHandler from './handler/VertexHandler';
 import EdgeSegmentHandler from './handler/EdgeSegmentHandler';
 import ElbowEdgeHandler from './handler/ElbowEdgeHandler';
-
-import CodecRegistry from '../serialization/CodecRegistry';
-import ObjectCodec from '../serialization/ObjectCodec';
 
 import type { GraphPlugin, GraphPluginConstructor, MouseListenerSet } from '../types';
 import Multiplicity from './other/Multiplicity';

--- a/packages/core/src/view/style/Stylesheet.ts
+++ b/packages/core/src/view/style/Stylesheet.ts
@@ -383,4 +383,3 @@ export class StylesheetCodec extends ObjectCodec {
 }
 
 CodecRegistry.register(new StylesheetCodec());
-export default Stylesheet;

--- a/packages/ts-example/package.json
+++ b/packages/ts-example/package.json
@@ -12,6 +12,6 @@
     "@maxgraph/core": "*"
   },
   "devDependencies": {
-    "vite": "~4.3.1"
+    "vite": "~4.3.9"
   }
 }


### PR DESCRIPTION
These 2 classes were previously not exported as they generated runtime errors when applications integrating `maxGraph` used the Vite dev server.

Bump vite from 4.3.1 to 4.3.9. This is probably what fixed the problem.
No need to export Stylesheet and EditorToolbar as default as they are already exported.

fixes #97