### PR TITLE
chore: fix dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,7 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    schedule:
+      interval: "weekly"
     commit-message:
       prefix: "chore(deps-gha)"


### PR DESCRIPTION
Add the missing `schedule.interval` configuration which is mandatory.