### PR TITLE
fix: use correct perimeter style property in stories

### DIFF
--- a/packages/html/stories/FileIO.stories.js
+++ b/packages/html/stories/FileIO.stories.js
@@ -26,7 +26,6 @@ import {
   Graph,
   InternalEvent,
   MaxXmlRequest,
-  Perimeter,
 } from '@maxgraph/core';
 
 import { globalTypes, globalValues } from './shared/args.js';
@@ -77,7 +76,6 @@ const Template = ({ label, ...args }) => {
       // Changes the default vertex style in-place
       let style = graph.getStylesheet().getDefaultVertexStyle();
       style.shape = constants.SHAPE.ROUNDED;
-      style.perimiter = Perimeter.RectanglePerimeter;
       style.gradientColor = 'white';
       style.perimeterSpacing = 4;
       style.shadow = true;

--- a/packages/html/stories/GraphLayout.stories.ts
+++ b/packages/html/stories/GraphLayout.stories.ts
@@ -23,31 +23,15 @@ limitations under the License.
 */
 
 import {
-  constants,
   CircleLayout,
   DomHelpers,
   FastOrganicLayout,
   Graph,
   InternalEvent,
   Morphing,
-  Perimeter,
 } from '@maxgraph/core';
 
 import { globalTypes, globalValues } from './shared/args.js';
-
-// TODO apply this settings to the container used by the Graph
-const HTML_TEMPLATE = `
-<!-- Page passes the container for the graph to the program -->
-<body onload="main(document.getElementById('graphContainer'))">
-
-  <!-- Creates a container for the graph with a grid wallpaper. Make sure to define the position
-    and overflow attributes! See comments on the adding of the size-listener on line 54 ff!  -->
-  <div id="graphContainer"
-    style="position:relative;overflow:auto;width:821px;height:641px;background:url('editors/images/grid.gif');">
-  </div>
-  <br>
-</body>
-`;
 
 export default {
   title: 'Layouts/GraphLayout',
@@ -64,7 +48,7 @@ export default {
   },
 };
 
-const Template = ({ label, ...args }) => {
+const Template = ({ label, ...args }: Record<string, any>) => {
   const mainContainer = document.createElement('div');
   const container = document.createElement('div');
 
@@ -76,15 +60,15 @@ const Template = ({ label, ...args }) => {
   container.style.cursor = 'default';
 
   // Creates the graph inside the given container
-  let graph = new Graph(container);
+  const graph = new Graph(container);
 
   // Disables basic selection and cell handling
   graph.setEnabled(false);
 
   // Changes the default vertex style in-place
-  let style = graph.getStylesheet().getDefaultVertexStyle();
-  style.shape = constants.SHAPE.ELLIPSE;
-  style.perimiter = Perimeter.EllipsePerimeter;
+  const style = graph.getStylesheet().getDefaultVertexStyle();
+  style.shape = 'ellipse';
+  style.perimeter = 'ellipsePerimeter';
   style.gradientColor = 'white';
   style.fontSize = 10;
 
@@ -104,27 +88,26 @@ const Template = ({ label, ...args }) => {
 
   // Gets the default parent for inserting new cells. This
   // is normally the first child of the root (ie. layer 0).
-  let parent = graph.getDefaultParent();
+  const parent = graph.getDefaultParent();
 
   // Creates a layout algorithm to be used
   // with the graph
-  let layout = new FastOrganicLayout(graph);
+  const layout = new FastOrganicLayout(graph);
 
   // Moves stuff wider apart than usual
   layout.forceConstant = 80;
 
   // Adds a button to execute the layout
   mainContainer.appendChild(
-    DomHelpers.button('Circle Layout', function (evt) {
+    DomHelpers.button('Circle Layout', () => {
       graph.getDataModel().beginUpdate();
       try {
-        // Creates a layout algorithm to be used
-        // with the graph
-        let circleLayout = new CircleLayout(graph);
+        // Creates a layout algorithm to be used with the graph
+        const circleLayout = new CircleLayout(graph);
         circleLayout.execute(parent);
       } finally {
         if (args.animate) {
-          let morph = new Morphing(graph, 6, 1.5, 20);
+          const morph = new Morphing(graph, 6, 1.5, 20);
           morph.addListener(InternalEvent.DONE, function () {
             graph.getDataModel().endUpdate();
           });
@@ -138,14 +121,14 @@ const Template = ({ label, ...args }) => {
 
   // Adds a button to execute the layout
   mainContainer.appendChild(
-    DomHelpers.button('Organic Layout', function (evt) {
+    DomHelpers.button('Organic Layout', () => {
       graph.getDataModel().beginUpdate();
       try {
         layout.execute(parent);
       } finally {
         if (args.animate) {
           // Default values are 6, 1.5, 20
-          let morph = new Morphing(graph, 10, 1.7, 20);
+          const morph = new Morphing(graph, 10, 1.7, 20);
           morph.addListener(InternalEvent.DONE, function () {
             graph.getDataModel().endUpdate();
           });
@@ -160,28 +143,28 @@ const Template = ({ label, ...args }) => {
   mainContainer.appendChild(container);
 
   // Adds cells to the model in a single step
-  let w = 30;
-  let h = 30;
+  const w = 30;
+  const h = 30;
 
   graph.batchUpdate(() => {
-    let v1 = graph.insertVertex(parent, null, 'A', 0, 0, w, h);
-    let v2 = graph.insertVertex(parent, null, 'B', 0, 0, w, h);
-    let v3 = graph.insertVertex(parent, null, 'C', 0, 0, w, h);
-    let v4 = graph.insertVertex(parent, null, 'D', 0, 0, w, h);
-    let v5 = graph.insertVertex(parent, null, 'E', 0, 0, w, h);
-    let v6 = graph.insertVertex(parent, null, 'F', 0, 0, w, h);
-    let v7 = graph.insertVertex(parent, null, 'G', 0, 0, w, h);
-    let v8 = graph.insertVertex(parent, null, 'H', 0, 0, w, h);
-    let e1 = graph.insertEdge(parent, null, 'ab', v1, v2);
-    let e2 = graph.insertEdge(parent, null, 'ac', v1, v3);
-    let e3 = graph.insertEdge(parent, null, 'cd', v3, v4);
-    let e4 = graph.insertEdge(parent, null, 'be', v2, v5);
-    let e5 = graph.insertEdge(parent, null, 'cf', v3, v6);
-    let e6 = graph.insertEdge(parent, null, 'ag', v1, v7);
-    let e7 = graph.insertEdge(parent, null, 'gh', v7, v8);
-    let e8 = graph.insertEdge(parent, null, 'gc', v7, v3);
-    let e9 = graph.insertEdge(parent, null, 'gd', v7, v4);
-    let e10 = graph.insertEdge(parent, null, 'eh', v5, v8);
+    const v1 = graph.insertVertex(parent, null, 'A', 0, 0, w, h);
+    const v2 = graph.insertVertex(parent, null, 'B', 0, 0, w, h);
+    const v3 = graph.insertVertex(parent, null, 'C', 0, 0, w, h);
+    const v4 = graph.insertVertex(parent, null, 'D', 0, 0, w, h);
+    const v5 = graph.insertVertex(parent, null, 'E', 0, 0, w, h);
+    const v6 = graph.insertVertex(parent, null, 'F', 0, 0, w, h);
+    const v7 = graph.insertVertex(parent, null, 'G', 0, 0, w, h);
+    const v8 = graph.insertVertex(parent, null, 'H', 0, 0, w, h);
+    graph.insertEdge(parent, null, 'ab', v1, v2);
+    graph.insertEdge(parent, null, 'ac', v1, v3);
+    graph.insertEdge(parent, null, 'cd', v3, v4);
+    graph.insertEdge(parent, null, 'be', v2, v5);
+    graph.insertEdge(parent, null, 'cf', v3, v6);
+    graph.insertEdge(parent, null, 'ag', v1, v7);
+    graph.insertEdge(parent, null, 'gh', v7, v8);
+    graph.insertEdge(parent, null, 'gc', v7, v3);
+    graph.insertEdge(parent, null, 'gd', v7, v4);
+    graph.insertEdge(parent, null, 'eh', v5, v8);
 
     // Executes the layout
     layout.execute(parent);

--- a/packages/html/stories/HierarchicalLayout.stories.ts
+++ b/packages/html/stories/HierarchicalLayout.stories.ts
@@ -16,11 +16,10 @@ limitations under the License.
 */
 
 import {
-  Graph,
-  domUtils,
+  DomHelpers,
   FastOrganicLayout,
+  Graph,
   HierarchicalLayout,
-  Perimeter,
   InternalEvent,
   RubberBandHandler,
 } from '@maxgraph/core';
@@ -45,7 +44,7 @@ export default {
   },
 };
 
-const Template = ({ label, ...args }) => {
+const Template = ({ label, ...args }: Record<string, any>) => {
   const div = document.createElement('div');
 
   const container = document.createElement('div');
@@ -57,6 +56,8 @@ const Template = ({ label, ...args }) => {
   container.style.cursor = 'default';
   div.appendChild(container);
 
+  InternalEvent.disableContextMenu(container);
+
   // Creates the graph inside the given container
   const graph = new Graph(container);
 
@@ -65,8 +66,8 @@ const Template = ({ label, ...args }) => {
 
   // Changes the default vertex style in-place
   let style = graph.getStylesheet().getDefaultVertexStyle();
-  style.perimiter = Perimeter.RectanglePerimeter;
   style.gradientColor = 'white';
+  style.gradientDirection = 'south';
   style.perimeterSpacing = 6;
   style.rounded = true;
   style.shadow = true;
@@ -74,34 +75,26 @@ const Template = ({ label, ...args }) => {
   style = graph.getStylesheet().getDefaultEdgeStyle();
   style.rounded = true;
 
-  // Creates a layout algorithm to be used
-  // with the graph
-  const layout = new HierarchicalLayout(graph);
-  const organic = new FastOrganicLayout(graph);
-  organic.forceConstant = 120;
+  // Creates a layout algorithm to be used with the graph
+  const hierarchicalLayout = new HierarchicalLayout(graph);
+  const organicLayout = new FastOrganicLayout(graph);
+  organicLayout.forceConstant = 120;
 
   const parent = graph.getDefaultParent();
 
+  // Adds buttons to execute the layout
   const buttons = document.createElement('div');
   div.appendChild(buttons);
-
-  // Adds a button to execute the layout
-  let button = document.createElement('button');
-  domUtils.write(button, 'Hierarchical');
-  InternalEvent.addListener(button, 'click', function (evt) {
-    layout.execute(parent);
-  });
-  buttons.appendChild(button);
-
-  // Adds a button to execute the layout
-  button = document.createElement('button');
-  domUtils.write(button, 'Organic');
-
-  InternalEvent.addListener(button, 'click', function (evt) {
-    organic.execute(parent);
-  });
-
-  buttons.appendChild(button);
+  buttons.appendChild(
+    DomHelpers.button('Hierarchical', () => {
+      hierarchicalLayout.execute(parent);
+    })
+  );
+  buttons.appendChild(
+    DomHelpers.button('Organic', () => {
+      organicLayout.execute(parent);
+    })
+  );
 
   // Load cells and layouts the graph
   graph.batchUpdate(() => {
@@ -115,22 +108,22 @@ const Template = ({ label, ...args }) => {
     const v8 = graph.insertVertex(parent, null, '8', 0, 0, 80, 30);
     const v9 = graph.insertVertex(parent, null, '9', 0, 0, 80, 30);
 
-    const e1 = graph.insertEdge(parent, null, '', v1, v2);
-    const e2 = graph.insertEdge(parent, null, '', v1, v3);
-    const e3 = graph.insertEdge(parent, null, '', v3, v4);
-    const e4 = graph.insertEdge(parent, null, '', v2, v5);
-    const e5 = graph.insertEdge(parent, null, '', v1, v6);
-    const e6 = graph.insertEdge(parent, null, '', v2, v3);
-    const e7 = graph.insertEdge(parent, null, '', v6, v4);
-    const e8 = graph.insertEdge(parent, null, '', v6, v1);
-    const e9 = graph.insertEdge(parent, null, '', v6, v7);
-    const e10 = graph.insertEdge(parent, null, '', v7, v8);
-    const e11 = graph.insertEdge(parent, null, '', v7, v9);
-    const e12 = graph.insertEdge(parent, null, '', v7, v6);
-    const e13 = graph.insertEdge(parent, null, '', v7, v5);
+    graph.insertEdge(parent, null, '', v1, v2);
+    graph.insertEdge(parent, null, '', v1, v3);
+    graph.insertEdge(parent, null, '', v3, v4);
+    graph.insertEdge(parent, null, '', v2, v5);
+    graph.insertEdge(parent, null, '', v1, v6);
+    graph.insertEdge(parent, null, '', v2, v3);
+    graph.insertEdge(parent, null, '', v6, v4);
+    graph.insertEdge(parent, null, '', v6, v1);
+    graph.insertEdge(parent, null, '', v6, v7);
+    graph.insertEdge(parent, null, '', v7, v8);
+    graph.insertEdge(parent, null, '', v7, v9);
+    graph.insertEdge(parent, null, '', v7, v6);
+    graph.insertEdge(parent, null, '', v7, v5);
 
     // Executes the layout
-    layout.execute(parent);
+    hierarchicalLayout.execute(parent);
   });
 
   return div;

--- a/packages/html/stories/Images.stories.ts
+++ b/packages/html/stories/Images.stories.ts
@@ -15,14 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {
-  Graph,
-  cloneUtils,
-  ImageBox,
-  Rectangle,
-  constants,
-  CellStateStyle,
-} from '@maxgraph/core';
+import { Graph, cloneUtils, ImageBox, Rectangle, CellStateStyle } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
 
 export default {
@@ -83,48 +76,48 @@ const Template = ({ label, ...args }: Record<string, any>) => {
 
   function configureStylesheet(graph: Graph) {
     let style: CellStateStyle = {};
-    style.shape = constants.SHAPE.IMAGE;
+    style.shape = 'image';
     style.image = 'images/icons48/keys.png';
     style.fontColor = '#FFFFFF';
     graph.getStylesheet().putCellStyle('image', style);
 
     style = cloneUtils.clone(style);
-    style.shape = constants.SHAPE.LABEL;
+    style.shape = 'label';
     style.strokeColor = '#000000';
-    style.align = constants.ALIGN.CENTER;
-    style.verticalAlign = constants.ALIGN.TOP;
-    style.imageAlign = constants.ALIGN.CENTER;
+    style.align = 'center';
+    style.verticalAlign = 'top';
+    style.imageAlign = 'center';
     // TODO missing 'imageVerticalAlign' property in CellStateStyle
-    style.imageVerticalAlign = constants.ALIGN.TOP;
+    // style.imageVerticalAlign = 'top';
     style.image = 'images/icons48/gear.png';
-    style.imageWidth = '48';
-    style.imageHeight = '48';
-    style.spacingTop = '56';
-    style.spacing = '8';
+    style.imageWidth = 48;
+    style.imageHeight = 48;
+    style.spacingTop = 56;
+    style.spacing = 8;
     graph.getStylesheet().putCellStyle('bottom', style);
 
     style = cloneUtils.clone(style);
     // TODO missing 'imageVerticalAlign' property in CellStateStyle
-    style.imageVerticalAlign = constants.ALIGN.BOTTOM;
+    // style.imageVerticalAlign = 'bottom';
     style.image = 'images/icons48/server.png';
     delete style.spacingTop;
     graph.getStylesheet().putCellStyle('top', style);
 
     style = cloneUtils.clone(style);
-    style.align = constants.ALIGN.LEFT;
-    style.verticalAlign = constants.ALIGN.MIDDLE;
+    style.align = 'left';
+    style.verticalAlign = 'middle';
     // TODO missing 'imageVerticalAlign' property in CellStateStyle
-    style.imageVerticalAlign = constants.ALIGN.MIDDLE;
+    // style.imageVerticalAlign = 'middle';
     style.image = 'images/icons48/earth.png';
-    style.spacingLeft = '55';
-    style.spacing = '4';
+    style.spacingLeft = 55;
+    style.spacing = 4;
     graph.getStylesheet().putCellStyle('right', style);
 
     style = cloneUtils.clone(style);
-    style.align = constants.ALIGN.RIGHT;
-    style.imageAlign = constants.ALIGN.RIGHT;
+    style.align = 'right';
+    style.imageAlign = 'right';
     delete style.spacingLeft;
-    style.spacingRight = '55';
+    style.spacingRight = 55;
     graph.getStylesheet().putCellStyle('left', style);
   }
 

--- a/packages/html/stories/Images.stories.ts
+++ b/packages/html/stories/Images.stories.ts
@@ -21,7 +21,7 @@ import {
   ImageBox,
   Rectangle,
   constants,
-  Perimeter,
+  CellStateStyle,
 } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
 
@@ -35,13 +35,12 @@ export default {
   },
 };
 
-const Template = ({ label, ...args }) => {
+const Template = ({ label, ...args }: Record<string, any>) => {
   const container = document.createElement('div');
   container.style.position = 'relative';
   container.style.overflow = 'hidden';
   container.style.width = `${args.width}px`;
   container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
   container.style.cursor = 'default';
 
   // Creates the graph inside the given container
@@ -65,55 +64,26 @@ const Template = ({ label, ...args }) => {
 
   // Adds cells to the model in a single step
   graph.batchUpdate(() => {
-    var v1 = graph.insertVertex(
-      parent,
-      null,
-      'First Line\nSecond Line',
-      20,
-      10,
-      80,
-      100,
-      { baseStyleNames: ['bottom'] }
-    );
-    var v1 = graph.insertVertex(
-      parent,
-      null,
-      'First Line\nSecond Line',
-      130,
-      10,
-      80,
-      100,
-      { baseStyleNames: ['top'] }
-    );
-    var v1 = graph.insertVertex(parent, null, '', 230, 10, 100, 100, {
+    graph.insertVertex(parent, null, 'First Line\nSecond Line', 20, 10, 80, 100, {
+      baseStyleNames: ['bottom'],
+    });
+    graph.insertVertex(parent, null, 'First Line\nSecond Line', 130, 10, 80, 100, {
+      baseStyleNames: ['top'],
+    });
+    graph.insertVertex(parent, null, '', 230, 10, 100, 100, {
       baseStyleNames: ['image'],
     });
-    var v2 = graph.insertVertex(
-      parent,
-      null,
-      'First Line\nSecond Line',
-      20,
-      130,
-      140,
-      60,
-      { baseStyleNames: ['right'] }
-    );
-    var v2 = graph.insertVertex(
-      parent,
-      null,
-      'First Line\nSecond Line',
-      180,
-      130,
-      140,
-      60,
-      { baseStyleNames: ['left'] }
-    );
+    graph.insertVertex(parent, null, 'First Line\nSecond Line', 20, 130, 140, 60, {
+      baseStyleNames: ['right'],
+    });
+    graph.insertVertex(parent, null, 'First Line\nSecond Line', 180, 130, 140, 60, {
+      baseStyleNames: ['left'],
+    });
   });
 
-  function configureStylesheet(graph) {
-    let style = {};
+  function configureStylesheet(graph: Graph) {
+    let style: CellStateStyle = {};
     style.shape = constants.SHAPE.IMAGE;
-    style.perimiter = Perimeter.RectanglePerimeter;
     style.image = 'images/icons48/keys.png';
     style.fontColor = '#FFFFFF';
     graph.getStylesheet().putCellStyle('image', style);
@@ -124,6 +94,7 @@ const Template = ({ label, ...args }) => {
     style.align = constants.ALIGN.CENTER;
     style.verticalAlign = constants.ALIGN.TOP;
     style.imageAlign = constants.ALIGN.CENTER;
+    // TODO missing 'imageVerticalAlign' property in CellStateStyle
     style.imageVerticalAlign = constants.ALIGN.TOP;
     style.image = 'images/icons48/gear.png';
     style.imageWidth = '48';
@@ -133,6 +104,7 @@ const Template = ({ label, ...args }) => {
     graph.getStylesheet().putCellStyle('bottom', style);
 
     style = cloneUtils.clone(style);
+    // TODO missing 'imageVerticalAlign' property in CellStateStyle
     style.imageVerticalAlign = constants.ALIGN.BOTTOM;
     style.image = 'images/icons48/server.png';
     delete style.spacingTop;
@@ -140,8 +112,8 @@ const Template = ({ label, ...args }) => {
 
     style = cloneUtils.clone(style);
     style.align = constants.ALIGN.LEFT;
-    style.imageAlign = constants.ALIGN.LEFT;
     style.verticalAlign = constants.ALIGN.MIDDLE;
+    // TODO missing 'imageVerticalAlign' property in CellStateStyle
     style.imageVerticalAlign = constants.ALIGN.MIDDLE;
     style.image = 'images/icons48/earth.png';
     style.spacingLeft = '55';

--- a/packages/html/stories/Merge.stories.ts
+++ b/packages/html/stories/Merge.stories.ts
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Graph, Perimeter, constants, RubberBandHandler } from '@maxgraph/core';
+import { Graph, Perimeter, RubberBandHandler } from '@maxgraph/core';
 import {
   globalTypes,
   globalValues,
@@ -57,18 +57,18 @@ const Template = ({ label, ...args }: Record<string, any>) => {
 
   // Makes all cells round with a white, bold label
   let style = graph.stylesheet.getDefaultVertexStyle();
-  style.shape = constants.SHAPE.ELLIPSE;
+  style.shape = 'ellipse';
   style.perimeter = Perimeter.EllipsePerimeter;
   style.fontColor = 'white';
   style.gradientColor = 'white';
-  style.fontStyle = constants.FONT.BOLD;
+  style.fontStyle = 1; // bold
   style.fontSize = 14;
   style.shadow = true;
 
   // Makes all edge labels gray with a white background
   style = graph.stylesheet.getDefaultEdgeStyle();
   style.fontColor = 'gray';
-  style.fontStyle = constants.FONT.BOLD;
+  style.fontStyle = 1; // bold
   style.fontColor = 'black';
   style.strokeWidth = 2;
 
@@ -105,7 +105,7 @@ const Template = ({ label, ...args }: Record<string, any>) => {
   });
 
   // Creates the second graph model (without a container)
-  const graph2 = new Graph();
+  const graph2 = new Graph(null!);
 
   // Gets the default parent for inserting new cells. This
   // is normally the first child of the root (ie. layer 0).

--- a/packages/html/stories/Merge.stories.ts
+++ b/packages/html/stories/Merge.stories.ts
@@ -37,7 +37,7 @@ export default {
   },
 };
 
-const Template = ({ label, ...args }) => {
+const Template = ({ label, ...args }: Record<string, any>) => {
   const container = document.createElement('div');
   container.style.position = 'relative';
   container.style.overflow = 'hidden';
@@ -58,7 +58,7 @@ const Template = ({ label, ...args }) => {
   // Makes all cells round with a white, bold label
   let style = graph.stylesheet.getDefaultVertexStyle();
   style.shape = constants.SHAPE.ELLIPSE;
-  style.perimiter = Perimeter.EllipsePerimeter;
+  style.perimeter = Perimeter.EllipsePerimeter;
   style.fontColor = 'white';
   style.gradientColor = 'white';
   style.fontStyle = constants.FONT.BOLD;
@@ -89,16 +89,16 @@ const Template = ({ label, ...args }) => {
     const b = graph.insertVertex(parent, 'b', 'B', 20, 200, w, h, { fillColor: 'blue' });
     const c = graph.insertVertex(parent, 'c', 'C', 200, 20, w, h, { fillColor: 'red' });
     const d = graph.insertVertex(parent, 'd', 'D', 200, 200, w, h, { fillColor: 'red' });
-    const ac = graph.insertEdge(parent, 'ac', 'ac', a, c, {
+    graph.insertEdge(parent, 'ac', 'ac', a, c, {
       strokeColor: 'blue',
       verticalAlign: 'bottom',
     });
-    const ad = graph.insertEdge(parent, 'ad', 'ad', a, d, {
+    graph.insertEdge(parent, 'ad', 'ad', a, d, {
       strokeColor: 'blue',
       align: 'left',
       verticalAlign: 'bottom',
     });
-    const bd = graph.insertEdge(parent, 'bd', 'bd', b, d, {
+    graph.insertEdge(parent, 'bd', 'bd', b, d, {
       strokeColor: 'blue',
       verticalAlign: 'bottom',
     });
@@ -126,16 +126,16 @@ const Template = ({ label, ...args }) => {
     const f = graph2.insertVertex(parent2, 'f', 'F', 400, 200, w, h, {
       fillColor: 'green',
     });
-    const ce = graph2.insertEdge(parent2, 'ce', 'ce', c, e, {
+    graph2.insertEdge(parent2, 'ce', 'ce', c, e, {
       strokeColor: 'green',
       verticalAlign: 'bottom',
     });
-    const ed = graph2.insertEdge(parent2, 'ed', 'ed', e, d, {
+    graph2.insertEdge(parent2, 'ed', 'ed', e, d, {
       strokeColor: 'green',
       align: 'right',
       verticalAlign: 'bottom',
     });
-    const fd = graph2.insertEdge(parent2, 'bd', 'fd', f, d, {
+    graph2.insertEdge(parent2, 'bd', 'fd', f, d, {
       strokeColor: 'green',
       verticalAlign: 'bottom',
     });

--- a/packages/html/stories/Monitor.stories.js
+++ b/packages/html/stories/Monitor.stories.js
@@ -222,7 +222,6 @@ const Template = ({ label, ...args }) => {
 
     style = [];
     style.shape = constants.SHAPE.SWIMLANE;
-    style.perimiter = Perimeter.RectanglePerimeter;
     style.strokeColor = '#a0a0a0';
     style.fontColor = '#606060';
     style.fillColor = '#E0E0DF';
@@ -239,7 +238,7 @@ const Template = ({ label, ...args }) => {
 
     style = [];
     style.shape = constants.SHAPE.RHOMBUS;
-    style.perimiter = Perimeter.RhombusPerimeter;
+    style.perimeter = Perimeter.RhombusPerimeter;
     style.strokeColor = '#91BCC0';
     style.fontColor = 'gray';
     style.fillColor = '#91BCC0';
@@ -251,7 +250,7 @@ const Template = ({ label, ...args }) => {
 
     style = [];
     style.shape = constants.SHAPE.ELLIPSE;
-    style.perimiter = Perimeter.EllipsePerimeter;
+    style.perimeter = Perimeter.EllipsePerimeter;
     style.fontColor = 'gray';
     style.fillColor = '#A0C88F';
     style.gradientColor = 'white';

--- a/packages/html/stories/RadialTreeLayout.stories.ts
+++ b/packages/html/stories/RadialTreeLayout.stories.ts
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Graph, RubberBandHandler, RadialTreeLayout, Perimeter } from '@maxgraph/core';
+import { Graph, RubberBandHandler, RadialTreeLayout } from '@maxgraph/core';
 import {
   globalTypes,
   globalValues,
@@ -37,7 +37,7 @@ export default {
   },
 };
 
-const Template = ({ label, ...args }) => {
+const Template = ({ label, ...args }: Record<string, any>) => {
   const container = document.createElement('div');
   container.style.position = 'relative';
   container.style.overflow = 'hidden';
@@ -54,7 +54,6 @@ const Template = ({ label, ...args }) => {
 
   // Changes the default vertex style in-place
   let style = graph.getStylesheet().getDefaultVertexStyle();
-  style.perimiter = Perimeter.RectanglePerimeter;
   style.gradientColor = 'white';
   style.perimeterSpacing = 6;
   style.rounded = true;
@@ -89,22 +88,22 @@ const Template = ({ label, ...args }) => {
     const v7_5 = graph.insertVertex(parent, null, '4.6', 0, 0, 80, 30);
     const v7_6 = graph.insertVertex(parent, null, '4.7', 0, 0, 80, 30);
 
-    const e1 = graph.insertEdge(parent, null, '', v1, v2);
-    const e2 = graph.insertEdge(parent, null, '', v1, v3);
-    const e3 = graph.insertEdge(parent, null, '', v3, v4);
-    const e3_1 = graph.insertEdge(parent, null, '', v3, v4_1);
-    const e3_2 = graph.insertEdge(parent, null, '', v3, v4_2);
-    const e3_3 = graph.insertEdge(parent, null, '', v3, v4_3);
-    const e3_4 = graph.insertEdge(parent, null, '', v3, v4_4);
-    const e4 = graph.insertEdge(parent, null, '', v2, v5);
-    const e5 = graph.insertEdge(parent, null, '', v1, v6);
-    const e6 = graph.insertEdge(parent, null, '', v4_3, v7);
-    var e6_1 = graph.insertEdge(parent, null, '', v4_4, v7_4);
-    var e6_2 = graph.insertEdge(parent, null, '', v4_4, v7_5);
-    var e6_3 = graph.insertEdge(parent, null, '', v4_4, v7_6);
-    var e6_1 = graph.insertEdge(parent, null, '', v4_3, v7_1);
-    var e6_2 = graph.insertEdge(parent, null, '', v4_3, v7_2);
-    var e6_3 = graph.insertEdge(parent, null, '', v4_3, v7_3);
+    graph.insertEdge(parent, null, '', v1, v2);
+    graph.insertEdge(parent, null, '', v1, v3);
+    graph.insertEdge(parent, null, '', v3, v4);
+    graph.insertEdge(parent, null, '', v3, v4_1);
+    graph.insertEdge(parent, null, '', v3, v4_2);
+    graph.insertEdge(parent, null, '', v3, v4_3);
+    graph.insertEdge(parent, null, '', v3, v4_4);
+    graph.insertEdge(parent, null, '', v2, v5);
+    graph.insertEdge(parent, null, '', v1, v6);
+    graph.insertEdge(parent, null, '', v4_3, v7);
+    graph.insertEdge(parent, null, '', v4_4, v7_4);
+    graph.insertEdge(parent, null, '', v4_4, v7_5);
+    graph.insertEdge(parent, null, '', v4_4, v7_6);
+    graph.insertEdge(parent, null, '', v4_3, v7_1);
+    graph.insertEdge(parent, null, '', v4_3, v7_2);
+    graph.insertEdge(parent, null, '', v4_3, v7_3);
 
     // Executes the layout
     layout.execute(parent);

--- a/packages/html/stories/Scrollbars.stories.js
+++ b/packages/html/stories/Scrollbars.stories.js
@@ -36,7 +36,6 @@ import {
   GraphView,
   KeyHandler,
   PanningHandler,
-  Perimeter,
   Point,
   Rectangle,
   RubberBandHandler,
@@ -512,7 +511,6 @@ const Template = ({ label, ...args }) => {
 
   // Uses the entity perimeter (below) as default
   graph.stylesheet.getDefaultVertexStyle().verticalAlign = constants.ALIGN.TOP;
-  graph.stylesheet.getDefaultVertexStyle().perimeter = Perimeter.RectanglePerimeter;
   graph.stylesheet.getDefaultVertexStyle().shadow = true;
   graph.stylesheet.getDefaultVertexStyle().fillColor = '#DDEAFF';
   graph.stylesheet.getDefaultVertexStyle().gradientColor = '#A9C4EB';

--- a/packages/html/stories/SwimLanes.stories.js
+++ b/packages/html/stories/SwimLanes.stories.js
@@ -104,13 +104,13 @@ const Template = ({ label, ...args }) => {
 
   style = cloneUtils.clone(style);
   style.shape = constants.SHAPE.ELLIPSE;
-  style.perimiter = Perimeter.EllipsePerimeter;
+  style.perimeter = Perimeter.EllipsePerimeter;
   delete style.rounded;
   graph.getStylesheet().putCellStyle('state', style);
 
   style = cloneUtils.clone(style);
   style.shape = constants.SHAPE.RHOMBUS;
-  style.perimiter = Perimeter.RhombusPerimeter;
+  style.perimeter = Perimeter.RhombusPerimeter;
   style.verticalAlign = 'top';
   style.spacingTop = 40;
   style.spacingRight = 64;
@@ -118,7 +118,7 @@ const Template = ({ label, ...args }) => {
 
   style = cloneUtils.clone(style);
   style.shape = constants.SHAPE.DOUBLE_ELLIPSE;
-  style.perimiter = Perimeter.EllipsePerimeter;
+  style.perimeter = Perimeter.EllipsePerimeter;
   style.spacingTop = 28;
   style.fontSize = 14;
   style.fontStyle = 1;


### PR DESCRIPTION
Some stories used a `perimiter` property instead of `perimeter` (i instead of e). This is now fixed. When possible, do not set the RectanglePerimeter in the style configuration as it is already set in the default vertex style.
Migrate some stories to TypeScript when possible (migrating Swimlanes involved too many unrelated changes, so it will be done later).
The migration to TS required to remove the usage of constants to avoid errors like "Cannot access ambient const enums when 'isolatedModules' is enabled".

The following stories already had issues unrelated to the perimeter property and are still not working. This is why they weren't migrated to TypeScript as part of the fix.
  - FileIO
  - Monitor
  - Scrollbars

### Notes

The "Cannot access ambient const enums when 'isolatedModules' is enabled" error relates to #205.