### PR TITLE
fix: remove extra "implements" clause in `MaxPopupMenu`

### DIFF
--- a/packages/core/src/gui/MaxPopupMenu.ts
+++ b/packages/core/src/gui/MaxPopupMenu.ts
@@ -51,7 +51,7 @@ import { PopupMenuItem } from '../types';
  *
  * Fires after the menu has been shown in <popup>.
  */
-class MaxPopupMenu extends EventSource implements Partial<PopupMenuItem> {
+class MaxPopupMenu extends EventSource {
   constructor(
     factoryMethod?: (handler: PopupMenuItem, cell: Cell | null, me: MouseEvent) => void
   ) {


### PR DESCRIPTION
 This clause has been introduced in 61648e4 and seems not needed.

Closes #235