### PR TITLE
test: execute tests serially to speed up test execution

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,7 @@
     "build": "tsc --version && tsc",
     "docs:api": "typedoc src/index.ts",
     "prepack": "run-s clean build",
-    "test": "jest"
+    "test": "jest --runInBand"
   },
   "devDependencies": {
     "jest": "^29.3.1",


### PR DESCRIPTION
By default, `jest` runs tests in parallel. However, with the current configuration of `ts-jest`, all workers run `tsc` in parallel, which is very slow and consumes a lot of resources. This is what takes the longest.
By running `jest` serially, `tsc` runs before starting the first test, then all subsequent tests run faster. This will probably be improved by customizing the configuration of `jest` or with future versions of `ts-jest`.

### Notes

Jest configuration: https://jestjs.io/docs/cli#--runinband

Tests with 9463e1e2 (v0.5.0)
> Test Suites: 10 passed, 10 total
Tests:       31 passed, 31 total
Snapshots:   0 total

Environment | parallel | sequential
---- | ---- | ---- 
Local Ubuntu 20 | 48s-54s | 18s-20s
GH Actions Ubuntu 22 | 24s-27s | 15s-17s
GH Actions macOS 13 | 38s-40s | 18s-20s
GH Actions windows 2022  | 29s-30s | 22s-23s
