### PR TITLE
docs: add the API documentation to the website

### DIFF
--- a/.github/workflows/generate-website.yml
+++ b/.github/workflows/generate-website.yml
@@ -26,10 +26,11 @@ jobs:
         run: npm run docs:api -w packages/core
       - name: Build website
         run: npm run build -w packages/website
+      - name: Copy generated resources to the website
+        run: npm run extra:copy-gen-resources -w packages/website
       - name: Upload website artifact
         uses: actions/upload-artifact@v4
         with:
           name: website-${{github.sha}}
           path: |
-            packages/core/build/api/
             packages/website/build/

--- a/.github/workflows/generate-website.yml
+++ b/.github/workflows/generate-website.yml
@@ -24,10 +24,10 @@ jobs:
         uses: ./.github/actions/build-setup
       - name: Build @maxgraph/core API docs
         run: npm run docs:api -w packages/core
-      - name: Build website
-        run: npm run build -w packages/website
       - name: Copy generated resources to the website
         run: npm run extra:copy-gen-resources -w packages/website
+      - name: Build website
+        run: npm run build -w packages/website
       - name: Upload website artifact
         uses: actions/upload-artifact@v4
         with:

--- a/packages/website/.gitignore
+++ b/packages/website/.gitignore
@@ -1,2 +1,3 @@
 .docusaurus/
 build/
+generated/

--- a/packages/website/README.md
+++ b/packages/website/README.md
@@ -24,20 +24,19 @@ $ npm build
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
 
-<!-- TODO document deployment
-### Deployment
 
-Using SSH:
+### External resources to include within the site
 
+The navbar includes links to external resources built by other packages
+- the API documentation
+- the Storybook demo
+
+Such resources are expected to be copied into the `generated` directory of the website.
+- build the related resources
+- copy `/packages/core/` to `/packages/webapp/generated/api-docs`
+- copy `/packages/html/dist` to `/packages/webapp/generated/demo`
+
+Run the following commands to copy the resources:
+```bash
+npm run extra:copy-gen-resources
 ```
