### PR TITLE
refactor!: split Perimeter implementations and improve related types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 **Breaking Changes**
 - rename the `StyleArrayValue` type into `StyleArrowValue`.
 This only has an impact on TypeScript users who use this type explicitly, which should happen rarely.
+- `Perimeter` is no longer a class but a value object. This only impact users that had extended the
+`Perimeter` class. Regular user that define perimeter style properties using function provided by
+ `maxGraph` are not impacted by this change.
+- `CellState.perimeter` no longer accept `Function`, but only the `PerimeterFunction`.
+  - Passing an arbitrary `Function` was incorrect and always failed at runtime.
+  - This change should not impact people using working implementation of perimeter function
+  (including these provided by maxGraph) as they already have the right signature. Implementers of
+  custom perimeter in TypeScript may have to slightly update their perimeter function declaration.
 
 ## 0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This only has an impact on TypeScript users who use this type explicitly, which 
   - This change should not impact people using working implementation of perimeter function
   (including these provided by maxGraph) as they already have the right signature. Implementers of
   custom perimeter in TypeScript may have to slightly update their perimeter function declaration.
+- `GraphView` signature method changes
+  -  `getPerimeterPoint` can now return `null`
+  - `getPerimeterBounds` no longer accept null `CellState` and no longer returns `null`
 
 ## 0.7.0
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -18,9 +18,11 @@ import { DIRECTION, IDENTITY_FIELD_NAME } from './util/Constants';
 import type { Graph } from './view/Graph';
 import type Cell from './view/cell/Cell';
 import type CellState from './view/cell/CellState';
-import EventSource from './view/event/EventSource';
+import type EventSource from './view/event/EventSource';
 import type InternalMouseEvent from './view/event/InternalMouseEvent';
-import Geometry from './view/geometry/Geometry';
+import type Geometry from './view/geometry/Geometry';
+import type Point from './view/geometry/Point';
+import type Rectangle from './view/geometry/Rectangle';
 import type Shape from './view/geometry/Shape';
 import type ImageBox from './view/image/ImageBox';
 
