### PR TITLE
refactor: set the default perimeter using a key rather than a function

### DIFF
--- a/packages/core/src/view/style/StyleRegistry.ts
+++ b/packages/core/src/view/style/StyleRegistry.ts
@@ -16,10 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { EDGESTYLE, PERIMETER } from '../../util/Constants';
-import EdgeStyle from './EdgeStyle';
-import Perimeter from './Perimeter';
-
 /**
  * Singleton class that acts as a global converter from string to object values
  * in a style. This is currently only used to perimeters and edge styles.

--- a/packages/core/src/view/style/Stylesheet.ts
+++ b/packages/core/src/view/style/Stylesheet.ts
@@ -17,7 +17,6 @@ limitations under the License.
 */
 
 import { ALIGN, ARROW, SHAPE } from '../../util/Constants';
-import Perimeter from './Perimeter';
 import { clone } from '../../util/cloneUtils';
 import type { CellStateStyle, CellStyle } from '../../types';
 
@@ -65,7 +64,7 @@ export class Stylesheet {
   createDefaultVertexStyle() {
     const style = {} as CellStateStyle;
     style.shape = SHAPE.RECTANGLE;
-    style.perimeter = Perimeter.RectanglePerimeter;
+    style.perimeter = 'rectanglePerimeter';
     style.verticalAlign = ALIGN.MIDDLE;
     style.align = ALIGN.CENTER;
     style.fillColor = '#C3D9FF';


### PR DESCRIPTION
In the default vertex style configuration, declare the perimeter using the key stored in the `StyleRegistry` instead of the actual perimeter function.
This reduces code coupling and will also improve tree-shaking in the future for people who don't want to rely on this perimeter implementation.

The "perimeter" configuration was the only one to use an actual implementation, which makes things more consistent.

### Notes

Tested with the existing stories and the new story introduced in #317