### PR TITLE
docs: remove extra "markdown-page" page

### DIFF
--- a/packages/website/src/pages/markdown-page.md
+++ b/packages/website/src/pages/markdown-page.md
@@ -1,7 +1,0 @@
----
-title: Markdown page example
----
-
-# Markdown page example
-
-You don't need React to write simple standalone pages.


### PR DESCRIPTION
This page is an example from the Docusaurus initialization. It has been kept by mistake.