### PR TITLE
fix: use configurable path for `errorImage`

### DIFF
--- a/packages/core/src/util/Utils.ts
+++ b/packages/core/src/util/Utils.ts
@@ -16,6 +16,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import Client from '../Client';
+
 /**
  * A singleton class that provides cross-browser helper methods.
  * This is a global functionality. To access the functions in this

--- a/packages/core/src/util/Utils.ts
+++ b/packages/core/src/util/Utils.ts
@@ -48,7 +48,7 @@ export const utils = {
   /**
    * Defines the image used for error dialogs.
    */
-  errorImage: '/error.gif', // Client.imageBasePath + '/error.gif',
+  errorImage: `${Client.imageBasePath}/error.gif`,
 };
 
 export const isNullish = (v: string | object | null | undefined | number) =>


### PR DESCRIPTION
**Summary**
<!--
What existing issue does the pull request solve?
Please provide enough information so that others can review your pull request
-->
The default path of `errorImage` hard coded the context instead of using `Client.imageBasePath` as everywhere else.
This seemed to be a migration mistake (the original code using the configurable path was commented).

<!--
**Description for the changelog**
A short (one line) summary that describes the changes in this
pull request for inclusion in the change log
If this is a bug fix, your description should include "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number
-->

**Other info**
<!--
Thanks for submitting a pull request!

All contributions to this project are done under the terms of the Apache 2.0 license as stated in https://www.apache.org/licenses/LICENSE-2.0

Please make sure you read github's contributing guidelines;
https://docs.github.com/en/desktop/installing-and-configuring-github-desktop/getting-started-with-github-desktop#part-3-contributing-to-projects-with-github-desktop
-->

Refs #238
