### PR TITLE
feat(js-example): add a button to display the exported XML model

### DIFF
--- a/packages/js-example/index.html
+++ b/packages/js-example/index.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <h1>maxGraph JavaScript Integration with Webpack</h1>
-    <p>Display a test graph. Activated behaviours:</p>
+    <p>Display a test graph loaded from an XML source. Activated behaviours:</p>
     <ul>
       <li>Panning: use mouse right button</li>
       <li>Cells selection with Rubberband: use mouse left button</li>

--- a/packages/js-example/src/index.js
+++ b/packages/js-example/src/index.js
@@ -18,6 +18,7 @@ import '@maxgraph/core/css/common.css';
 import './style.css';
 import {
   Client,
+  DomHelpers,
   Graph,
   InternalEvent,
   ModelXmlSerializer,
@@ -64,9 +65,7 @@ const initializeGraph = (container) => {
   const modelXmlSerializer = new ModelXmlSerializer(graph.model);
   modelXmlSerializer.import(xmlWithVerticesAndEdges);
 
-  // check what has been imported
-  console.info('Exporting model...');
-  console.info('Model as XML', modelXmlSerializer.export());
+  return graph;
 };
 
 // display the maxGraph version in the footer
@@ -74,4 +73,14 @@ const footer = document.querySelector('footer');
 footer.innerText = `Built with maxGraph ${Client.VERSION}`;
 
 // Creates the graph inside the given container
-initializeGraph(document.querySelector('#graph-container'));
+const container = document.querySelector('#graph-container');
+const graph = initializeGraph(container);
+
+const button = DomHelpers.button('View XML', function () {
+  const modelXmlSerializer = new ModelXmlSerializer(graph.model);
+  const xml = modelXmlSerializer.export();
+
+  // poor way to display the XML
+  window.alert(xml);
+});
+container.parentElement.appendChild(button);

--- a/packages/js-example/src/index.js
+++ b/packages/js-example/src/index.js
@@ -25,15 +25,7 @@ import {
   RubberBandHandler,
 } from '@maxgraph/core';
 
-const initializeGraph = (container) => {
-  // Disables the built-in context menu
-  InternalEvent.disableContextMenu(container);
-
-  const graph = new Graph(container);
-  graph.setPanning(true); // Use mouse right button for panning
-  new RubberBandHandler(graph); // Enables rubber band selection
-
-  const xmlWithVerticesAndEdges = `<GraphDataModel>
+const xmlWithVerticesAndEdges = `<GraphDataModel>
     <root>
       <Cell id="0">
         <Object as="style" />
@@ -61,7 +53,16 @@ const initializeGraph = (container) => {
       </Cell>
     </root>
   </GraphDataModel>
-  `;
+`;
+
+const initializeGraph = (container) => {
+  // Disables the built-in context menu
+  InternalEvent.disableContextMenu(container);
+
+  const graph = new Graph(container);
+  graph.setPanning(true); // Use mouse right button for panning
+  new RubberBandHandler(graph); // Enables rubber band selection
+
   const modelXmlSerializer = new ModelXmlSerializer(graph.model);
   modelXmlSerializer.import(xmlWithVerticesAndEdges);
 
@@ -76,11 +77,19 @@ footer.innerText = `Built with maxGraph ${Client.VERSION}`;
 const container = document.querySelector('#graph-container');
 const graph = initializeGraph(container);
 
-const button = DomHelpers.button('View XML', function () {
-  const modelXmlSerializer = new ModelXmlSerializer(graph.model);
-  const xml = modelXmlSerializer.export();
+// poor way to display the XML
+const popup = (content) => {
+  window.alert(content);
+};
 
-  // poor way to display the XML
-  window.alert(xml);
-});
-container.parentElement.appendChild(button);
+container.parentElement.appendChild(
+  DomHelpers.button('View Original XML', () => {
+    popup(xmlWithVerticesAndEdges);
+  })
+);
+container.parentElement.appendChild(
+  DomHelpers.button('Export XML', () => {
+    const xml = new ModelXmlSerializer(graph.model).export();
+    popup(xml);
+  })
+);

--- a/packages/js-example/src/style.css
+++ b/packages/js-example/src/style.css
@@ -40,6 +40,10 @@ footer {
   overflow: hidden;
 }
 
+button {
+  margin-top: 1.5rem;
+}
+
 /* For rubber band selection, override maxGraph defaults */
 div.mxRubberband {
   border-color: #b18426;

--- a/packages/js-example/src/style.css
+++ b/packages/js-example/src/style.css
@@ -42,6 +42,7 @@ footer {
 
 button {
   margin-top: 1.5rem;
+  margin-left: .5rem;
 }
 
 /* For rubber band selection, override maxGraph defaults */


### PR DESCRIPTION
This is to demonstrate that the Geometry is not correctly exported. Be kind with the poor design.
Also add a button to view the original XML used for the model import (for comparison).

Covers #327