### PR TITLE
docs: improve the "project status" paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ Chrome, Edge, Firefox, Safari, Chromium based browsers (Brave, Opera, ....) for 
 
 ## Project status
 
-`maxGraph` is under active development and is in **alpha**. Please try it in your application and [submit an issue](https://github.com/maxGraph/maxGraph/issues)
-if you think that something is not working.
+`maxGraph` is currently under active development, with a few adjustments still required to match the behavior of `mxGraph`.
+In the meantime, new features are also being added to enrich the library.
+
+Please try it in your application and [submit an issue](https://github.com/maxGraph/maxGraph/issues) if you think that something is not working.
 
 You can also test `maxGraph` by running the [Storybook examples](#development) or [build the npm package locally](#build-local-npm-package) to get the latest changes.
 


### PR DESCRIPTION
In particular, remove reference to an "alpha" status and better explain the project status.