### PR TITLE
chore: clean before pack

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,16 +27,18 @@
     "url": "https://github.com/maxGraph/maxGraph/issues"
   },
   "scripts": {
+    "clean": "rimraf dist",
     "dev": "tsc --watch",
     "build": "tsc --version && tsc",
     "docs:api": "typedoc src/index.ts",
-    "prepack": "run-s build",
+    "prepack": "run-s clean build",
     "test": "jest"
   },
   "devDependencies": {
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
     "npm-run-all": "~4.1.5",
+    "rimraf": "~5.0.5",
     "ts-jest": "^29.0.3",
     "typedoc": "^0.23.21",
     "typescript": "^4.9.5"

--- a/packages/website/docs/development/release.md
+++ b/packages/website/docs/development/release.md
@@ -49,7 +49,6 @@ git push origin v0.2.0
 
 - Checkout the tag that has just been created
 - From packages/core:
-  - delete the `dist` folder 
   - run `npm publish`
 
 


### PR DESCRIPTION
This simplifies the release procedure. No manual cleaning is required, this reduces the risk of errors.