@@ -499,12 +501,17 @@ export type CellStateStyle = {
   /**
    * This defines the perimeter around a particular shape.
    *
-   * For `Function` types, the possible values are the functions defined in {@link Perimeter}.
+   * For {@link PerimeterFunction} types, some possible values are the functions defined in {@link Perimeter}.
    *
    * Alternatively, use a string or a value from {@link PERIMETER} to access perimeter styles
    * registered in {@link StyleRegistry}.
+   * If {@link GraphView.allowEval} is set to `true`, you can pass the {@link PerimeterFunction} implementation directly as a string.
+   * Remember that enabling this switch carries a possible security risk
+   *
+   * **WARNING**: explicitly set the value to null or undefined means to not use any perimeter.
+   * To use the perimeter defined in the default vertex, do not set this property.
    */
-  perimeter?: Function | string | null;
+  perimeter?: PerimeterFunction | PerimeterValue | (string & {}) | null;
   /**
    * This is the distance between the connection point and the perimeter in pixels.
    * - When used in a vertex style, this applies to all incoming edges to floating ports
@@ -1056,3 +1063,30 @@ export type IdentityFunction = {
   (): any;
   [IDENTITY_FIELD_NAME]?: string;
 };
+
+/**
+ * Describes a perimeter for the given bounds.
+ *
+ * @param bounds the {@link Rectangle} that represents the absolute bounds of the vertex.
+ * @param vertex the {@link CellState} that represents the vertex.
+ * @param next the {@link Point} that represents the nearest neighbour point on the given edge.
+ * @param orthogonal Boolean that specifies if the orthogonal projection onto the perimeter should be returned.
+ *                   If this is `false`, then the intersection of the perimeter and the line between the next and the center point is returned.
+ * @returns the resulting {@link Point} projected to the perimeter.
+ */
+export type PerimeterFunction = (
+  bounds: Rectangle,
+  vertex: CellState,
+  next: Point,
+  orthogonal: boolean
+) => Point | null;
+
+/**
+ * Names used to register the perimeter provided out-of-the-box by maxGraph with {@link StyleRegistry.putValue}.
+ */
+export type PerimeterValue =
+  | 'ellipsePerimeter'
+  | 'hexagonPerimeter'
+  | 'rectanglePerimeter'
+  | 'rhombusPerimeter'
+  | 'trianglePerimeter';

--- a/packages/core/src/view/GraphDataModel.ts
+++ b/packages/core/src/view/GraphDataModel.ts
@@ -853,9 +853,8 @@ export class GraphDataModel extends EventSource {
    * Sets the style of the given {@link Cell} using {@link StyleChange} and
    * adds the change to the current transaction.
    *
-   * @param {Cell} cell  whose style should be changed.
-   * @param style  String of the form [stylename;|key=value;] to specify
-   * the new cell style.
+   * @param cell  whose style should be changed.
+   * @param style the new cell style to set.
    */
   setStyle(cell: Cell, style: CellStyle) {
     if (style !== cell.getStyle()) {

--- a/packages/core/src/view/GraphView.ts
+++ b/packages/core/src/view/GraphView.ts
@@ -1413,7 +1413,7 @@ export class GraphView extends EventSource {
       edge.style[source ? 'sourcePerimeterSpacing' : 'targetPerimeterSpacing'] ?? 0;
     let pt = this.getPerimeterPoint(start, <Point>next, alpha === 0 && orth, border);
 
-    if (alpha !== 0) {
+    if (pt && alpha !== 0) {
       const cos = Math.cos(alpha);
       const sin = Math.sin(alpha);
       pt = getRotatedPoint(pt, cos, sin, center);
@@ -1455,7 +1455,7 @@ export class GraphView extends EventSource {
    * the perimeter and the line between the center of the shape and the given point.
    *
    * @param terminal {@link CellState} for the source or target terminal.
-   * @param next {@link mxPoint} that lies outside of the given terminal.
+   * @param next {@link Point} that lies outside the given terminal.
    * @param orthogonal Boolean that specifies if the orthogonal projection onto
    * the perimeter should be returned. If this is false then the intersection
    * of the perimeter and the line between the next and the center point is
@@ -1467,14 +1467,14 @@ export class GraphView extends EventSource {
     next: Point,
     orthogonal: boolean,
     border = 0
-  ): Point {
+  ): Point | null {
     let point = null;
 
     if (terminal != null) {
       const perimeter = this.getPerimeterFunction(terminal);
 
       if (perimeter != null && next != null) {
-        const bounds = <Rectangle>this.getPerimeterBounds(terminal, border);
+        const bounds = this.getPerimeterBounds(terminal, border);
 
         if (bounds.width > 0 || bounds.height > 0) {
           point = new Point(next.x, next.y);
@@ -1568,14 +1568,12 @@ export class GraphView extends EventSource {
    * };
    * ```
    *
-   * @param {CellState} terminal CellState that represents the terminal.
-   * @param {number} border Number that adds a border between the shape and the perimeter.
+   * @param terminal CellState that represents the terminal.
+   * @param border Number that adds a border between the shape and the perimeter.
    */
-  getPerimeterBounds(terminal: CellState | null = null, border = 0): Rectangle | null {
-    if (terminal) {
-      border += terminal.style.perimeterSpacing ?? 0;
-    }
-    return (<CellState>terminal).getPerimeterBounds(border * this.scale);
+  getPerimeterBounds(terminal: CellState, border = 0): Rectangle {
+    border += terminal.style.perimeterSpacing ?? 0;
+    return terminal.getPerimeterBounds(border * this.scale);
   }
 
   /**

--- a/packages/core/src/view/handler/ConnectionHandler.ts
+++ b/packages/core/src/view/handler/ConnectionHandler.ts
@@ -220,7 +220,6 @@ type FactoryMethod = (
 class ConnectionHandler extends EventSource implements GraphPlugin {
   static pluginId = 'ConnectionHandler';
 
-  // TODO: Document me!
   previous: CellState | null = null;
   iconState: CellState | null = null;
   icons: ImageShape[] = [];
@@ -249,8 +248,9 @@ class ConnectionHandler extends EventSource implements GraphPlugin {
   /**
    * Specifies if icons should be displayed inside the graph container instead
    * of the overlay pane. This is used for HTML labels on vertices which hide
-   * the connect icon. This has precendence over {@link oveIconBack} when set
-   * to true. Default is false.
+   * the connect icon. This has precedence over {@link moveIconBack} when set
+   * to true.
+   * @default `false`
    */
   moveIconFront = false;
 
@@ -262,10 +262,10 @@ class ConnectionHandler extends EventSource implements GraphPlugin {
   moveIconBack = false;
 
   /**
-   * {@link Image} that is used to trigger the creation of a new connection. This
-   * is used in <createIcons>. Default is null.
+   * {@link Image} that is used to trigger the creation of a new connection.
+   * This is used in {@link createIcons}.
+   * @default null
    */
-
   connectImage: Image | null = null;
 
   /**
@@ -1352,7 +1352,7 @@ class ConnectionHandler extends EventSource implements GraphPlugin {
     const { view } = state;
     const targetPerimeter = view.getPerimeterFunction(state);
 
-    if (targetPerimeter && this.previous) {
+    if (targetPerimeter && this.previous && this.edgeState) {
       const next =
         this.waypoints.length > 0
           ? this.waypoints[this.waypoints.length - 1]
@@ -1707,7 +1707,7 @@ class ConnectionHandler extends EventSource implements GraphPlugin {
         let value = null;
         let style = {};
 
-        if (this.edgeState) {
+        if (this.edgeState?.cell) {
           value = this.edgeState.cell.value;
           style = this.edgeState.cell.style ?? {};
         }
@@ -1725,7 +1725,7 @@ class ConnectionHandler extends EventSource implements GraphPlugin {
           );
 
           // Uses geometry of the preview edge state
-          if (this.edgeState && this.edgeState.cell && this.edgeState.cell.geometry) {
+          if (this.edgeState?.cell?.geometry) {
             model.setGeometry(edge, this.edgeState.cell.geometry);
           }
 

--- a/packages/core/src/view/mixins/ConnectionsMixin.ts
+++ b/packages/core/src/view/mixins/ConnectionsMixin.ts
@@ -174,7 +174,7 @@ const ConnectionsMixin: PartialType = {
    */
   getOutlineConstraint(point, terminalState, me) {
     if (terminalState.shape) {
-      const bounds = <Rectangle>this.getView().getPerimeterBounds(terminalState);
+      const bounds = this.getView().getPerimeterBounds(terminalState);
       const direction = terminalState.style.direction;
 
       if (direction === DIRECTION.NORTH || direction === DIRECTION.SOUTH) {
@@ -341,7 +341,7 @@ const ConnectionsMixin: PartialType = {
     let point: Point | null = null;
 
     if (constraint.point) {
-      const bounds = <Rectangle>this.getView().getPerimeterBounds(vertex);
+      const bounds = this.getView().getPerimeterBounds(vertex);
       const cx = new Point(bounds.getCenterX(), bounds.getCenterY());
       const direction = vertex.style.direction;
       let r1 = 0;

--- a/packages/core/src/view/style/Perimeter.ts
+++ b/packages/core/src/view/style/Perimeter.ts
@@ -16,718 +16,91 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { intersection } from '../../util/mathUtils';
-import Point from '../geometry/Point';
-import { DIRECTION } from '../../util/Constants';
-import Rectangle from '../geometry/Rectangle';
-import CellState from '../cell/CellState';
-import { CellStateStyle } from '../../types';
+import { EllipsePerimeter as EllipsePerimeterFunction } from './perimeter/EllipsePerimeter';
+import { HexagonPerimeter as HexagonPerimeterFunction } from './perimeter/HexagonPerimeter';
+import { RectanglePerimeter as RectanglePerimeterFunction } from './perimeter/RectanglePerimeter';
+import { RhombusPerimeter as RhombusPerimeterFunction } from './perimeter/RhombusPerimeter';
+import { TrianglePerimeter as TrianglePerimeterFunction } from './perimeter/TrianglePerimeter';
 
 /**
- * @class Perimeter
- *
- * Provides various perimeter functions to be used in a style
- * as the value of {@link mxConstants.STYLE_PERIMETER}. Perimeters for
- * rectangle, circle, rhombus and triangle are available.
+ * Provides various perimeter functions to be used in a style as the value of {@link CellStateStyle.perimeter}.
  *
  * ### Example
  *
  * ```javascript
- * <add as="perimeter">mxPerimeter.RectanglePerimeter</add>
+ * <add as="perimeter">Perimeter.RectanglePerimeter</add>
  * ```
  *
  * ### Or programmatically
  *
  * ```javascript
- * style.perimiter = mxPerimeter.RectanglePerimeter;
+ * style.perimeter = Perimeter.RectanglePerimeter;
  * ```
  *
- * When adding new perimeter functions, it is recommended to use the
- * mxPerimeter-namespace as follows:
+ * When adding new perimeter functions, it is recommended to use the Perimeter-namespace as follows:
  *
  * ```javascript
- * mxPerimeter.CustomPerimeter = function (bounds, vertex, next, orthogonal)
+ * Perimeter.CustomPerimeter = function (bounds, vertex, next, orthogonal)
  * {
- *   var x = 0; // Calculate x-coordinate
- *   var y = 0; // Calculate y-coordainte
+ *   const x = 0; // Calculate x-coordinate
+ *   const y = 0; // Calculate y-coordinate
  *
- *   return new mxPoint(x, y);
+ *   return new Point(x, y);
  * }
  * ```
  *
- * #### The new perimeter should then be registered in the {@link mxStyleRegistry} as follows
+ * #### The new perimeter should then be registered in the {@link StyleRegistry} as follows
  * ```javascript
- * mxStyleRegistry.putValue('customPerimeter', mxPerimeter.CustomPerimeter);
+ * StyleRegistry.putValue('customPerimeter', Perimeter.CustomPerimeter);
  * ```
  *
  * #### The custom perimeter above can now be used in a specific vertex as follows:
  *
  * ```javascript
- * model.setStyle(vertex, 'perimeter=customPerimeter');
+ * model.setStyle(vertex, {...vertex.style, perimeter: 'customPerimeter'});
  * ```
  *
- * Note that the key of the {@link mxStyleRegistry} entry for the function should
- * be used in string values, unless {@link view.allowEval} is true, in
- * which case you can also use mxPerimeter.CustomPerimeter for the value in
+ * Note that the key of the {@link StyleRegistry} entry for the function should
+ * be used in string values, unless {@link GraphView.allowEval} is `true`, in
+ * which case you can also use Perimeter.CustomPerimeter for the value in
  * the cell style above.
  *
  * #### Or it can be used for all vertices in the graph as follows:
  *
  * ```javascript
  * var style = graph.getStylesheet().getDefaultVertexStyle();
- * style.perimiter = mxPerimeter.CustomPerimeter;
+ * style.perimeter = Perimeter.CustomPerimeter;
  * ```
  *
  * Note that the object can be used directly when programmatically setting
- * the value, but the key in the {@link mxStyleRegistry} should be used when
+ * the value, but the key in the {@link StyleRegistry} should be used when
  * setting the value via a key, value pair in a cell style.
- *
- * The parameters are explained in {@link RectanglePerimeter}.
  */
-class Perimeter {
+const Perimeter = {
   /**
-   * Describes a rectangular perimeter for the given bounds.
-   *
-   * @param bounds {@link mxRectangle} that represents the absolute bounds of the
-   * vertex.
-   * @param vertex {@link CellState} that represents the vertex.
-   * @param next {@link mxPoint} that represents the nearest neighbour point on the
-   * given edge.
-   * @param orthogonal Boolean that specifies if the orthogonal projection onto
-   * the perimeter should be returned. If this is false then the intersection
-   * of the perimeter and the line between the next and the center point is
-   * returned.
+   * Describes a rectangular perimeter.
    */
-  static RectanglePerimeter(
-    bounds: Rectangle,
-    vertex: CellState,
-    next: Point,
-    orthogonal = false
-  ): Point {
-    const cx = bounds.getCenterX();
-    const cy = bounds.getCenterY();
-    const dx = next.x - cx;
-    const dy = next.y - cy;
-    const alpha = Math.atan2(dy, dx);
-    const p = new Point(0, 0);
-    const pi = Math.PI;
-    const pi2 = Math.PI / 2;
-    const beta = pi2 - alpha;
-    const t = Math.atan2(bounds.height, bounds.width);
-
-    if (alpha < -pi + t || alpha > pi - t) {
-      // Left edge
-      p.x = bounds.x;
-      p.y = cy - (bounds.width * Math.tan(alpha)) / 2;
-    } else if (alpha < -t) {
-      // Top Edge
-      p.y = bounds.y;
-      p.x = cx - (bounds.height * Math.tan(beta)) / 2;
-    } else if (alpha < t) {
-      // Right Edge
-      p.x = bounds.x + bounds.width;
-      p.y = cy + (bounds.width * Math.tan(alpha)) / 2;
-    } else {
-      // Bottom Edge
-      p.y = bounds.y + bounds.height;
-      p.x = cx + (bounds.height * Math.tan(beta)) / 2;
-    }
-
-    if (orthogonal) {
-      if (next.x >= bounds.x && next.x <= bounds.x + bounds.width) {
-        p.x = next.x;
-      } else if (next.y >= bounds.y && next.y <= bounds.y + bounds.height) {
-        p.y = next.y;
-      }
-      if (next.x < bounds.x) {
-        p.x = bounds.x;
-      } else if (next.x > bounds.x + bounds.width) {
-        p.x = bounds.x + bounds.width;
-      }
-      if (next.y < bounds.y) {
-        p.y = bounds.y;
-      } else if (next.y > bounds.y + bounds.height) {
-        p.y = bounds.y + bounds.height;
-      }
-    }
-
-    return p;
-  }
+  RectanglePerimeter: RectanglePerimeterFunction,
 
   /**
-   * Describes an elliptic perimeter. See {@link RectanglePerimeter}
-   * for a description of the parameters.
+   * Describes an elliptic perimeter.
    */
-  static EllipsePerimeter(
-    bounds: Rectangle,
-    vertex: CellState,
-    next: Point,
-    orthogonal = false
-  ): Point {
-    const { x } = bounds;
-    const { y } = bounds;
-    const a = bounds.width / 2;
-    const b = bounds.height / 2;
-    const cx = x + a;
-    const cy = y + b;
-    const px = next.x;
-    const py = next.y;
-
-    // Calculates straight line equation through
-    // point and ellipse center y = d * x + h
-    const dx = parseInt(String(px - cx));
-    const dy = parseInt(String(py - cy));
-
-    if (dx === 0 && dy !== 0) {
-      return new Point(cx, cy + (b * dy) / Math.abs(dy));
-    }
-    if (dx === 0 && dy === 0) {
-      return new Point(px, py);
-    }
-
-    if (orthogonal) {
-      if (py >= y && py <= y + bounds.height) {
-        const ty = py - cy;
-        let tx = Math.sqrt(a * a * (1 - (ty * ty) / (b * b))) || 0;
-
-        if (px <= x) {
-          tx = -tx;
-        }
-
-        return new Point(cx + tx, py);
-      }
-
-      if (px >= x && px <= x + bounds.width) {
-        const tx = px - cx;
-        let ty = Math.sqrt(b * b * (1 - (tx * tx) / (a * a))) || 0;
-
-        if (py <= y) {
-          ty = -ty;
-        }
-
-        return new Point(px, cy + ty);
-      }
-    }
-
-    // Calculates intersection
-    const d = dy / dx;
-    const h = cy - d * cx;
-    const e = a * a * d * d + b * b;
-    const f = -2 * cx * e;
-    const g = a * a * d * d * cx * cx + b * b * cx * cx - a * a * b * b;
-    const det = Math.sqrt(f * f - 4 * e * g);
-
-    // Two solutions (perimeter points)
-    const xout1 = (-f + det) / (2 * e);
-    const xout2 = (-f - det) / (2 * e);
-    const yout1 = d * xout1 + h;
-    const yout2 = d * xout2 + h;
-    const dist1 = Math.sqrt(Math.pow(xout1 - px, 2) + Math.pow(yout1 - py, 2));
-    const dist2 = Math.sqrt(Math.pow(xout2 - px, 2) + Math.pow(yout2 - py, 2));
-
-    // Correct solution
-    let xout = 0;
-    let yout = 0;
-
-    if (dist1 < dist2) {
-      xout = xout1;
-      yout = yout1;
-    } else {
-      xout = xout2;
-      yout = yout2;
-    }
-
-    return new Point(xout, yout);
-  }
+  EllipsePerimeter: EllipsePerimeterFunction,
 
   /**
-   * Describes a rhombus (aka diamond) perimeter. See {@link RectanglePerimeter}
-   * for a description of the parameters.
+   * Describes a rhombus (aka diamond) perimeter.
    */
-  static RhombusPerimeter(
-    bounds: Rectangle,
-    vertex: CellState,
-    next: Point,
-    orthogonal = false
-  ): Point | null {
-    const { x } = bounds;
-    const { y } = bounds;
-    const w = bounds.width;
-    const h = bounds.height;
-
-    const cx = x + w / 2;
-    const cy = y + h / 2;
-
-    const px = next.x;
-    const py = next.y;
-
-    // Special case for intersecting the diamond's corners
-    if (cx === px) {
-      if (cy > py) {
-        return new Point(cx, y); // top
-      }
-      return new Point(cx, y + h); // bottom
-    }
-    if (cy === py) {
-      if (cx > px) {
-        return new Point(x, cy); // left
-      }
-      return new Point(x + w, cy); // right
-    }
-
-    let tx = cx;
-    let ty = cy;
-
-    if (orthogonal) {
-      if (px >= x && px <= x + w) {
-        tx = px;
-      } else if (py >= y && py <= y + h) {
-        ty = py;
-      }
-    }
-
-    // In which quadrant will the intersection be?
-    // set the slope and offset of the border line accordingly
-    if (px < cx) {
-      if (py < cy) {
-        return intersection(px, py, tx, ty, cx, y, x, cy);
-      }
-      return intersection(px, py, tx, ty, cx, y + h, x, cy);
-    }
-    if (py < cy) {
-      return intersection(px, py, tx, ty, cx, y, x + w, cy);
-    }
-    return intersection(px, py, tx, ty, cx, y + h, x + w, cy);
-  }
+  RhombusPerimeter: RhombusPerimeterFunction,
 
   /**
-   * Describes a triangle perimeter. See {@link RectanglePerimeter}
-   * for a description of the parameters.
+   * Describes a triangle perimeter.
    */
-  static TrianglePerimeter(
-    bounds: Rectangle,
-    vertex: CellState,
-    next: Point,
-    orthogonal = false
-  ): Point | null {
-    const direction = vertex != null ? vertex.style.direction : null;
-    const vertical = direction === DIRECTION.NORTH || direction === DIRECTION.SOUTH;
-
-    const { x } = bounds;
-    const { y } = bounds;
-    const w = bounds.width;
-    const h = bounds.height;
-
-    let cx = x + w / 2;
-    let cy = y + h / 2;
-
-    let start = new Point(x, y);
-    let corner = new Point(x + w, cy);
-    let end = new Point(x, y + h);
-
-    if (direction === DIRECTION.NORTH) {
-      start = end;
-      corner = new Point(cx, y);
-      end = new Point(x + w, y + h);
-    } else if (direction === DIRECTION.SOUTH) {
-      corner = new Point(cx, y + h);
-      end = new Point(x + w, y);
-    } else if (direction === DIRECTION.WEST) {
-      start = new Point(x + w, y);
-      corner = new Point(x, cy);
-      end = new Point(x + w, y + h);
-    }
-
-    let dx = next.x - cx;
-    let dy = next.y - cy;
-
-    const alpha = vertical ? Math.atan2(dx, dy) : Math.atan2(dy, dx);
-    const t = vertical ? Math.atan2(w, h) : Math.atan2(h, w);
-
-    let base = false;
-
-    if (direction === DIRECTION.NORTH || direction === DIRECTION.WEST) {
-      base = alpha > -t && alpha < t;
-    } else {
-      base = alpha < -Math.PI + t || alpha > Math.PI - t;
-    }
-
-    let result = null;
-
-    if (base) {
-      if (
-        orthogonal &&
-        ((vertical && next.x >= start.x && next.x <= end.x) ||
-          (!vertical && next.y >= start.y && next.y <= end.y))
-      ) {
-        if (vertical) {
-          result = new Point(next.x, start.y);
-        } else {
-          result = new Point(start.x, next.y);
-        }
-      } else if (direction === DIRECTION.NORTH) {
-        result = new Point(x + w / 2 + (h * Math.tan(alpha)) / 2, y + h);
-      } else if (direction === DIRECTION.SOUTH) {
-        result = new Point(x + w / 2 - (h * Math.tan(alpha)) / 2, y);
-      } else if (direction === DIRECTION.WEST) {
-        result = new Point(x + w, y + h / 2 + (w * Math.tan(alpha)) / 2);
-      } else {
-        result = new Point(x, y + h / 2 - (w * Math.tan(alpha)) / 2);
-      }
-    } else {
-      if (orthogonal) {
-        const pt = new Point(cx, cy);
-
-        if (next.y >= y && next.y <= y + h) {
-          pt.x = vertical ? cx : direction === DIRECTION.WEST ? x + w : x;
-          pt.y = next.y;
-        } else if (next.x >= x && next.x <= x + w) {
-          pt.x = next.x;
-          pt.y = !vertical ? cy : direction === DIRECTION.NORTH ? y + h : y;
-        }
-
-        // Compute angle
-        dx = next.x - pt.x;
-        dy = next.y - pt.y;
-
-        cx = pt.x;
-        cy = pt.y;
-      }
-
-      if ((vertical && next.x <= x + w / 2) || (!vertical && next.y <= y + h / 2)) {
-        result = intersection(
-          next.x,
-          next.y,
-          cx,
-          cy,
-          start.x,
-          start.y,
-          corner.x,
-          corner.y
-        );
-      } else {
-        result = intersection(next.x, next.y, cx, cy, corner.x, corner.y, end.x, end.y);
-      }
-    }
-
-    if (result == null) {
-      result = new Point(cx, cy);
-    }
-    return result;
-  }
+  TrianglePerimeter: TrianglePerimeterFunction,
 
   /**
-   * Describes a hexagon perimeter. See {@link RectanglePerimeter}
-   * for a description of the parameters.
+   * Describes a hexagon perimeter.
    */
-  static HexagonPerimeter(
-    bounds: Rectangle,
-    vertex: CellState,
-    next: Point,
-    orthogonal = false
-  ): Point | null {
-    const { x } = bounds;
-    const { y } = bounds;
-    const w = bounds.width;
-    const h = bounds.height;
-
-    const cx = bounds.getCenterX();
-    const cy = bounds.getCenterY();
-    const px = next.x;
-    const py = next.y;
-    const dx = px - cx;
-    const dy = py - cy;
-    const alpha = -Math.atan2(dy, dx);
-    const pi = Math.PI;
-    const pi2 = Math.PI / 2;
-
-    let result: Point | null = new Point(cx, cy);
-
-    const direction =
-      vertex != null
-        ? Perimeter.getValue(vertex.style, 'direction', DIRECTION.EAST)
-        : DIRECTION.EAST;
-    const vertical = direction === DIRECTION.NORTH || direction === DIRECTION.SOUTH;
-    let a = new Point();
-    let b = new Point();
-
-    // Only consider corrects quadrants for the orthogonal case.
-    if (
-      (px < x && py < y) ||
-      (px < x && py > y + h) ||
-      (px > x + w && py < y) ||
-      (px > x + w && py > y + h)
-    ) {
-      orthogonal = false;
-    }
-
-    if (orthogonal) {
-      if (vertical) {
-        // Special cases where intersects with hexagon corners
-        if (px === cx) {
-          if (py <= y) {
-            return new Point(cx, y);
-          }
-          if (py >= y + h) {
-            return new Point(cx, y + h);
-          }
-        } else if (px < x) {
-          if (py === y + h / 4) {
-            return new Point(x, y + h / 4);
-          }
-          if (py === y + (3 * h) / 4) {
-            return new Point(x, y + (3 * h) / 4);
-          }
-        } else if (px > x + w) {
-          if (py === y + h / 4) {
-            return new Point(x + w, y + h / 4);
-          }
-          if (py === y + (3 * h) / 4) {
-            return new Point(x + w, y + (3 * h) / 4);
-          }
-        } else if (px === x) {
-          if (py < cy) {
-            return new Point(x, y + h / 4);
-          }
-          if (py > cy) {
-            return new Point(x, y + (3 * h) / 4);
-          }
-        } else if (px === x + w) {
-          if (py < cy) {
-            return new Point(x + w, y + h / 4);
-          }
-          if (py > cy) {
-            return new Point(x + w, y + (3 * h) / 4);
-          }
-        }
-        if (py === y) {
-          return new Point(cx, y);
-        }
-        if (py === y + h) {
-          return new Point(cx, y + h);
-        }
-
-        if (px < cx) {
-          if (py > y + h / 4 && py < y + (3 * h) / 4) {
-            a = new Point(x, y);
-            b = new Point(x, y + h);
-          } else if (py < y + h / 4) {
-            a = new Point(x - Math.floor(0.5 * w), y + Math.floor(0.5 * h));
-            b = new Point(x + w, y - Math.floor(0.25 * h));
-          } else if (py > y + (3 * h) / 4) {
-            a = new Point(x - Math.floor(0.5 * w), y + Math.floor(0.5 * h));
-            b = new Point(x + w, y + Math.floor(1.25 * h));
-          }
-        } else if (px > cx) {
-          if (py > y + h / 4 && py < y + (3 * h) / 4) {
-            a = new Point(x + w, y);
-            b = new Point(x + w, y + h);
-          } else if (py < y + h / 4) {
-            a = new Point(x, y - Math.floor(0.25 * h));
-            b = new Point(x + Math.floor(1.5 * w), y + Math.floor(0.5 * h));
-          } else if (py > y + (3 * h) / 4) {
-            a = new Point(x + Math.floor(1.5 * w), y + Math.floor(0.5 * h));
-            b = new Point(x, y + Math.floor(1.25 * h));
-          }
-        }
-      } else {
-        // Special cases where intersects with hexagon corners
-        if (py === cy) {
-          if (px <= x) {
-            return new Point(x, y + h / 2);
-          }
-          if (px >= x + w) {
-            return new Point(x + w, y + h / 2);
-          }
-        } else if (py < y) {
-          if (px === x + w / 4) {
-            return new Point(x + w / 4, y);
-          }
-          if (px === x + (3 * w) / 4) {
-            return new Point(x + (3 * w) / 4, y);
-          }
-        } else if (py > y + h) {
-          if (px === x + w / 4) {
-            return new Point(x + w / 4, y + h);
-          }
-          if (px === x + (3 * w) / 4) {
-            return new Point(x + (3 * w) / 4, y + h);
-          }
-        } else if (py === y) {
-          if (px < cx) {
-            return new Point(x + w / 4, y);
-          }
-          if (px > cx) {
-            return new Point(x + (3 * w) / 4, y);
-          }
-        } else if (py === y + h) {
-          if (px < cx) {
-            return new Point(x + w / 4, y + h);
-          }
-          if (py > cy) {
-            return new Point(x + (3 * w) / 4, y + h);
-          }
-        }
-        if (px === x) {
-          return new Point(x, cy);
-        }
-        if (px === x + w) {
-          return new Point(x + w, cy);
-        }
-
-        if (py < cy) {
-          if (px > x + w / 4 && px < x + (3 * w) / 4) {
-            a = new Point(x, y);
-            b = new Point(x + w, y);
-          } else if (px < x + w / 4) {
-            a = new Point(x - Math.floor(0.25 * w), y + h);
-            b = new Point(x + Math.floor(0.5 * w), y - Math.floor(0.5 * h));
-          } else if (px > x + (3 * w) / 4) {
-            a = new Point(x + Math.floor(0.5 * w), y - Math.floor(0.5 * h));
-            b = new Point(x + Math.floor(1.25 * w), y + h);
-          }
-        } else if (py > cy) {
-          if (px > x + w / 4 && px < x + (3 * w) / 4) {
-            a = new Point(x, y + h);
-            b = new Point(x + w, y + h);
-          } else if (px < x + w / 4) {
-            a = new Point(x - Math.floor(0.25 * w), y);
-            b = new Point(x + Math.floor(0.5 * w), y + Math.floor(1.5 * h));
-          } else if (px > x + (3 * w) / 4) {
-            a = new Point(x + Math.floor(0.5 * w), y + Math.floor(1.5 * h));
-            b = new Point(x + Math.floor(1.25 * w), y);
-          }
-        }
-      }
-
-      let tx = cx;
-      let ty = cy;
-
-      if (px >= x && px <= x + w) {
-        tx = px;
-
-        if (py < cy) {
-          ty = y + h;
-        } else {
-          ty = y;
-        }
-      } else if (py >= y && py <= y + h) {
-        ty = py;
-
-        if (px < cx) {
-          tx = x + w;
-        } else {
-          tx = x;
-        }
-      }
-
-      result = intersection(tx, ty, next.x, next.y, a.x, a.y, b.x, b.y);
-    } else {
-      if (vertical) {
-        const beta = Math.atan2(h / 4, w / 2);
-
-        // Special cases where intersects with hexagon corners
-        if (alpha === beta) {
-          return new Point(x + w, y + Math.floor(0.25 * h));
-        }
-        if (alpha === pi2) {
-          return new Point(x + Math.floor(0.5 * w), y);
-        }
-        if (alpha === pi - beta) {
-          return new Point(x, y + Math.floor(0.25 * h));
-        }
-        if (alpha === -beta) {
-          return new Point(x + w, y + Math.floor(0.75 * h));
-        }
-        if (alpha === -pi2) {
-          return new Point(x + Math.floor(0.5 * w), y + h);
-        }
-        if (alpha === -pi + beta) {
-          return new Point(x, y + Math.floor(0.75 * h));
-        }
-
-        if (alpha < beta && alpha > -beta) {
-          a = new Point(x + w, y);
-          b = new Point(x + w, y + h);
-        } else if (alpha > beta && alpha < pi2) {
-          a = new Point(x, y - Math.floor(0.25 * h));
-          b = new Point(x + Math.floor(1.5 * w), y + Math.floor(0.5 * h));
-        } else if (alpha > pi2 && alpha < pi - beta) {
-          a = new Point(x - Math.floor(0.5 * w), y + Math.floor(0.5 * h));
-          b = new Point(x + w, y - Math.floor(0.25 * h));
-        } else if (
-          (alpha > pi - beta && alpha <= pi) ||
-          (alpha < -pi + beta && alpha >= -pi)
-        ) {
-          a = new Point(x, y);
-          b = new Point(x, y + h);
-        } else if (alpha < -beta && alpha > -pi2) {
-          a = new Point(x + Math.floor(1.5 * w), y + Math.floor(0.5 * h));
-          b = new Point(x, y + Math.floor(1.25 * h));
-        } else if (alpha < -pi2 && alpha > -pi + beta) {
-          a = new Point(x - Math.floor(0.5 * w), y + Math.floor(0.5 * h));
-          b = new Point(x + w, y + Math.floor(1.25 * h));
-        }
-      } else {
-        const beta = Math.atan2(h / 2, w / 4);
-
-        // Special cases where intersects with hexagon corners
-        if (alpha === beta) {
-          return new Point(x + Math.floor(0.75 * w), y);
-        }
-        if (alpha === pi - beta) {
-          return new Point(x + Math.floor(0.25 * w), y);
-        }
-        if (alpha === pi || alpha === -pi) {
-          return new Point(x, y + Math.floor(0.5 * h));
-        }
-        if (alpha === 0) {
-          return new Point(x + w, y + Math.floor(0.5 * h));
-        }
-        if (alpha === -beta) {
-          return new Point(x + Math.floor(0.75 * w), y + h);
-        }
-        if (alpha === -pi + beta) {
-          return new Point(x + Math.floor(0.25 * w), y + h);
-        }
-
-        if (alpha > 0 && alpha < beta) {
-          a = new Point(x + Math.floor(0.5 * w), y - Math.floor(0.5 * h));
-          b = new Point(x + Math.floor(1.25 * w), y + h);
-        } else if (alpha > beta && alpha < pi - beta) {
-          a = new Point(x, y);
-          b = new Point(x + w, y);
-        } else if (alpha > pi - beta && alpha < pi) {
-          a = new Point(x - Math.floor(0.25 * w), y + h);
-          b = new Point(x + Math.floor(0.5 * w), y - Math.floor(0.5 * h));
-        } else if (alpha < 0 && alpha > -beta) {
-          a = new Point(x + Math.floor(0.5 * w), y + Math.floor(1.5 * h));
-          b = new Point(x + Math.floor(1.25 * w), y);
-        } else if (alpha < -beta && alpha > -pi + beta) {
-          a = new Point(x, y + h);
-          b = new Point(x + w, y + h);
-        } else if (alpha < -pi + beta && alpha > -pi) {
-          a = new Point(x - Math.floor(0.25 * w), y);
-          b = new Point(x + Math.floor(0.5 * w), y + Math.floor(1.5 * h));
-        }
-      }
-
-      result = intersection(cx, cy, next.x, next.y, a.x, a.y, b.x, b.y);
-    }
-
-    if (result == null) {
-      return new Point(cx, cy);
-    }
-    return result;
-  }
-
-  private static getValue(
-    style: CellStateStyle,
-    direction: string,
-    DIRECTION_EAST: string
-  ) {
-    return '';
-  }
-}
+  HexagonPerimeter: HexagonPerimeterFunction,
+};
 
 export default Perimeter;

--- a/packages/core/src/view/style/perimeter/EllipsePerimeter.ts
+++ b/packages/core/src/view/style/perimeter/EllipsePerimeter.ts
@@ -1,0 +1,104 @@
+/*
+Copyright 2021-present The maxGraph project Contributors
+Copyright (c) 2006-2015, JGraph Ltd
+Copyright (c) 2006-2015, Gaudenz Alder
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import type Rectangle from '../../geometry/Rectangle';
+import type CellState from '../../cell/CellState';
+import Point from '../../geometry/Point';
+import type { PerimeterFunction } from '../../../types';
+
+export const EllipsePerimeter: PerimeterFunction = (
+  bounds: Rectangle,
+  _vertex: CellState,
+  next: Point,
+  orthogonal = false
+): Point => {
+  const { x } = bounds;
+  const { y } = bounds;
+  const a = bounds.width / 2;
+  const b = bounds.height / 2;
+  const cx = x + a;
+  const cy = y + b;
+  const px = next.x;
+  const py = next.y;
+
+  // Calculates straight line equation through
+  // point and ellipse center y = d * x + h
+  const dx = parseInt(String(px - cx));
+  const dy = parseInt(String(py - cy));
+
+  if (dx === 0 && dy !== 0) {
+    return new Point(cx, cy + (b * dy) / Math.abs(dy));
+  }
+  if (dx === 0 && dy === 0) {
+    return new Point(px, py);
+  }
+
+  if (orthogonal) {
+    if (py >= y && py <= y + bounds.height) {
+      const ty = py - cy;
+      let tx = Math.sqrt(a * a * (1 - (ty * ty) / (b * b))) || 0;
+
+      if (px <= x) {
+        tx = -tx;
+      }
+
+      return new Point(cx + tx, py);
+    }
+
+    if (px >= x && px <= x + bounds.width) {
+      const tx = px - cx;
+      let ty = Math.sqrt(b * b * (1 - (tx * tx) / (a * a))) || 0;
+
+      if (py <= y) {
+        ty = -ty;
+      }
+
+      return new Point(px, cy + ty);
+    }
+  }
+
+  // Calculates intersection
+  const d = dy / dx;
+  const h = cy - d * cx;
+  const e = a * a * d * d + b * b;
+  const f = -2 * cx * e;
+  const g = a * a * d * d * cx * cx + b * b * cx * cx - a * a * b * b;
+  const det = Math.sqrt(f * f - 4 * e * g);
+
+  // Two solutions (perimeter points)
+  const xout1 = (-f + det) / (2 * e);
+  const xout2 = (-f - det) / (2 * e);
+  const yout1 = d * xout1 + h;
+  const yout2 = d * xout2 + h;
+  const dist1 = Math.sqrt(Math.pow(xout1 - px, 2) + Math.pow(yout1 - py, 2));
+  const dist2 = Math.sqrt(Math.pow(xout2 - px, 2) + Math.pow(yout2 - py, 2));
+
+  // Correct solution
+  let xout = 0;
+  let yout = 0;
+
+  if (dist1 < dist2) {
+    xout = xout1;
+    yout = yout1;
+  } else {
+    xout = xout2;
+    yout = yout2;
+  }
+
+  return new Point(xout, yout);
+};

--- a/packages/core/src/view/style/perimeter/HexagonPerimeter.ts
+++ b/packages/core/src/view/style/perimeter/HexagonPerimeter.ts
@@ -1,0 +1,323 @@
+/*
+Copyright 2021-present The maxGraph project Contributors
+Copyright (c) 2006-2015, JGraph Ltd
+Copyright (c) 2006-2015, Gaudenz Alder
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import type Rectangle from '../../geometry/Rectangle';
+import type CellState from '../../cell/CellState';
+import Point from '../../geometry/Point';
+import type { PerimeterFunction } from '../../../types';
+import { DIRECTION } from '../../../util/Constants';
+import { intersection } from '../../../util/mathUtils';
+
+
+export const HexagonPerimeter: PerimeterFunction = (
+  bounds: Rectangle,
+  vertex: CellState,
+  next: Point,
+  orthogonal = false
+): Point | null => {
+  const { x } = bounds;
+  const { y } = bounds;
+  const w = bounds.width;
+  const h = bounds.height;
+
+  const cx = bounds.getCenterX();
+  const cy = bounds.getCenterY();
+  const px = next.x;
+  const py = next.y;
+  const dx = px - cx;
+  const dy = py - cy;
+  const alpha = -Math.atan2(dy, dx);
+  const pi = Math.PI;
+  const pi2 = Math.PI / 2;
+
+  let result: Point | null = new Point(cx, cy);
+
+  const direction = vertex?.style?.direction ?? DIRECTION.EAST;
+  const vertical = direction === DIRECTION.NORTH || direction === DIRECTION.SOUTH;
+  let a = new Point();
+  let b = new Point();
+
+  // Only consider corrects quadrants for the orthogonal case.
+  if (
+    (px < x && py < y) ||
+    (px < x && py > y + h) ||
+    (px > x + w && py < y) ||
+    (px > x + w && py > y + h)
+  ) {
+    orthogonal = false;
+  }
+
+  if (orthogonal) {
+    if (vertical) {
+      // Special cases where intersects with hexagon corners
+      if (px === cx) {
+        if (py <= y) {
+          return new Point(cx, y);
+        }
+        if (py >= y + h) {
+          return new Point(cx, y + h);
+        }
+      } else if (px < x) {
+        if (py === y + h / 4) {
+          return new Point(x, y + h / 4);
+        }
+        if (py === y + (3 * h) / 4) {
+          return new Point(x, y + (3 * h) / 4);
+        }
+      } else if (px > x + w) {
+        if (py === y + h / 4) {
+          return new Point(x + w, y + h / 4);
+        }
+        if (py === y + (3 * h) / 4) {
+          return new Point(x + w, y + (3 * h) / 4);
+        }
+      } else if (px === x) {
+        if (py < cy) {
+          return new Point(x, y + h / 4);
+        }
+        if (py > cy) {
+          return new Point(x, y + (3 * h) / 4);
+        }
+      } else if (px === x + w) {
+        if (py < cy) {
+          return new Point(x + w, y + h / 4);
+        }
+        if (py > cy) {
+          return new Point(x + w, y + (3 * h) / 4);
+        }
+      }
+      if (py === y) {
+        return new Point(cx, y);
+      }
+      if (py === y + h) {
+        return new Point(cx, y + h);
+      }
+
+      if (px < cx) {
+        if (py > y + h / 4 && py < y + (3 * h) / 4) {
+          a = new Point(x, y);
+          b = new Point(x, y + h);
+        } else if (py < y + h / 4) {
+          a = new Point(x - Math.floor(0.5 * w), y + Math.floor(0.5 * h));
+          b = new Point(x + w, y - Math.floor(0.25 * h));
+        } else if (py > y + (3 * h) / 4) {
+          a = new Point(x - Math.floor(0.5 * w), y + Math.floor(0.5 * h));
+          b = new Point(x + w, y + Math.floor(1.25 * h));
+        }
+      } else if (px > cx) {
+        if (py > y + h / 4 && py < y + (3 * h) / 4) {
+          a = new Point(x + w, y);
+          b = new Point(x + w, y + h);
+        } else if (py < y + h / 4) {
+          a = new Point(x, y - Math.floor(0.25 * h));
+          b = new Point(x + Math.floor(1.5 * w), y + Math.floor(0.5 * h));
+        } else if (py > y + (3 * h) / 4) {
+          a = new Point(x + Math.floor(1.5 * w), y + Math.floor(0.5 * h));
+          b = new Point(x, y + Math.floor(1.25 * h));
+        }
+      }
+    } else {
+      // Special cases where intersects with hexagon corners
+      if (py === cy) {
+        if (px <= x) {
+          return new Point(x, y + h / 2);
+        }
+        if (px >= x + w) {
+          return new Point(x + w, y + h / 2);
+        }
+      } else if (py < y) {
+        if (px === x + w / 4) {
+          return new Point(x + w / 4, y);
+        }
+        if (px === x + (3 * w) / 4) {
+          return new Point(x + (3 * w) / 4, y);
+        }
+      } else if (py > y + h) {
+        if (px === x + w / 4) {
+          return new Point(x + w / 4, y + h);
+        }
+        if (px === x + (3 * w) / 4) {
+          return new Point(x + (3 * w) / 4, y + h);
+        }
+      } else if (py === y) {
+        if (px < cx) {
+          return new Point(x + w / 4, y);
+        }
+        if (px > cx) {
+          return new Point(x + (3 * w) / 4, y);
+        }
+      } else if (py === y + h) {
+        if (px < cx) {
+          return new Point(x + w / 4, y + h);
+        }
+        if (py > cy) {
+          return new Point(x + (3 * w) / 4, y + h);
+        }
+      }
+      if (px === x) {
+        return new Point(x, cy);
+      }
+      if (px === x + w) {
+        return new Point(x + w, cy);
+      }
+
+      if (py < cy) {
+        if (px > x + w / 4 && px < x + (3 * w) / 4) {
+          a = new Point(x, y);
+          b = new Point(x + w, y);
+        } else if (px < x + w / 4) {
+          a = new Point(x - Math.floor(0.25 * w), y + h);
+          b = new Point(x + Math.floor(0.5 * w), y - Math.floor(0.5 * h));
+        } else if (px > x + (3 * w) / 4) {
+          a = new Point(x + Math.floor(0.5 * w), y - Math.floor(0.5 * h));
+          b = new Point(x + Math.floor(1.25 * w), y + h);
+        }
+      } else if (py > cy) {
+        if (px > x + w / 4 && px < x + (3 * w) / 4) {
+          a = new Point(x, y + h);
+          b = new Point(x + w, y + h);
+        } else if (px < x + w / 4) {
+          a = new Point(x - Math.floor(0.25 * w), y);
+          b = new Point(x + Math.floor(0.5 * w), y + Math.floor(1.5 * h));
+        } else if (px > x + (3 * w) / 4) {
+          a = new Point(x + Math.floor(0.5 * w), y + Math.floor(1.5 * h));
+          b = new Point(x + Math.floor(1.25 * w), y);
+        }
+      }
+    }
+
+    let tx = cx;
+    let ty = cy;
+
+    if (px >= x && px <= x + w) {
+      tx = px;
+
+      if (py < cy) {
+        ty = y + h;
+      } else {
+        ty = y;
+      }
+    } else if (py >= y && py <= y + h) {
+      ty = py;
+
+      if (px < cx) {
+        tx = x + w;
+      } else {
+        tx = x;
+      }
+    }
+
+    result = intersection(tx, ty, next.x, next.y, a.x, a.y, b.x, b.y);
+  } else {
+    if (vertical) {
+      const beta = Math.atan2(h / 4, w / 2);
+
+      // Special cases where intersects with hexagon corners
+      if (alpha === beta) {
+        return new Point(x + w, y + Math.floor(0.25 * h));
+      }
+      if (alpha === pi2) {
+        return new Point(x + Math.floor(0.5 * w), y);
+      }
+      if (alpha === pi - beta) {
+        return new Point(x, y + Math.floor(0.25 * h));
+      }
+      if (alpha === -beta) {
+        return new Point(x + w, y + Math.floor(0.75 * h));
+      }
+      if (alpha === -pi2) {
+        return new Point(x + Math.floor(0.5 * w), y + h);
+      }
+      if (alpha === -pi + beta) {
+        return new Point(x, y + Math.floor(0.75 * h));
+      }
+
+      if (alpha < beta && alpha > -beta) {
+        a = new Point(x + w, y);
+        b = new Point(x + w, y + h);
+      } else if (alpha > beta && alpha < pi2) {
+        a = new Point(x, y - Math.floor(0.25 * h));
+        b = new Point(x + Math.floor(1.5 * w), y + Math.floor(0.5 * h));
+      } else if (alpha > pi2 && alpha < pi - beta) {
+        a = new Point(x - Math.floor(0.5 * w), y + Math.floor(0.5 * h));
+        b = new Point(x + w, y - Math.floor(0.25 * h));
+      } else if (
+        (alpha > pi - beta && alpha <= pi) ||
+        (alpha < -pi + beta && alpha >= -pi)
+      ) {
+        a = new Point(x, y);
+        b = new Point(x, y + h);
+      } else if (alpha < -beta && alpha > -pi2) {
+        a = new Point(x + Math.floor(1.5 * w), y + Math.floor(0.5 * h));
+        b = new Point(x, y + Math.floor(1.25 * h));
+      } else if (alpha < -pi2 && alpha > -pi + beta) {
+        a = new Point(x - Math.floor(0.5 * w), y + Math.floor(0.5 * h));
+        b = new Point(x + w, y + Math.floor(1.25 * h));
+      }
+    } else {
+      const beta = Math.atan2(h / 2, w / 4);
+
+      // Special cases where intersects with hexagon corners
+      if (alpha === beta) {
+        return new Point(x + Math.floor(0.75 * w), y);
+      }
+      if (alpha === pi - beta) {
+        return new Point(x + Math.floor(0.25 * w), y);
+      }
+      if (alpha === pi || alpha === -pi) {
+        return new Point(x, y + Math.floor(0.5 * h));
+      }
+      if (alpha === 0) {
+        return new Point(x + w, y + Math.floor(0.5 * h));
+      }
+      if (alpha === -beta) {
+        return new Point(x + Math.floor(0.75 * w), y + h);
+      }
+      if (alpha === -pi + beta) {
+        return new Point(x + Math.floor(0.25 * w), y + h);
+      }
+
+      if (alpha > 0 && alpha < beta) {
+        a = new Point(x + Math.floor(0.5 * w), y - Math.floor(0.5 * h));
+        b = new Point(x + Math.floor(1.25 * w), y + h);
+      } else if (alpha > beta && alpha < pi - beta) {
+        a = new Point(x, y);
+        b = new Point(x + w, y);
+      } else if (alpha > pi - beta && alpha < pi) {
+        a = new Point(x - Math.floor(0.25 * w), y + h);
+        b = new Point(x + Math.floor(0.5 * w), y - Math.floor(0.5 * h));
+      } else if (alpha < 0 && alpha > -beta) {
+        a = new Point(x + Math.floor(0.5 * w), y + Math.floor(1.5 * h));
+        b = new Point(x + Math.floor(1.25 * w), y);
+      } else if (alpha < -beta && alpha > -pi + beta) {
+        a = new Point(x, y + h);
+        b = new Point(x + w, y + h);
+      } else if (alpha < -pi + beta && alpha > -pi) {
+        a = new Point(x - Math.floor(0.25 * w), y);
+        b = new Point(x + Math.floor(0.5 * w), y + Math.floor(1.5 * h));
+      }
+    }
+
+    result = intersection(cx, cy, next.x, next.y, a.x, a.y, b.x, b.y);
+  }
+
+  if (result == null) {
+    return new Point(cx, cy);
+  }
+  return result;
+};

--- a/packages/core/src/view/style/perimeter/RectanglePerimeter.ts
+++ b/packages/core/src/view/style/perimeter/RectanglePerimeter.ts
@@ -1,0 +1,81 @@
+/*
+Copyright 2021-present The maxGraph project Contributors
+Copyright (c) 2006-2015, JGraph Ltd
+Copyright (c) 2006-2015, Gaudenz Alder
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import type Rectangle from '../../geometry/Rectangle';
+import type CellState from '../../cell/CellState';
+import Point from '../../geometry/Point';
+import type { PerimeterFunction } from '../../../types';
+
+/**
+ * Describes a rectangular perimeter for the given bounds.
+ */
+export const RectanglePerimeter: PerimeterFunction = (
+  bounds: Rectangle,
+  _vertex: CellState,
+  next: Point,
+  orthogonal = false
+): Point => {
+  const cx = bounds.getCenterX();
+  const cy = bounds.getCenterY();
+  const dx = next.x - cx;
+  const dy = next.y - cy;
+  const alpha = Math.atan2(dy, dx);
+  const p = new Point(0, 0);
+  const pi = Math.PI;
+  const pi2 = Math.PI / 2;
+  const beta = pi2 - alpha;
+  const t = Math.atan2(bounds.height, bounds.width);
+
+  if (alpha < -pi + t || alpha > pi - t) {
+    // Left edge
+    p.x = bounds.x;
+    p.y = cy - (bounds.width * Math.tan(alpha)) / 2;
+  } else if (alpha < -t) {
+    // Top Edge
+    p.y = bounds.y;
+    p.x = cx - (bounds.height * Math.tan(beta)) / 2;
+  } else if (alpha < t) {
+    // Right Edge
+    p.x = bounds.x + bounds.width;
+    p.y = cy + (bounds.width * Math.tan(alpha)) / 2;
+  } else {
+    // Bottom Edge
+    p.y = bounds.y + bounds.height;
+    p.x = cx + (bounds.height * Math.tan(beta)) / 2;
+  }
+
+  if (orthogonal) {
+    if (next.x >= bounds.x && next.x <= bounds.x + bounds.width) {
+      p.x = next.x;
+    } else if (next.y >= bounds.y && next.y <= bounds.y + bounds.height) {
+      p.y = next.y;
+    }
+    if (next.x < bounds.x) {
+      p.x = bounds.x;
+    } else if (next.x > bounds.x + bounds.width) {
+      p.x = bounds.x + bounds.width;
+    }
+    if (next.y < bounds.y) {
+      p.y = bounds.y;
+    } else if (next.y > bounds.y + bounds.height) {
+      p.y = bounds.y + bounds.height;
+    }
+  }
+
+  return p;
+};

--- a/packages/core/src/view/style/perimeter/RhombusPerimeter.ts
+++ b/packages/core/src/view/style/perimeter/RhombusPerimeter.ts
@@ -1,0 +1,79 @@
+/*
+Copyright 2021-present The maxGraph project Contributors
+Copyright (c) 2006-2015, JGraph Ltd
+Copyright (c) 2006-2015, Gaudenz Alder
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import type Rectangle from '../../geometry/Rectangle';
+import type CellState from '../../cell/CellState';
+import Point from '../../geometry/Point';
+import type { PerimeterFunction } from '../../../types';
+import { intersection } from '../../../util/mathUtils';
+
+export const RhombusPerimeter: PerimeterFunction = (
+  bounds: Rectangle,
+  _vertex: CellState,
+  next: Point,
+  orthogonal = false
+): Point | null => {
+  const { x } = bounds;
+  const { y } = bounds;
+  const w = bounds.width;
+  const h = bounds.height;
+
+  const cx = x + w / 2;
+  const cy = y + h / 2;
+
+  const px = next.x;
+  const py = next.y;
+
+  // Special case for intersecting the diamond's corners
+  if (cx === px) {
+    if (cy > py) {
+      return new Point(cx, y); // top
+    }
+    return new Point(cx, y + h); // bottom
+  }
+  if (cy === py) {
+    if (cx > px) {
+      return new Point(x, cy); // left
+    }
+    return new Point(x + w, cy); // right
+  }
+
+  let tx = cx;
+  let ty = cy;
+
+  if (orthogonal) {
+    if (px >= x && px <= x + w) {
+      tx = px;
+    } else if (py >= y && py <= y + h) {
+      ty = py;
+    }
+  }
+
+  // In which quadrant will the intersection be?
+  // set the slope and offset of the border line accordingly
+  if (px < cx) {
+    if (py < cy) {
+      return intersection(px, py, tx, ty, cx, y, x, cy);
+    }
+    return intersection(px, py, tx, ty, cx, y + h, x, cy);
+  }
+  if (py < cy) {
+    return intersection(px, py, tx, ty, cx, y, x + w, cy);
+  }
+  return intersection(px, py, tx, ty, cx, y + h, x + w, cy);
+};

--- a/packages/core/src/view/style/perimeter/TrianglePerimeter.ts
+++ b/packages/core/src/view/style/perimeter/TrianglePerimeter.ts
@@ -1,0 +1,136 @@
+/*
+Copyright 2021-present The maxGraph project Contributors
+Copyright (c) 2006-2015, JGraph Ltd
+Copyright (c) 2006-2015, Gaudenz Alder
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import type Rectangle from '../../geometry/Rectangle';
+import type CellState from '../../cell/CellState';
+import Point from '../../geometry/Point';
+import type { PerimeterFunction } from '../../../types';
+import { DIRECTION } from '../../../util/Constants';
+import { intersection } from '../../../util/mathUtils';
+
+export const TrianglePerimeter: PerimeterFunction = (
+  bounds: Rectangle,
+  vertex: CellState,
+  next: Point,
+  orthogonal = false
+): Point | null => {
+  const direction = vertex != null ? vertex.style.direction : null;
+  const vertical = direction === DIRECTION.NORTH || direction === DIRECTION.SOUTH;
+
+  const { x } = bounds;
+  const { y } = bounds;
+  const w = bounds.width;
+  const h = bounds.height;
+
+  let cx = x + w / 2;
+  let cy = y + h / 2;
+
+  let start = new Point(x, y);
+  let corner = new Point(x + w, cy);
+  let end = new Point(x, y + h);
+
+  if (direction === DIRECTION.NORTH) {
+    start = end;
+    corner = new Point(cx, y);
+    end = new Point(x + w, y + h);
+  } else if (direction === DIRECTION.SOUTH) {
+    corner = new Point(cx, y + h);
+    end = new Point(x + w, y);
+  } else if (direction === DIRECTION.WEST) {
+    start = new Point(x + w, y);
+    corner = new Point(x, cy);
+    end = new Point(x + w, y + h);
+  }
+
+  let dx = next.x - cx;
+  let dy = next.y - cy;
+
+  const alpha = vertical ? Math.atan2(dx, dy) : Math.atan2(dy, dx);
+  const t = vertical ? Math.atan2(w, h) : Math.atan2(h, w);
+
+  let base = false;
+
+  if (direction === DIRECTION.NORTH || direction === DIRECTION.WEST) {
+    base = alpha > -t && alpha < t;
+  } else {
+    base = alpha < -Math.PI + t || alpha > Math.PI - t;
+  }
+
+  let result = null;
+
+  if (base) {
+    if (
+      orthogonal &&
+      ((vertical && next.x >= start.x && next.x <= end.x) ||
+        (!vertical && next.y >= start.y && next.y <= end.y))
+    ) {
+      if (vertical) {
+        result = new Point(next.x, start.y);
+      } else {
+        result = new Point(start.x, next.y);
+      }
+    } else if (direction === DIRECTION.NORTH) {
+      result = new Point(x + w / 2 + (h * Math.tan(alpha)) / 2, y + h);
+    } else if (direction === DIRECTION.SOUTH) {
+      result = new Point(x + w / 2 - (h * Math.tan(alpha)) / 2, y);
+    } else if (direction === DIRECTION.WEST) {
+      result = new Point(x + w, y + h / 2 + (w * Math.tan(alpha)) / 2);
+    } else {
+      result = new Point(x, y + h / 2 - (w * Math.tan(alpha)) / 2);
+    }
+  } else {
+    if (orthogonal) {
+      const pt = new Point(cx, cy);
+
+      if (next.y >= y && next.y <= y + h) {
+        pt.x = vertical ? cx : direction === DIRECTION.WEST ? x + w : x;
+        pt.y = next.y;
+      } else if (next.x >= x && next.x <= x + w) {
+        pt.x = next.x;
+        pt.y = !vertical ? cy : direction === DIRECTION.NORTH ? y + h : y;
+      }
+
+      // Compute angle
+      dx = next.x - pt.x;
+      dy = next.y - pt.y;
+
+      cx = pt.x;
+      cy = pt.y;
+    }
+
+    if ((vertical && next.x <= x + w / 2) || (!vertical && next.y <= y + h / 2)) {
+      result = intersection(
+        next.x,
+        next.y,
+        cx,
+        cy,
+        start.x,
+        start.y,
+        corner.x,
+        corner.y
+      );
+    } else {
+      result = intersection(next.x, next.y, cx, cy, corner.x, corner.y, end.x, end.y);
+    }
+  }
+
+  if (result == null) {
+    result = new Point(cx, cy);
+  }
+  return result;
+};

--- a/packages/html/stories/PerimeterOnLabelBounds.stories.ts
+++ b/packages/html/stories/PerimeterOnLabelBounds.stories.ts
@@ -67,7 +67,7 @@ const Template = ({ label, ...args }: Record<string, any>) => {
       next: Point,
       orthogonal: boolean,
       border: number
-    ): Point {
+    ): Point | null {
       let point = super.getPerimeterPoint(terminal, next, orthogonal, border);
 
       if (point) {

--- a/packages/html/stories/PerimeterVariousImplementations.stories.ts
+++ b/packages/html/stories/PerimeterVariousImplementations.stories.ts
@@ -187,6 +187,7 @@ const Template = ({ label, ...args }: Record<string, any>) => {
       size: [80, 80],
       style: withPerimeter(
         {
+          direction: 'north', // use vertical side and ensure that the perimeter follow the shape direction
           fillColor: 'lightblue',
           shape: 'hexagon',
         },


### PR DESCRIPTION
Introduce a `PerimeterFunction` type to precisely document the function accepted as perimeter. This
better guides implementers of perimeter. This required to update the code calling the perimeter
function (mainly to manage `null` values).

Split `Perimeter` implementations. The "Perimeter" file was too large, the change also prepare better
tree-shaking in the future for people that don't want to use all default perimeter implementation.
In addition, fix the `HexagonPerimeter` implementation to match the direction style value of the underlying
hexagon shape. The "Perimeter" story has been updated to use an orthogonal direction and show the fix.

`Perimeter` is no longer a class but a value object. It only contains static methods and properties.

Add various JSDoc improvements.

BREAKING CHANGES
  - `Perimeter` is no longer a class but a value object. This only impact users that had extended the
  `Perimeter` class. Regular user that define perimeter style properties using function provided by
  `maxGraph` are not impacted by this change.
  - CellState.perimeter no longer accept `Function`, but only the `PerimeterFunction`.
    - Passing an arbitrary `Function` was incorrect and always failed at runtime.
    - This change should not impact people using working implementation of perimeter function
    (including these provided by maxGraph) as they already have the right signature. Implementers of
    custom perimeter in TypeScript may have to slightly update their perimeter function declaration.
  - `GraphView` signature method changes
    -  `getPerimeterPoint` can now return `null`
    - `getPerimeterBounds` no longer accept null `CellState` and no longer returns `null`

### Notes

Rationale for switching Perimeter from class to value object: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v51.0.1/docs/rules/no-static-only-class.md


### Fix in the `HexagonPerimeter`

With the Perimeter story using `style.direction` set to `north`

before | now
----- | -----
![hexagon_perimeter_01_before](https://github.com/maxGraph/maxGraph/assets/27200110/76a9128f-c3ab-4bfc-a8e1-77fc5e4da3d2) | ![hexagon_perimeter_02_after png](https://github.com/maxGraph/maxGraph/assets/27200110/4d186f80-fddc-40b6-b88b-90ba086c825c)

