### PR TITLE
fix!: use the correct name for the `StyleArrowValue` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # `maxGraph` Change Log
 
+## UNRELEASED
+
+**Breaking Changes**
+- rename the `StyleArrayValue` type into `StyleArrowValue`.
+This only has an impact on TypeScript users who use this type explicitly, which should happen rarely.
+
 ## 0.7.0
 
 Release date: `2024-01-20`

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -184,7 +184,7 @@ export type CellStateStyle = {
    *
    * See {@link startArrow}.
    */
-  endArrow?: StyleArrayValue;
+  endArrow?: StyleArrowValue;
   /**
    * Use `false` to not fill or `true` to fill the end arrow marker.
    * See {@link startFill}.
@@ -684,7 +684,7 @@ export type CellStateStyle = {
    *
    * See {@link endArrow}.
    */
-  startArrow?: StyleArrayValue;
+  startArrow?: StyleArrowValue;
   /**
    * Use `false` to not fill or `true` to fill the start arrow marker.
    * See {@link endFill}.
@@ -830,7 +830,7 @@ export type ArrowValue =
 /**
  * {@link ArrowValue} with support for extensions.
  */
-export type StyleArrayValue = ArrowValue | (string & {});
+export type StyleArrowValue = ArrowValue | (string & {});
 
 /**
  * Names used to register the shapes provided out-of-the-box by maxGraph with {@link CellRenderer.registerShape}.


### PR DESCRIPTION
The previous name was incorrect, it used "Array" instead of "Arrow"

BREAKING CHANGES: rename the `StyleArrayValue` type into `StyleArrowValue`.
This only has an impact on TypeScript users who use this type explicitly, which should happen rarely.

### Notes

The previous was incorrectly added in #265, included in version `0.5.0`.