### PR TITLE
fix: make 'movable' style attribute behave as expected

### DIFF
--- a/packages/core/src/view/mixins/CellsMixin.ts
+++ b/packages/core/src/view/mixins/CellsMixin.ts
@@ -2712,10 +2712,9 @@ export const CellsMixin: PartialType = {
   },
 
   /**
-   * Returns true if the given cell is moveable. This returns {@link cellsMovable}
-   * for all given cells if {@link isCellLocked} does not return true for the given
-   * cell, and its style either explicitly specifies {@link 'movable'} as true or
-   * doesn't specify it at all
+   * Returns `true` if the given cell is movable. This returns {@link cellsMovable}
+   * for all given cells if {@link isCellLocked} does not return `true` for the given
+   * cell, and its style does not specify {@link CellStateStyle.movable} to be `false`.
    *
    * @param cell {@link mxCell} whose movable state should be returned.
    */
@@ -2723,7 +2722,7 @@ export const CellsMixin: PartialType = {
     const style = this.getCurrentCellStyle(cell);
     return this.isCellsMovable()
       && !this.isCellLocked(cell)
-      && (style.movable === undefined || style.movable);
+      && (style.movable ?? true);
   },
 
   /**

--- a/packages/core/src/view/mixins/CellsMixin.ts
+++ b/packages/core/src/view/mixins/CellsMixin.ts
@@ -2714,13 +2714,16 @@ export const CellsMixin: PartialType = {
   /**
    * Returns true if the given cell is moveable. This returns {@link cellsMovable}
    * for all given cells if {@link isCellLocked} does not return true for the given
-   * cell and its style does not specify {@link 'movable'} to be 0.
+   * cell, and its style either explicitly specifies {@link 'movable'} as true or
+   * doesn't specify it at all
    *
    * @param cell {@link mxCell} whose movable state should be returned.
    */
   isCellMovable(cell) {
     const style = this.getCurrentCellStyle(cell);
-    return this.isCellsMovable() && !this.isCellLocked(cell) && !style.movable;
+    return this.isCellsMovable()
+      && !this.isCellLocked(cell)
+      && (style.movable === undefined || style.movable);
   },
 
   /**


### PR DESCRIPTION
**Summary**

The 'movable' style attribute of cells has the opposite effect as what would be expected. When set to false, cells can be moved, and when true, cells can't be moved. It looks like this is something that got lost in translation in the conversion from mxgraph -- previously, it assumed that if 'movable' had any value, it must be the string "0". This attribute got changed to a boolean in Typescript, but it looks like the check never got updated leading to this strange behaviour. 

The fix is fairly simple, as you can see in the diff. If 'movable' is undefined, then we assume that it's true. If not, then we check it like a regular boolean. 

**Description for the changelog**

'movable' style attribute behaves as expected
