### PR TITLE
refactor: remove side effects when registering default style elements

### DIFF
--- a/packages/core/src/view/Graph.ts
+++ b/packages/core/src/view/Graph.ts
@@ -56,8 +56,8 @@ import type { GraphPlugin, GraphPluginConstructor, MouseListenerSet } from '../t
 import Multiplicity from './other/Multiplicity';
 import ImageBundle from './image/ImageBundle';
 import GraphSelectionModel from './GraphSelectionModel';
-import { registerCoreShapes } from './cell/register-shapes';
-import { registerCoreStyleElements } from './style/register';
+import { registerDefaultShapes } from './cell/register-shapes';
+import { registerDefaultStyleElements } from './style/register';
 
 export const defaultPlugins: GraphPluginConstructor[] = [
   CellEditorHandler,
@@ -488,9 +488,9 @@ class Graph extends EventSource {
   // Group: Main graph constructor and functions
   // ===================================================================================================================
 
-  protected registerDefaultStyleElements(): void {
-    registerCoreShapes();
-    registerCoreStyleElements();
+  protected registerDefaults(): void {
+    registerDefaultShapes();
+    registerDefaultStyleElements();
   }
 
   constructor(
@@ -500,7 +500,7 @@ class Graph extends EventSource {
     stylesheet: Stylesheet | null = null
   ) {
     super();
-    this.registerDefaultStyleElements();
+    this.registerDefaults();
 
     this.container = container ?? document.createElement('div');
     this.model = model ?? this.createGraphDataModel();

--- a/packages/core/src/view/Graph.ts
+++ b/packages/core/src/view/Graph.ts
@@ -56,6 +56,8 @@ import type { GraphPlugin, GraphPluginConstructor, MouseListenerSet } from '../t
 import Multiplicity from './other/Multiplicity';
 import ImageBundle from './image/ImageBundle';
 import GraphSelectionModel from './GraphSelectionModel';
+import { registerCoreShapes } from './cell/register-shapes';
+import { registerCoreStyleElements } from './style/register';
 
 export const defaultPlugins: GraphPluginConstructor[] = [
   CellEditorHandler,
@@ -486,6 +488,11 @@ class Graph extends EventSource {
   // Group: Main graph constructor and functions
   // ===================================================================================================================
 
+  protected registerDefaultStyleElements(): void {
+    registerCoreShapes();
+    registerCoreStyleElements();
+  }
+
   constructor(
     container: HTMLElement,
     model?: GraphDataModel,
@@ -493,6 +500,7 @@ class Graph extends EventSource {
     stylesheet: Stylesheet | null = null
   ) {
     super();
+    this.registerDefaultStyleElements();
 
     this.container = container ?? document.createElement('div');
     this.model = model ?? this.createGraphDataModel();

--- a/packages/core/src/view/cell/CellRenderer.ts
+++ b/packages/core/src/view/cell/CellRenderer.ts
@@ -17,21 +17,8 @@ limitations under the License.
 */
 
 import RectangleShape from '../geometry/node/RectangleShape';
-import EllipseShape from '../geometry/node/EllipseShape';
-import RhombusShape from '../geometry/node/RhombusShape';
-import CylinderShape from '../geometry/node/CylinderShape';
 import ConnectorShape from '../geometry/edge/ConnectorShape';
-import ActorShape from '../geometry/ActorShape';
-import TriangleShape from '../geometry/node/TriangleShape';
-import HexagonShape from '../geometry/node/HexagonShape';
-import CloudShape from '../geometry/node/CloudShape';
-import LineShape from '../geometry/edge/LineShape';
-import ArrowShape from '../geometry/edge/ArrowShape';
-import ArrowConnectorShape from '../geometry/edge/ArrowConnectorShape';
-import DoubleEllipseShape from '../geometry/node/DoubleEllipseShape';
-import SwimlaneShape from '../geometry/node/SwimlaneShape';
 import ImageShape from '../geometry/node/ImageShape';
-import LabelShape from '../geometry/node/LabelShape';
 import TextShape from '../geometry/node/TextShape';
 import {
   ALIGN,
@@ -41,7 +28,6 @@ import {
   DEFAULT_TEXT_DIRECTION,
   DIALECT,
   NONE,
-  SHAPE,
 } from '../../util/Constants';
 import { getRotatedPoint, mod, toRadians } from '../../util/mathUtils';
 import { convertPoint } from '../../util/styleUtils';
@@ -1513,29 +1499,6 @@ class CellRenderer {
       state.shape = null;
     }
   }
-}
-
-// Add default shapes into the default shapes array
-for (const [shapeName, shapeClass] of [
-  [SHAPE.RECTANGLE, RectangleShape],
-  [SHAPE.ELLIPSE, EllipseShape],
-  [SHAPE.RHOMBUS, RhombusShape],
-  [SHAPE.CYLINDER, CylinderShape],
-  [SHAPE.CONNECTOR, ConnectorShape],
-  [SHAPE.ACTOR, ActorShape],
-  [SHAPE.TRIANGLE, TriangleShape],
-  [SHAPE.HEXAGON, HexagonShape],
-  [SHAPE.CLOUD, CloudShape],
-  [SHAPE.LINE, LineShape],
-  [SHAPE.ARROW, ArrowShape],
-  [SHAPE.ARROW_CONNECTOR, ArrowConnectorShape],
-  [SHAPE.DOUBLE_ELLIPSE, DoubleEllipseShape],
-  [SHAPE.SWIMLANE, SwimlaneShape],
-  [SHAPE.IMAGE, ImageShape],
-  [SHAPE.LABEL, LabelShape],
-]) {
-  // @ts-ignore
-  CellRenderer.registerShape(shapeName, shapeClass);
 }
 
 export default CellRenderer;

--- a/packages/core/src/view/cell/register-shapes.ts
+++ b/packages/core/src/view/cell/register-shapes.ts
@@ -33,12 +33,12 @@ import ImageShape from '../geometry/node/ImageShape';
 import LabelShape from '../geometry/node/LabelShape';
 import { SHAPE } from '../../util/Constants';
 
-let isCoreElementsRegistered = false;
+let isDefaultElementsRegistered = false;
 /**
  * Add default shapes into `CellRenderer` shapes.
  */
-export function registerCoreShapes() {
-  if (!isCoreElementsRegistered) {
+export function registerDefaultShapes() {
+  if (!isDefaultElementsRegistered) {
     for (const [shapeName, shapeClass] of [
       [SHAPE.ACTOR, ActorShape],
       [SHAPE.ARROW, ArrowShape],
@@ -61,6 +61,6 @@ export function registerCoreShapes() {
       CellRenderer.registerShape(shapeName, shapeClass);
     }
 
-    isCoreElementsRegistered = true;
+    isDefaultElementsRegistered = true;
   }
 }

--- a/packages/core/src/view/cell/register-shapes.ts
+++ b/packages/core/src/view/cell/register-shapes.ts
@@ -1,0 +1,66 @@
+/*
+Copyright 2024-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import CellRenderer from './CellRenderer';
+import RectangleShape from '../geometry/node/RectangleShape';
+import EllipseShape from '../geometry/node/EllipseShape';
+import RhombusShape from '../geometry/node/RhombusShape';
+import CylinderShape from '../geometry/node/CylinderShape';
+import ConnectorShape from '../geometry/edge/ConnectorShape';
+import ActorShape from '../geometry/ActorShape';
+import TriangleShape from '../geometry/node/TriangleShape';
+import HexagonShape from '../geometry/node/HexagonShape';
+import CloudShape from '../geometry/node/CloudShape';
+import LineShape from '../geometry/edge/LineShape';
+import ArrowShape from '../geometry/edge/ArrowShape';
+import ArrowConnectorShape from '../geometry/edge/ArrowConnectorShape';
+import DoubleEllipseShape from '../geometry/node/DoubleEllipseShape';
+import SwimlaneShape from '../geometry/node/SwimlaneShape';
+import ImageShape from '../geometry/node/ImageShape';
+import LabelShape from '../geometry/node/LabelShape';
+import { SHAPE } from '../../util/Constants';
+
+let isCoreElementsRegistered = false;
+/**
+ * Add default shapes into `CellRenderer` shapes.
+ */
+export function registerCoreShapes() {
+  if (!isCoreElementsRegistered) {
+    for (const [shapeName, shapeClass] of [
+      [SHAPE.ACTOR, ActorShape],
+      [SHAPE.ARROW, ArrowShape],
+      [SHAPE.ARROW_CONNECTOR, ArrowConnectorShape],
+      [SHAPE.CONNECTOR, ConnectorShape],
+      [SHAPE.CLOUD, CloudShape],
+      [SHAPE.CYLINDER, CylinderShape],
+      [SHAPE.DOUBLE_ELLIPSE, DoubleEllipseShape],
+      [SHAPE.ELLIPSE, EllipseShape],
+      [SHAPE.HEXAGON, HexagonShape],
+      [SHAPE.IMAGE, ImageShape],
+      [SHAPE.LABEL, LabelShape],
+      [SHAPE.LINE, LineShape],
+      [SHAPE.RECTANGLE, RectangleShape],
+      [SHAPE.RHOMBUS, RhombusShape],
+      [SHAPE.SWIMLANE, SwimlaneShape],
+      [SHAPE.TRIANGLE, TriangleShape],
+    ]) {
+      // @ts-ignore
+      CellRenderer.registerShape(shapeName, shapeClass);
+    }
+
+    isCoreElementsRegistered = true;
+  }
+}

--- a/packages/core/src/view/cell/register-shapes.ts
+++ b/packages/core/src/view/cell/register-shapes.ts
@@ -34,6 +34,7 @@ import LabelShape from '../geometry/node/LabelShape';
 import { SHAPE } from '../../util/Constants';
 
 let isDefaultElementsRegistered = false;
+
 /**
  * Add default shapes into `CellRenderer` shapes.
  */

--- a/packages/core/src/view/style/StyleRegistry.ts
+++ b/packages/core/src/view/style/StyleRegistry.ts
@@ -21,8 +21,6 @@ import EdgeStyle from './EdgeStyle';
 import Perimeter from './Perimeter';
 
 /**
- * @class StyleRegistry
- *
  * Singleton class that acts as a global converter from string to object values
  * in a style. This is currently only used to perimeters and edge styles.
  */
@@ -58,20 +56,5 @@ class StyleRegistry {
     return null;
   }
 }
-
-StyleRegistry.putValue(EDGESTYLE.ELBOW, EdgeStyle.ElbowConnector);
-StyleRegistry.putValue(EDGESTYLE.ENTITY_RELATION, EdgeStyle.EntityRelation);
-StyleRegistry.putValue(EDGESTYLE.LOOP, EdgeStyle.Loop);
-StyleRegistry.putValue(EDGESTYLE.SIDETOSIDE, EdgeStyle.SideToSide);
-StyleRegistry.putValue(EDGESTYLE.TOPTOBOTTOM, EdgeStyle.TopToBottom);
-StyleRegistry.putValue(EDGESTYLE.ORTHOGONAL, EdgeStyle.OrthConnector);
-StyleRegistry.putValue(EDGESTYLE.SEGMENT, EdgeStyle.SegmentConnector);
-StyleRegistry.putValue(EDGESTYLE.MANHATTAN, EdgeStyle.ManhattanConnector);
-
-StyleRegistry.putValue(PERIMETER.ELLIPSE, Perimeter.EllipsePerimeter);
-StyleRegistry.putValue(PERIMETER.RECTANGLE, Perimeter.RectanglePerimeter);
-StyleRegistry.putValue(PERIMETER.RHOMBUS, Perimeter.RhombusPerimeter);
-StyleRegistry.putValue(PERIMETER.TRIANGLE, Perimeter.TrianglePerimeter);
-StyleRegistry.putValue(PERIMETER.HEXAGON, Perimeter.HexagonPerimeter);
 
 export default StyleRegistry;

--- a/packages/core/src/view/style/register.ts
+++ b/packages/core/src/view/style/register.ts
@@ -19,15 +19,15 @@ import EdgeStyle from './EdgeStyle';
 import Perimeter from './Perimeter';
 import StyleRegistry from './StyleRegistry';
 
-let isCoreElementsRegistered = false;
+let isDefaultElementsRegistered = false;
 /**
  * Register style elements for "EdgeStyle" and "Perimeters".
  */
-export const registerCoreStyleElements = (): void => {
-  if (!isCoreElementsRegistered) {
+export const registerDefaultStyleElements = (): void => {
+  if (!isDefaultElementsRegistered) {
     registerEdgeStyles();
     registerPerimeters();
-    isCoreElementsRegistered = true;
+    isDefaultElementsRegistered = true;
   }
 };
 

--- a/packages/core/src/view/style/register.ts
+++ b/packages/core/src/view/style/register.ts
@@ -1,0 +1,51 @@
+/*
+Copyright 2024-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { EDGESTYLE, PERIMETER } from '../../util/Constants';
+import EdgeStyle from './EdgeStyle';
+import Perimeter from './Perimeter';
+import StyleRegistry from './StyleRegistry';
+
+let isCoreElementsRegistered = false;
+/**
+ * Register style elements for "EdgeStyle" and "Perimeters".
+ */
+export const registerCoreStyleElements = (): void => {
+  if (!isCoreElementsRegistered) {
+    registerEdgeStyles();
+    registerPerimeters();
+    isCoreElementsRegistered = true;
+  }
+};
+
+const registerEdgeStyles = (): void => {
+  StyleRegistry.putValue(EDGESTYLE.ELBOW, EdgeStyle.ElbowConnector);
+  StyleRegistry.putValue(EDGESTYLE.ENTITY_RELATION, EdgeStyle.EntityRelation);
+  StyleRegistry.putValue(EDGESTYLE.LOOP, EdgeStyle.Loop);
+  StyleRegistry.putValue(EDGESTYLE.MANHATTAN, EdgeStyle.ManhattanConnector);
+  StyleRegistry.putValue(EDGESTYLE.ORTHOGONAL, EdgeStyle.OrthConnector);
+  StyleRegistry.putValue(EDGESTYLE.SEGMENT, EdgeStyle.SegmentConnector);
+  StyleRegistry.putValue(EDGESTYLE.SIDETOSIDE, EdgeStyle.SideToSide);
+  StyleRegistry.putValue(EDGESTYLE.TOPTOBOTTOM, EdgeStyle.TopToBottom);
+};
+
+const registerPerimeters = (): void => {
+  StyleRegistry.putValue(PERIMETER.ELLIPSE, Perimeter.EllipsePerimeter);
+  StyleRegistry.putValue(PERIMETER.HEXAGON, Perimeter.HexagonPerimeter);
+  StyleRegistry.putValue(PERIMETER.RECTANGLE, Perimeter.RectanglePerimeter);
+  StyleRegistry.putValue(PERIMETER.RHOMBUS, Perimeter.RhombusPerimeter);
+  StyleRegistry.putValue(PERIMETER.TRIANGLE, Perimeter.TrianglePerimeter);
+};

--- a/packages/core/src/view/style/register.ts
+++ b/packages/core/src/view/style/register.ts
@@ -19,33 +19,30 @@ import EdgeStyle from './EdgeStyle';
 import Perimeter from './Perimeter';
 import StyleRegistry from './StyleRegistry';
 
-let isDefaultElementsRegistered = false;
+let isDefaultsRegistered = false;
+
 /**
  * Register style elements for "EdgeStyle" and "Perimeters".
  */
 export const registerDefaultStyleElements = (): void => {
-  if (!isDefaultElementsRegistered) {
-    registerEdgeStyles();
-    registerPerimeters();
-    isDefaultElementsRegistered = true;
+  if (!isDefaultsRegistered) {
+    // Edge styles
+    StyleRegistry.putValue(EDGESTYLE.ELBOW, EdgeStyle.ElbowConnector);
+    StyleRegistry.putValue(EDGESTYLE.ENTITY_RELATION, EdgeStyle.EntityRelation);
+    StyleRegistry.putValue(EDGESTYLE.LOOP, EdgeStyle.Loop);
+    StyleRegistry.putValue(EDGESTYLE.MANHATTAN, EdgeStyle.ManhattanConnector);
+    StyleRegistry.putValue(EDGESTYLE.ORTHOGONAL, EdgeStyle.OrthConnector);
+    StyleRegistry.putValue(EDGESTYLE.SEGMENT, EdgeStyle.SegmentConnector);
+    StyleRegistry.putValue(EDGESTYLE.SIDETOSIDE, EdgeStyle.SideToSide);
+    StyleRegistry.putValue(EDGESTYLE.TOPTOBOTTOM, EdgeStyle.TopToBottom);
+
+    // Perimeters
+    StyleRegistry.putValue(PERIMETER.ELLIPSE, Perimeter.EllipsePerimeter);
+    StyleRegistry.putValue(PERIMETER.HEXAGON, Perimeter.HexagonPerimeter);
+    StyleRegistry.putValue(PERIMETER.RECTANGLE, Perimeter.RectanglePerimeter);
+    StyleRegistry.putValue(PERIMETER.RHOMBUS, Perimeter.RhombusPerimeter);
+    StyleRegistry.putValue(PERIMETER.TRIANGLE, Perimeter.TrianglePerimeter);
+
+    isDefaultsRegistered = true;
   }
-};
-
-const registerEdgeStyles = (): void => {
-  StyleRegistry.putValue(EDGESTYLE.ELBOW, EdgeStyle.ElbowConnector);
-  StyleRegistry.putValue(EDGESTYLE.ENTITY_RELATION, EdgeStyle.EntityRelation);
-  StyleRegistry.putValue(EDGESTYLE.LOOP, EdgeStyle.Loop);
-  StyleRegistry.putValue(EDGESTYLE.MANHATTAN, EdgeStyle.ManhattanConnector);
-  StyleRegistry.putValue(EDGESTYLE.ORTHOGONAL, EdgeStyle.OrthConnector);
-  StyleRegistry.putValue(EDGESTYLE.SEGMENT, EdgeStyle.SegmentConnector);
-  StyleRegistry.putValue(EDGESTYLE.SIDETOSIDE, EdgeStyle.SideToSide);
-  StyleRegistry.putValue(EDGESTYLE.TOPTOBOTTOM, EdgeStyle.TopToBottom);
-};
-
-const registerPerimeters = (): void => {
-  StyleRegistry.putValue(PERIMETER.ELLIPSE, Perimeter.EllipsePerimeter);
-  StyleRegistry.putValue(PERIMETER.HEXAGON, Perimeter.HexagonPerimeter);
-  StyleRegistry.putValue(PERIMETER.RECTANGLE, Perimeter.RectanglePerimeter);
-  StyleRegistry.putValue(PERIMETER.RHOMBUS, Perimeter.RhombusPerimeter);
-  StyleRegistry.putValue(PERIMETER.TRIANGLE, Perimeter.TrianglePerimeter);
 };


### PR DESCRIPTION
Explicitly call the elements to remove the side effects in `CellRenderer` and `StyleRegistry`.
This prepares the possibility to mark the library as "side effects free" and will allow to changes the defaults in the future.