### PR TITLE
ci: automate npm publish

### DIFF
--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -1,6 +1,11 @@
 name: 'Build Setup'
 description: 'Setup node and install dependencies'
 
+inputs:
+  registry-url:
+    description: 'Optional registry to set up for auth.'
+    required: false
+
 runs:
   using: 'composite'
   steps:
@@ -8,6 +13,7 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version-file: '.nvmrc'
+        registry-url: ${{ inputs.registry-url }}
     - name: Install dependencies
       uses: bahmutov/npm-install@v1
       with:

--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -1,0 +1,22 @@
+name: Publish NPM Package
+on:
+  push:
+    tags:
+      -  v*
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    permissions:
+      # required for "npm provenance"
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Setup
+        uses: ./.github/actions/build-setup
+        with:
+          registry-url: 'https://registry.npmjs.org'
+      # scoped package requires "access=public"
+      - run: npm publish -w packages/core --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/website/docs/development/release.md
+++ b/packages/website/docs/development/release.md
@@ -56,6 +56,8 @@ git tag v0.2.0
 
 ## Publish the npm package
 
+TODO link to the new workflow
+
 - Checkout the tag that has just been created
 - From packages/core:
   - run `npm publish`

--- a/packages/website/docs/development/release.md
+++ b/packages/website/docs/development/release.md
@@ -56,8 +56,9 @@ git tag v0.2.0
 
 ## Publish the npm package
 
-TODO link to the new workflow
+The package is published automatically once the Git tag is pushed thanks to a [GitHub workflow](https://github.com/maxGraph/maxgraph-integration-examples/actions/workflows/publish-npm-package.yml).
 
+If its execution fails, and you want to publish the package manually:
 - Checkout the tag that has just been created
 - From packages/core:
   - run `npm publish`


### PR DESCRIPTION
Add a workflow that performs the publishing when a new Git tag is pushed.