-$ USE_SSH=true yarn deploy
-```
-
-Not using SSH:
-
-```
-$ GIT_USER=<Your GitHub username> yarn deploy
-```
-
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
--->

--- a/packages/website/README.md
+++ b/packages/website/README.md
@@ -2,30 +2,15 @@
 
 This website is built using [Docusaurus 3](https://docusaurus.io/), a modern static website generator.
 
-### Installation
+## Installation
 
 ```
 $ npm install
 ```
 
-### Local Development
+## Prerequisites
 
-```
-$ npm start
-```
-
-This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
-
-### Build
-
-```
-$ npm build
-```
-
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
-
-
-### External resources to include within the site
+### External resources that MUST include within the site
 
 The navbar includes links to external resources built by other packages
 - the API documentation
@@ -40,3 +25,24 @@ Run the following commands to copy the resources:
 ```bash
 npm run extra:copy-gen-resources
 ```
+
+In local development, not copying the resources let the server start but the links to the resources will be broken.
+
+When building, you must run this command at least once before building the website. Otherwise, the docusaurus will fail to build because of `Error: Docusaurus found broken links!`.
+
+
+## Local Development
+
+```
+$ npm start
+```
+
+This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
+
+## Build
+
+```
+$ npm build
+```
+
+This command generates static content into the `build` directory and can be served using any static contents hosting service.

--- a/packages/website/docs/intro.md
+++ b/packages/website/docs/intro.md
@@ -19,7 +19,9 @@ which requires finer-grained customization of functionality than off-the-shelf p
 
 :::warning
 
-This documentation is a **work in progress**. Please be patient, the content will be updated progressively.
+This documentation is a **work in progress**.
+
+Please be patient, as content will be gradually updated, especially the content of the original `mxGraph` documentation.
 
 :::
 

--- a/packages/website/docs/usage/migrate-from-mxgraph.md
+++ b/packages/website/docs/usage/migrate-from-mxgraph.md
@@ -25,6 +25,7 @@ The concepts are the same, so experienced `mxGraph` users should be able to swit
 
 The main changes are the removal of support for Internet Explorer (including VML support) and Legacy Edge.
 
+The initial description of the changes has been described in [#70](https://github.com/maxGraph/maxGraph/pull/70).
 
 ## Application setup
 

--- a/packages/website/docusaurus.config.ts
+++ b/packages/website/docusaurus.config.ts
@@ -13,7 +13,7 @@ const config: Config = {
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here
-  url: 'https://maxgraph.github.io/', // TODO add 'maxGraph/'?
+  url: 'https://maxgraph.github.io/', // mainly used for sitemap.xml
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl,

--- a/packages/website/docusaurus.config.ts
+++ b/packages/website/docusaurus.config.ts
@@ -146,7 +146,7 @@ const config: Config = {
           ],
         },
       ],
-      copyright: `Copyright © ${new Date().getFullYear()} - The maxGraph project Contributors. Built with Docusaurus.`,
+      copyright: `Copyright © 2021-${new Date().getFullYear()} - The maxGraph project Contributors. Built with Docusaurus.`,
     },
     prism: {
       theme: prismThemes.github,

--- a/packages/website/docusaurus.config.ts
+++ b/packages/website/docusaurus.config.ts
@@ -1,17 +1,22 @@
-import {themes as prismThemes} from 'prism-react-renderer';
-import type {Config} from '@docusaurus/types';
+import { themes as prismThemes } from 'prism-react-renderer';
+import type { Config } from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
+
+const baseUrl: string = '/'; // TODO baseUrl: '/maxGraph/' + also hard coded url,
 
 const config: Config = {
   title: 'maxGraph',
-  tagline: 'A TypeScript library which can display and allow interaction with vector diagrams.',
+  // The "generated" directory contains the demo (storybook) and the API documentation (typedoc)
+  staticDirectories: ['generated', 'static'],
+  tagline:
+    'A TypeScript library which can display and allow interaction with vector diagrams.',
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here
-  url: 'https://maxgraph.github.io/',
+  url: 'https://maxgraph.github.io/', // TODO add 'maxGraph/'?
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/', // TODO   baseUrl: '/maxGraph/',
+  baseUrl,
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
@@ -35,10 +40,8 @@ const config: Config = {
       {
         docs: {
           sidebarPath: './sidebars.ts',
-          // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl:
-            'https://github.com/maxGraph/maxGraph/tree/main/packages/docs/',
+          editUrl: 'https://github.com/maxGraph/maxGraph/tree/main/packages/docs/',
         },
         theme: {
           customCss: './src/css/custom.css',
@@ -50,6 +53,12 @@ const config: Config = {
   themeConfig: {
     // Replace with your project's social card
     // image: 'img/docusaurus-social-card.jpg',
+    announcementBar: {
+      content:
+        '⚠️ This is a <b>work in progress</b>, the content of the original <i>mxGraph</i> documentation will be progressively migrated here ⚠️',
+      backgroundColor: 'rgb(255, 248, 230)',
+      isCloseable: false,
+    },
     docs: {
       sidebar: {
         hideable: true,
@@ -63,13 +72,24 @@ const config: Config = {
       },
       items: [
         {
-          type: 'docSidebar',
-          sidebarId: 'docsSidebar',
-          position: 'left',
           label: 'Documentation',
+          position: 'left',
+          sidebarId: 'docsSidebar',
+          type: 'docSidebar',
         },
-        // {to: '/storybook', label: 'Demo', position: 'left'},
-        // {to: '/docs/api', label: 'API', position: 'left'},
+        // TODO when enabling this, also enable the corresponding configuration in the footer
+        // {
+        //   href: `${baseUrl}demo/`,
+        //   label: 'Demo',
+        //   position: 'left',
+        //   target: '_blank',
+        // },
+        {
+          href: `${baseUrl}api-docs/`,
+          label: 'API',
+          position: 'left',
+          target: '_blank',
+        },
         {
           href: 'https://github.com/maxGraph/maxGraph',
           label: 'GitHub',
@@ -88,13 +108,15 @@ const config: Config = {
               to: '/docs/intro',
             },
             // {
+            //   href: `${baseUrl}demo/`,
             //   label: 'Demo',
-            //   to: '/storybook',
+            //   target: '_blank',
             // },
-            // {
-            //   label: 'API',
-            //   to: '/docs/api',
-            // },
+            {
+              href: `${baseUrl}api-docs/`,
+              label: 'API',
+              target: '_blank',
+            },
           ],
         },
         {

--- a/packages/website/docusaurus.config.ts
+++ b/packages/website/docusaurus.config.ts
@@ -2,7 +2,7 @@ import { themes as prismThemes } from 'prism-react-renderer';
 import type { Config } from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 
-const baseUrl: string = '/'; // TODO baseUrl: '/maxGraph/' + also hard coded url,
+const baseUrl: string = '/maxGraph/';
 
 const config: Config = {
   title: 'maxGraph',

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -11,7 +11,8 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "extra:copy-gen-resources": "node scripts/copy-generated-resources.mjs"
   },
   "dependencies": {
     "@docusaurus/core": "3.0.0",

--- a/packages/website/scripts/copy-generated-resources.mjs
+++ b/packages/website/scripts/copy-generated-resources.mjs
@@ -1,0 +1,22 @@
+import { cpSync, rmSync } from 'node:fs';
+
+function copySync(src, dest) {
+  console.info(`Copying ${src} to ${dest}...`);
+  cpSync(src, dest, { recursive: true });
+  console.info('Copy done');
+}
+
+const targetDirectory = 'generated';
+console.info(`Copying generated resources to the "${targetDirectory}" directory...`);
+
+// clean existing resources
+rmSync(targetDirectory, {
+  recursive: true,
+  force: true, // When true, exceptions will be ignored if path does not exist.
+});
+
+copySync('../core/build/api', `${targetDirectory}/api-docs`);
+// TODO enable when the GH workflow will build storybook at the same time of the website
+// copySync('../html/dist', `${targetDirectory}/demo`);
+
+console.info('Copy of generated resources done');


### PR DESCRIPTION
Add a link to the API doc in the navbar and in the footer.
Add an announcement bar to warn about the content which is incomplete

Configuration updates
  - Prepare the configuration to be able to later integrate the Storybook demo in the website.
  - Provide a script to copy resources from other package within the website. The GitHub workflow
  uses it to prepare the uploaded artifact.
  - Remove the `.nojekyll` file. We are not going to use a branch to deploy to GH Pages, but we will
  use GH Actions instead, so there is no jekyll generation by default.
