### PR TITLE
chore!: build with TypeScript v5.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # `maxGraph` Change Log
 
+## UNRELEASED
+
+**Breaking Changes**
+- it is no longer possible to pass a 'n' value for the `max` property of the `Multiplicity` class. Pass `null` instead to have the same effect.
+
 ## 0.8.0
 
 Release date: `2024-02-14`

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "eslint-plugin-import": "~2.29.1",
         "eslint-plugin-prettier": "~5.1.3",
         "prettier": "~3.1.1",
-        "typescript": "^4.9.5"
+        "typescript": "~5.3.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -25905,15 +25905,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/ua-parser-js": {
@@ -28025,8 +28025,7 @@
         "npm-run-all": "~4.1.5",
         "rimraf": "~5.0.5",
         "ts-jest": "^29.0.3",
-        "typedoc": "^0.23.21",
-        "typescript": "^4.9.5"
+        "typedoc": "~0.25.8"
       }
     },
     "packages/core/node_modules/rimraf": {
@@ -28070,28 +28069,14 @@
       "name": "@maxgraph/html",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@storybook/addon-essentials": "^7.4.6",
-        "@storybook/addon-links": "^7.4.6",
-        "@storybook/addon-storysource": "^7.4.6",
-        "@storybook/blocks": "^7.4.6",
-        "@storybook/html": "^7.4.6",
-        "@storybook/html-vite": "^7.4.6",
-        "storybook": "^7.4.6",
-        "typescript": "^5.2.2",
+        "@storybook/addon-essentials": "~7.6.17",
+        "@storybook/addon-links": "~7.6.17",
+        "@storybook/addon-storysource": "~7.6.17",
+        "@storybook/blocks": "~7.6.17",
+        "@storybook/html": "~7.6.17",
+        "@storybook/html-vite": "~7.6.17",
+        "storybook": "~7.6.17",
         "vite": "^5.0.12"
-      }
-    },
-    "packages/html/node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/js-example": {
@@ -28810,19 +28795,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "packages/ts-example/node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "packages/ts-example/node_modules/vite": {
       "version": "5.0.12",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
@@ -28910,8 +28882,7 @@
       "devDependencies": {
         "@docusaurus/module-type-aliases": "3.0.0",
         "@docusaurus/tsconfig": "3.0.0",
-        "@docusaurus/types": "3.0.0",
-        "typescript": "~5.2.2"
+        "@docusaurus/types": "3.0.0"
       },
       "engines": {
         "node": ">=18.0"
@@ -28931,18 +28902,6 @@
       "peerDependencies": {
         "@types/react": ">=16",
         "react": ">=16"
-      }
-    },
-    "packages/website/node_modules/typescript": {
-      "version": "5.2.2",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint-plugin-import": "~2.29.1",
     "eslint-plugin-prettier": "~5.1.3",
     "prettier": "~3.1.1",
-    "typescript": "^4.9.5"
+    "typescript": "~5.3.2"
   },
   "overrides": {
     "@types/node": "^16.18.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint-plugin-import": "~2.29.1",
     "eslint-plugin-prettier": "~5.1.3",
     "prettier": "~3.1.1",
-    "typescript": "~5.3.2"
+    "typescript": "~5.3.3"
   },
   "overrides": {
     "@types/node": "^16.18.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,7 +51,7 @@
     "npm-run-all": "~4.1.5",
     "rimraf": "~5.0.5",
     "ts-jest": "^29.0.3",
-    "typedoc": "~0.25.4"
+    "typedoc": "~0.25.8"
   },
   "sideEffects": true
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,8 +51,7 @@
     "npm-run-all": "~4.1.5",
     "rimraf": "~5.0.5",
     "ts-jest": "^29.0.3",
-    "typedoc": "^0.23.21",
-    "typescript": "^4.9.5"
+    "typedoc": "~0.25.4"
   },
   "sideEffects": true
 }

--- a/packages/core/src/view/Graph.ts
+++ b/packages/core/src/view/Graph.ts
@@ -113,8 +113,7 @@ class Graph extends EventSource {
   mouseListeners: MouseListenerSet[] = [];
 
   /**
-   * An array of {@link Multiplicity} describing the allowed
-   * connections in a graph.
+   * An array of {@link Multiplicity} describing the allowed connections in a graph.
    */
   multiplicities: Multiplicity[] = [];
 

--- a/packages/core/src/view/other/Multiplicity.ts
+++ b/packages/core/src/view/other/Multiplicity.ts
@@ -47,7 +47,7 @@ class Multiplicity {
     attr: string,
     value: string,
     min: number | null | undefined,
-    max: number | 'n' | null | undefined,
+    max: number | null | undefined,
     validNeighbors: string[],
     countError: string,
     typeError: string,
@@ -57,8 +57,8 @@ class Multiplicity {
     this.type = type;
     this.attr = attr;
     this.value = value;
-    this.min = min != null ? min : 0;
-    this.max = max != null ? max : 'n';
+    this.min = min ?? 0;
+    this.max = max ?? Number.MAX_VALUE;
     this.validNeighbors = validNeighbors;
     this.countError = Translations.get(countError) || countError;
     this.typeError = Translations.get(typeError) || typeError;
@@ -92,17 +92,15 @@ class Multiplicity {
 
   /**
    * Defines the minimum number of connections for which this rule applies.
-   *
    * @default 0
    */
   min: number;
 
   /**
    * Defines the maximum number of connections for which this rule applies.
-   * A value of 'n' means unlimited times.
-   * @default 'n'
+   * @default {@link Number.MAX_VALUE}
    */
-  max: number | 'n';
+  max: number;
 
   /**
    * Holds an array of strings that specify the type of neighbor for which

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -10,13 +10,13 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "@storybook/addon-essentials": "^7.4.6",
-    "@storybook/addon-links": "^7.4.6",
-    "@storybook/addon-storysource": "^7.4.6",
-    "@storybook/blocks": "^7.4.6",
-    "@storybook/html": "^7.4.6",
-    "@storybook/html-vite": "^7.4.6",
-    "storybook": "^7.4.6",
+    "@storybook/addon-essentials": "~7.6.17",
+    "@storybook/addon-links": "~7.6.17",
+    "@storybook/addon-storysource": "~7.6.17",
+    "@storybook/blocks": "~7.6.17",
+    "@storybook/html": "~7.6.17",
+    "@storybook/html-vite": "~7.6.17",
+    "storybook": "~7.6.17",
     "vite": "^5.0.12"
   }
 }

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -17,7 +17,6 @@
     "@storybook/html": "^7.4.6",
     "@storybook/html-vite": "^7.4.6",
     "storybook": "^7.4.6",
-    "typescript": "^5.2.2",
     "vite": "^5.0.12"
   }
 }

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -26,8 +26,7 @@
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.0.0",
     "@docusaurus/tsconfig": "3.0.0",
-    "@docusaurus/types": "3.0.0",
-    "typescript": "~5.2.2"
+    "@docusaurus/types": "3.0.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
As TypeScript v5 detects more errors, the version bump requires to update the `Multiplicity` class. It now only accepts number for the `max` property. Previously, it accepted a special string value, but TypeScript v5 now complains when comparing a number with a string. So, as the `max` property is used in number comparisons, it must only accept number.

Also bump some development dependencies to get better support for TypeScript v5.
  - `typedoc` from 0.23 to 0.25 
  - `storybook` from 7.4  to 7.6

BREAKING CHANGE:  it is no longer possible to pass an 'n' value for the `max` property of the `Multiplicity` class. Pass `null` instead to have the same effect.

Closes #189