### PR TITLE
docs(release): improve the "examples repository update" paragraph

### DIFF
--- a/packages/website/docs/development/release.md
+++ b/packages/website/docs/development/release.md
@@ -93,7 +93,9 @@ Review the newly created discussion in the [Announces](https://github.com/maxGra
 ## Update the integration examples repository
 
 Once done, create a Pull Request in the [integration examples repository](https://github.com/maxGraph/maxgraph-integration-examples) to use the new release.
-Dependencies in this repository are automatically updated by Dependabot, so you can trigger a new Dependabot run or wait for the next scheduled Dependabot run for this update to take place.
+- Dependencies in this repository are automatically updated by Dependabot, so you can trigger a new Dependabot run or wait for the next scheduled Dependabot run for this update to take place.
+- Validate that examples work: use the artifact built by the GitHub Actions to test the various applications locally
+
 
 Then, create a [new draft release](https://github.com/maxGraph/maxgraph-integration-examples/releases):
 - name: use the same version as in `maxGraph`, like `0.2.1` 

--- a/packages/website/docs/development/release.md
+++ b/packages/website/docs/development/release.md
@@ -92,8 +92,7 @@ Review the newly created discussion in the [Announces](https://github.com/maxGra
 
 ## Update the integration examples repository
 
-Once done, create a Pull Request in the [integration examples repository](https://github.com/maxGraph/maxgraph-integration-examples)
-to use the new release.
+Once done, create a Pull Request in the [integration examples repository](https://github.com/maxGraph/maxgraph-integration-examples) to use the new release.
 Dependencies in this repository are automatically updated by Dependabot, so you can trigger a new Dependabot run or wait for the next scheduled Dependabot run for this update to take place.
 
 Then, create a [new draft release](https://github.com/maxGraph/maxgraph-integration-examples/releases)

--- a/packages/website/docs/development/release.md
+++ b/packages/website/docs/development/release.md
@@ -94,8 +94,7 @@ Review the newly created discussion in the [Announces](https://github.com/maxGra
 
 Once done, create a Pull Request in the [integration examples repository](https://github.com/maxGraph/maxgraph-integration-examples) to use the new release.
 - Dependencies in this repository are automatically updated by Dependabot, so you can trigger a new Dependabot run or wait for the next scheduled Dependabot run for this update to take place.
-- Validate that examples work: use the artifact built by the GitHub Actions to test the various applications locally
-
+- Validate that the examples work: use the artifact built by GitHub Actions to test the various applications locally.
 
 Then, create a [new draft release](https://github.com/maxGraph/maxgraph-integration-examples/releases):
 - name: use the same version as in `maxGraph`, like `0.2.1` 

--- a/packages/website/docs/development/release.md
+++ b/packages/website/docs/development/release.md
@@ -95,7 +95,7 @@ Review the newly created discussion in the [Announces](https://github.com/maxGra
 Once done, create a Pull Request in the [integration examples repository](https://github.com/maxGraph/maxgraph-integration-examples) to use the new release.
 Dependencies in this repository are automatically updated by Dependabot, so you can trigger a new Dependabot run or wait for the next scheduled Dependabot run for this update to take place.
 
-Then, create a [new draft release](https://github.com/maxGraph/maxgraph-integration-examples/releases)
+Then, create a [new draft release](https://github.com/maxGraph/maxgraph-integration-examples/releases):
 - name: use the same version as in `maxGraph`, like `0.2.1` 
 - tag: use the version prefixed with v, like `v0.2.1`
 - save it as a draft

--- a/packages/website/docs/development/release.md
+++ b/packages/website/docs/development/release.md
@@ -93,11 +93,10 @@ Review the newly created discussion in the [Announces](https://github.com/maxGra
 ## Update the integration examples repository
 
 Once done, create a Pull Request in the [integration examples repository](https://github.com/maxGraph/maxgraph-integration-examples)
-to use the new release. Use [PR #28](https://github.com/maxGraph/maxgraph-integration-examples/pull/28) as an example.
+to use the new release.
+Dependencies in this repository are automatically updated by Dependabot, so you can trigger a new Dependabot run or wait for the next scheduled Dependabot run for this update to take place.
 
-**Note:** The examples will be updated automatically in the future, see the [issue #27](https://github.com/maxGraph/maxgraph-integration-examples/issues/27) for more details.
-
-Then, create a [new draft release](https://github.com/maxGraph/maxGraph/releases/)
+Then, create a [new draft release](https://github.com/maxGraph/maxgraph-integration-examples/releases)
 - name: use the same version as in `maxGraph`, like `0.2.1` 
 - tag: use the version prefixed with v, like `v0.2.1`
 - save it as a draft


### PR DESCRIPTION
Changes are based on the feedback collected during the  `0.5.0` release:
  - Use Dependabot to update `maxGraph`
  - Fix link to GitHub releases.