### PR TITLE
fix: correctly position the child vertex of an edge using relative geometry

### DIFF
--- a/packages/core/src/view/GraphView.ts
+++ b/packages/core/src/view/GraphView.ts
@@ -897,11 +897,11 @@ export class GraphView extends EventSource {
 
           if (geo.relative && pState) {
             if (pState.cell.isEdge()) {
-              const origin = this.getPoint(pState, geo);
+              const point = this.getPoint(pState, geo);
 
-              if (origin) {
-                origin.x += origin.x / this.scale - pState.origin.x - this.translate.x;
-                origin.y += origin.y / this.scale - pState.origin.y - this.translate.y;
+              if (point) {
+                origin.x += point.x / this.scale - pState.origin.x - this.translate.x;
+                origin.y += point.y / this.scale - pState.origin.y - this.translate.y;
               }
             } else {
               origin.x += geo.x * pState.unscaledWidth + offset.x;


### PR DESCRIPTION
Fix for Marker story - issue with positioning the child vertex of an edge. It introduces new const to avoid overriding other const with the same name. Look at updateCellState(...) method in packages/core/src/view/GraphView.ts - 'const origin' is firstly defined in line 868 and then again in line 900 which should be separate const - it was separate const in original mxGraph implementation.

**Summary**
Issue described https://github.com/maxGraph/maxGraph/issues/158

**Description for the changelog**
Fix the issue with positioning the child vertex of an edge (fixes #158)