### PR TITLE
ci: use macos-13 in GitHub workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       # we want to run the full build on all os: don't cancel running jobs even if one fails
       fail-fast: false
       matrix:
-        os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
+        os: ['ubuntu-22.04', 'macos-13', 'windows-2022']
     steps:
       - uses: actions/checkout@v4
       - name: Setup node


### PR DESCRIPTION
Build with a more recent version to better suit developers' machines, which usually use a recent operating system.