### PR TITLE
feat: declare exports in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25084,7 +25084,21 @@
       "name": "@maxgraph/ts-example-built-with-vite",
       "license": "Apache-2.0",
       "devDependencies": {
+        "typescript": "~5.3.3",
         "vite": "~4.4.12"
+      }
+    },
+    "packages/ts-example/node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/ts-example/node_modules/vite": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,15 @@
   ],
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "css",
     "dist",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,8 @@
         "default": "./dist/index.js"
       }
     },
+    "./css/*": "./css/*",
+    "./images/*": "./images/*",
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/html/tsconfig.json
+++ b/packages/html/tsconfig.json
@@ -9,8 +9,7 @@
 
     /* Bundler mode */
     "allowJs": true,
-    // TODO restore bundler - require exports in the package.json of @maxgraph/core
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/packages/ts-example/package.json
+++ b/packages/ts-example/package.json
@@ -2,6 +2,7 @@
   "name": "@maxgraph/ts-example-built-with-vite",
   "license": "Apache-2.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "tsc --version && tsc && vite build --base ./",

--- a/packages/ts-example/package.json
+++ b/packages/ts-example/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
+    "typescript": "~5.3.3",
     "vite": "~4.4.12"
   }
 }

--- a/packages/ts-example/tsconfig.json
+++ b/packages/ts-example/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "useDefineForClassFields": true,
     "sourceMap": true,
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "noEmit": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
It lets use `moduleResolution=bundler` in TypeScript applications.
In particular, it lets use it with Storybook and ts-example in this repository.

### Notes

See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing