### PR TITLE
fix: prevent error when dragging in the DragSource story

### DIFF
--- a/packages/html/stories/DragSource.stories.js
+++ b/packages/html/stories/DragSource.stories.js
@@ -196,7 +196,7 @@ const Template = ({ label, ...args }) => {
   // Redirects feature to global switch. Note that this feature should only be used
   // if the the x and y arguments are used in funct to insert the cell.
   ds.isGuidesEnabled = () => {
-    return graphs[0].graphHandler.guidesEnabled;
+    return graphs[0].getPlugin('SelectionHandler')?.guidesEnabled;
   };
 
   // Restores original drag icon while outside of graph


### PR DESCRIPTION
Call the `SelectionHandler` plugin instead of the former `graphHandler` property which has been removed during the TypeScript migration.