### PR TITLE
fix(stories): display images when not serving in the root context

### DIFF
--- a/packages/html/stories/Anchors.stories.ts
+++ b/packages/html/stories/Anchors.stories.ts
@@ -18,7 +18,6 @@ limitations under the License.
 import {
   CellEditorHandler,
   CellState,
-  Client,
   ConnectionHandler,
   ConnectionConstraint,
   Geometry,
@@ -36,6 +35,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { configureImagesBasePath, createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -52,15 +52,8 @@ export default {
 };
 
 const Template = ({ label, ...args }: Record<string, string>) => {
-  Client.setImageBasePath('/images');
-
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  configureImagesBasePath();
+  const container = createGraphContainer(args);
 
   class MyCustomConnectionHandler extends ConnectionHandler {
     // Enables connect preview for the default edge style

--- a/packages/html/stories/Animation.stories.js
+++ b/packages/html/stories/Animation.stories.js
@@ -18,6 +18,7 @@ limitations under the License.
 import { Graph, Point } from '@maxgraph/core';
 
 import { globalTypes, globalValues } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // required by the custom code (see the end of the Story)
 import './css/animation.css';
 
@@ -32,13 +33,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   const graph = new Graph(container);
   graph.setEnabled(false);

--- a/packages/html/stories/AutoLayout.stories.js
+++ b/packages/html/stories/AutoLayout.stories.js
@@ -40,6 +40,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -58,13 +59,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   if (!args.contextMenu) InternalEvent.disableContextMenu(container);
 

--- a/packages/html/stories/Boundary.stories.js
+++ b/packages/html/stories/Boundary.stories.js
@@ -29,6 +29,8 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
+
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -45,13 +47,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   class MyCustomGraph extends Graph {
     // Enables moving of relative children

--- a/packages/html/stories/Clipboard.stories.js
+++ b/packages/html/stories/Clipboard.stories.js
@@ -36,6 +36,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -52,13 +53,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   // Creates the graph inside the given this.el
   const graph = new Graph(container);

--- a/packages/html/stories/Codec.stories.ts
+++ b/packages/html/stories/Codec.stories.ts
@@ -22,6 +22,7 @@ import {
   type PanningHandler,
 } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 
 const xmlModel = `<mxGraphModel>
   <root>
@@ -95,11 +96,7 @@ export default {
 const Template = ({ label, ...args }: Record<string, any>) => {
   const div = document.createElement('div');
 
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
+  const container = createGraphContainer(args);
   container.style.background = '#eeeeee';
   container.style.border = '1px solid gray';
   div.appendChild(container);

--- a/packages/html/stories/Collapse.stories.js
+++ b/packages/html/stories/Collapse.stories.js
@@ -18,6 +18,7 @@ limitations under the License.
 import { Graph, Rectangle } from '@maxgraph/core';
 
 import { globalTypes, globalValues } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Layouts/Collapse',
@@ -30,13 +31,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   const graph = new Graph(container);
   const parent = graph.getDefaultParent();

--- a/packages/html/stories/Constituent.stories.js
+++ b/packages/html/stories/Constituent.stories.js
@@ -22,6 +22,7 @@ import {
   RubberBandHandler,
 } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Layouts/Constituent',
@@ -34,13 +35,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   // Disables the built-in context menu
   InternalEvent.disableContextMenu(container);

--- a/packages/html/stories/ContextIcons.stories.js
+++ b/packages/html/stories/ContextIcons.stories.js
@@ -31,6 +31,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -47,13 +48,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   class mxVertexToolHandler extends VertexHandler {
     // Defines a subclass for VertexHandler that adds a set of clickable

--- a/packages/html/stories/Control.stories.js
+++ b/packages/html/stories/Control.stories.js
@@ -31,6 +31,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -48,18 +49,11 @@ export default {
 
 const Template = ({ label, ...args }) => {
   const div = document.createElement('div');
-
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
   div.appendChild(container);
 
   // Specifies the URL and size of the new control
-  const deleteImage = new ImageBox('/images/forbidden.png', 16, 16);
+  const deleteImage = new ImageBox('images/forbidden.png', 16, 16);
 
   class MyCustomCellRenderer extends CellRenderer {
     createControl(state) {

--- a/packages/html/stories/DragSource.stories.js
+++ b/packages/html/stories/DragSource.stories.js
@@ -35,6 +35,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -51,12 +52,8 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
+  container.style.background = ''; // no grid
 
   class MyCustomGuide extends Guide {
     isEnabledForEvent(evt) {
@@ -93,13 +90,7 @@ const Template = ({ label, ...args }) => {
 
   // Creates the graph inside the given container
   for (let i = 0; i < 2; i++) {
-    const subContainer = document.createElement('div');
-    subContainer.style.overflow = 'hidden';
-    subContainer.style.position = 'relative';
-    subContainer.style.width = '321px';
-    subContainer.style.height = '241px';
-    subContainer.style.background = "url('/images/grid.gif')";
-    subContainer.style.cursor = 'default';
+    const subContainer = createGraphContainer({ width: 321, height: 241 });
     container.appendChild(subContainer);
 
     const graph = new MyCustomGraph(subContainer);

--- a/packages/html/stories/Drop.stories.js
+++ b/packages/html/stories/Drop.stories.js
@@ -31,6 +31,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -49,14 +50,7 @@ export default {
 const Template = ({ label, ...args }) => {
   const div = document.createElement('div');
   div.innerHTML = 'Drag & drop your images below:<br>';
-
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
   div.appendChild(container);
 
   // Checks if the browser is supported

--- a/packages/html/stories/DynamicLoading.stories.ts
+++ b/packages/html/stories/DynamicLoading.stories.ts
@@ -27,6 +27,7 @@ import {
 } from '@maxgraph/core';
 import type { Cell } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Misc/DynamicLoading',
@@ -39,13 +40,8 @@ export default {
 };
 
 const Template = ({ label, ...args }: Record<string, any>) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
+
   let requestId = 0;
 
   // Speedup the animation

--- a/packages/html/stories/DynamicStyle.stories.js
+++ b/packages/html/stories/DynamicStyle.stories.js
@@ -22,6 +22,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -38,13 +39,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   // Creates the graph inside the given container
   const graph = new Graph(container);

--- a/packages/html/stories/DynamicToolbar.stories.js
+++ b/packages/html/stories/DynamicToolbar.stories.js
@@ -35,6 +35,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -52,23 +53,12 @@ export default {
 
 const Template = ({ label, ...args }) => {
   const div = document.createElement('div');
-
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
   div.appendChild(container);
 
   // Defines an icon for creating new connections in the connection handler.
   // This will automatically disable the highlighting of the source vertex.
-  ConnectionHandler.prototype.connectImage = new ImageBox(
-    '/images/connector.gif',
-    16,
-    16
-  );
+  ConnectionHandler.prototype.connectImage = new ImageBox('images/connector.gif', 16, 16);
 
   // Creates the div for the toolbar
   const tbContainer = document.createElement('div');
@@ -100,13 +90,13 @@ const Template = ({ label, ...args }) => {
 
   if (args.rubberBand) new RubberBandHandler(graph);
 
-  addVertex('/images/rectangle.gif', 100, 40, '');
-  addVertex('/images/rounded.gif', 100, 40, 'shape=rounded');
-  addVertex('/images/ellipse.gif', 40, 40, 'shape=ellipse');
-  addVertex('/images/rhombus.gif', 40, 40, 'shape=rhombus');
-  addVertex('/images/triangle.gif', 40, 40, 'shape=triangle');
-  addVertex('/images/cylinder.gif', 40, 40, 'shape=cylinder');
-  addVertex('/images/actor.gif', 30, 40, 'shape=actor');
+  addVertex('images/rectangle.gif', 100, 40, '');
+  addVertex('images/rounded.gif', 100, 40, 'shape=rounded');
+  addVertex('images/ellipse.gif', 40, 40, 'shape=ellipse');
+  addVertex('images/rhombus.gif', 40, 40, 'shape=rhombus');
+  addVertex('images/triangle.gif', 40, 40, 'shape=triangle');
+  addVertex('images/cylinder.gif', 40, 40, 'shape=cylinder');
+  addVertex('images/actor.gif', 30, 40, 'shape=actor');
 
   function addVertex(icon, w, h, style) {
     const vertex = new Cell(null, new Geometry(0, 0, w, h), style);

--- a/packages/html/stories/EdgeTolerance.stories.js
+++ b/packages/html/stories/EdgeTolerance.stories.js
@@ -17,6 +17,7 @@ limitations under the License.
 
 import { Graph, styleUtils } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Connections/EdgeTolerance',
@@ -29,13 +30,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   class MyCustomGraph extends Graph {
     fireMouseEvent(evtName, me, sender) {

--- a/packages/html/stories/Editing.stories.js
+++ b/packages/html/stories/Editing.stories.js
@@ -24,6 +24,7 @@ import {
   eventUtils,
 } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Editing/Editing',
@@ -42,13 +43,7 @@ const Template = ({ label, ...args }) => {
     of the user object.
   `;
 
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
   div.appendChild(container);
 
   class MyCustomGraph extends Graph {

--- a/packages/html/stories/Events.stories.js
+++ b/packages/html/stories/Events.stories.js
@@ -33,7 +33,9 @@ import {
   globalValues,
   rubberBandTypes,
   rubberBandValues,
-} from './shared/args.js'; // style required by RubberBand
+} from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
+// style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
 export default {
@@ -51,17 +53,11 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   class MyCustomConnectionHandler extends ConnectionHandler {
     // Sets the image to be used for creating new connections
-    connectImage = new ImageBox('/images/green-dot.gif', 14, 14);
+    connectImage = new ImageBox('images/green-dot.gif', 14, 14);
   }
 
   // Disables built-in context menu
@@ -143,16 +139,16 @@ const Template = ({ label, ...args }) => {
 function createPopupMenu(graph, menu, cell, evt) {
   // Function to create the entries in the popupmenu
   if (cell != null) {
-    menu.addItem('Cell Item', '/images/image.gif', () => {
+    menu.addItem('Cell Item', 'images/image.gif', () => {
       alert('MenuItem1');
     });
   } else {
-    menu.addItem('No-Cell Item', '/images/image.gif', () => {
+    menu.addItem('No-Cell Item', 'images/image.gif', () => {
       alert('MenuItem2');
     });
   }
   menu.addSeparator();
-  menu.addItem('MenuItem3', '/images/warning.gif', () => {
+  menu.addItem('MenuItem3', 'images/warning.gif', () => {
     alert(`MenuItem3: ${graph.getSelectionCount()} selected`);
   });
 }

--- a/packages/html/stories/ExtendCanvas.stories.js
+++ b/packages/html/stories/ExtendCanvas.stories.js
@@ -32,6 +32,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -50,13 +51,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'auto';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.cursor = 'default';
-  container.style.background = 'url(/images/grid.gif)';
+  const container = createGraphContainer(args);
 
   if (!args.contextMenu) InternalEvent.disableContextMenu(container);
 

--- a/packages/html/stories/FileIO.stories.js
+++ b/packages/html/stories/FileIO.stories.js
@@ -29,6 +29,7 @@ import {
 } from '@maxgraph/core';
 
 import { globalTypes, globalValues } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Xml_Json/FileIO',
@@ -42,14 +43,7 @@ export default {
 
 const Template = ({ label, ...args }) => {
   const div = document.createElement('div');
-
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
   div.appendChild(container);
 
   // Program starts here. Creates a sample graph in the

--- a/packages/html/stories/FixedIcons.stories.js
+++ b/packages/html/stories/FixedIcons.stories.js
@@ -30,6 +30,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -46,13 +47,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   // Overrides the image bounds code to change the position
   LabelShape.prototype.getImageBounds = function (x, y, w, h) {

--- a/packages/html/stories/FixedPoints.stories.js
+++ b/packages/html/stories/FixedPoints.stories.js
@@ -33,6 +33,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -49,13 +50,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   class MyCustomConstraintHandler extends ConstraintHandler {
     // Snaps to fixed points

--- a/packages/html/stories/Folding.stories.js
+++ b/packages/html/stories/Folding.stories.js
@@ -17,6 +17,7 @@ limitations under the License.
 
 import { Graph, constants, EdgeStyle, StackLayout, LayoutManager } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Layouts/Folding',
@@ -29,13 +30,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   // Should we allow overriding constant values?
   // Enables crisp rendering of rectangles in SVG

--- a/packages/html/stories/GraphLayout.stories.ts
+++ b/packages/html/stories/GraphLayout.stories.ts
@@ -32,6 +32,7 @@ import {
 } from '@maxgraph/core';
 
 import { globalTypes, globalValues } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Layouts/GraphLayout',
@@ -50,14 +51,7 @@ export default {
 
 const Template = ({ label, ...args }: Record<string, any>) => {
   const mainContainer = document.createElement('div');
-  const container = document.createElement('div');
-
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   // Creates the graph inside the given container
   const graph = new Graph(container);

--- a/packages/html/stories/Grid.stories.js
+++ b/packages/html/stories/Grid.stories.js
@@ -34,6 +34,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -53,13 +54,8 @@ export default {
 
 const Template = ({ label, ...args }) => {
   const div = document.createElement('div');
-
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
+  container.style.background = ''; // no grid
   div.appendChild(container);
 
   if (!args.contextMenu) InternalEvent.disableContextMenu(container);
@@ -184,7 +180,7 @@ const Template = ({ label, ...args }) => {
       MaxLog.show();
       MaxLog.debug('Using background image');
 
-      container.style.backgroundImage = "url('editors/images/grid.gif')";
+      container.style.backgroundImage = "url('./images/grid.gif')";
     }
 
     var mxGraphViewValidateBackground = GraphView.prototype.validateBackground;

--- a/packages/html/stories/Groups.stories.js
+++ b/packages/html/stories/Groups.stories.js
@@ -28,6 +28,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -44,13 +45,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   // Overrides check for valid roots
   Graph.prototype.isValidRoot = function () {

--- a/packages/html/stories/Guides.stories.js
+++ b/packages/html/stories/Guides.stories.js
@@ -32,6 +32,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -50,13 +51,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   // Alt disables guides
   SelectionHandler.prototype.useGuidesForEvent = function (me) {

--- a/packages/html/stories/Handles.stories.js
+++ b/packages/html/stories/Handles.stories.js
@@ -37,6 +37,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -55,14 +56,7 @@ export default {
 };
 const Template = ({ label, ...args }) => {
   const div = document.createElement('div');
-
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
   div.appendChild(container);
 
   class MyShape extends CylinderShape {

--- a/packages/html/stories/HelloPort.stories.js
+++ b/packages/html/stories/HelloPort.stories.js
@@ -16,7 +16,6 @@ limitations under the License.
 */
 
 import {
-  Client,
   DomHelpers,
   EdgeStyle,
   Graph,
@@ -32,6 +31,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { configureImagesBasePath, createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -48,17 +48,10 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  Client.setImageBasePath('/images');
+  configureImagesBasePath();
 
   const div = document.createElement('div');
-
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
   div.appendChild(container);
 
   // Creates the graph inside the given container

--- a/packages/html/stories/HelloWorld.stories.js
+++ b/packages/html/stories/HelloWorld.stories.js
@@ -24,6 +24,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -42,13 +43,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   if (!args.contextMenu) InternalEvent.disableContextMenu(container);
 

--- a/packages/html/stories/HierarchicalLayout.stories.ts
+++ b/packages/html/stories/HierarchicalLayout.stories.ts
@@ -29,6 +29,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -46,14 +47,7 @@ export default {
 
 const Template = ({ label, ...args }: Record<string, any>) => {
   const div = document.createElement('div');
-
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
   div.appendChild(container);
 
   InternalEvent.disableContextMenu(container);

--- a/packages/html/stories/HoverIcons.stories.js
+++ b/packages/html/stories/HoverIcons.stories.js
@@ -31,6 +31,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -47,13 +48,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   // Defines an icon for creating new connections in the connection handler.
   // This will automatically disable the highlighting of the source vertex.

--- a/packages/html/stories/HoverStyle.stories.js
+++ b/packages/html/stories/HoverStyle.stories.js
@@ -17,6 +17,7 @@ limitations under the License.
 
 import { Graph, constants, RubberBandHandler, cloneUtils } from '@maxgraph/core';
 import { globalValues, globalTypes } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Styles/HoverStyle',
@@ -29,13 +30,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   // Creates the graph inside the given container
   const graph = new Graph(container);

--- a/packages/html/stories/HtmlLabel.stories.js
+++ b/packages/html/stories/HtmlLabel.stories.js
@@ -42,6 +42,7 @@ import {
 } from '@maxgraph/core';
 
 import { globalTypes, globalValues } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -56,13 +57,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   // Disables the built-in context menu
   InternalEvent.disableContextMenu(container);

--- a/packages/html/stories/Images.stories.ts
+++ b/packages/html/stories/Images.stories.ts
@@ -17,6 +17,7 @@ limitations under the License.
 
 import { Graph, cloneUtils, ImageBox, Rectangle, CellStateStyle } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Icon_Images/Images',
@@ -29,12 +30,8 @@ export default {
 };
 
 const Template = ({ label, ...args }: Record<string, any>) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
+  container.style.background = ''; // no grid
 
   // Creates the graph inside the given container
   const graph = new Graph(container);

--- a/packages/html/stories/Indicators.stories.js
+++ b/packages/html/stories/Indicators.stories.js
@@ -17,6 +17,7 @@ limitations under the License.
 
 import { Graph, EdgeStyle, constants, KeyHandler } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Icon_Images/Indicators',
@@ -29,13 +30,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   // Creates the graph inside the given container
   const graph = new Graph(container);

--- a/packages/html/stories/JsonData.stories.js
+++ b/packages/html/stories/JsonData.stories.js
@@ -21,7 +21,6 @@ import {
   DomHelpers,
   CodecRegistry,
   InternalEvent,
-  Client,
   Codec,
   domUtils,
   xmlUtils,
@@ -34,6 +33,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { configureImagesBasePath, createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -50,17 +50,9 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  Client.setImageBasePath('/images');
-
+  configureImagesBasePath();
   const div = document.createElement('div');
-
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
   div.appendChild(container);
 
   // Register a new codec

--- a/packages/html/stories/LabelPosition.stories.js
+++ b/packages/html/stories/LabelPosition.stories.js
@@ -17,6 +17,7 @@ limitations under the License.
 
 import { Graph } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Labels/LabelPosition',
@@ -29,13 +30,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   // Creates the graph inside the given container
   const graph = new Graph(container);

--- a/packages/html/stories/Labels.stories.js
+++ b/packages/html/stories/Labels.stories.js
@@ -28,6 +28,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -44,13 +45,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   // Creates the graph inside the given container
   const graph = new Graph(container);

--- a/packages/html/stories/Layers.stories.js
+++ b/packages/html/stories/Layers.stories.js
@@ -17,6 +17,7 @@ limitations under the License.
 
 import { Graph, DomHelpers, Cell, GraphDataModel, Point } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Layouts/Layers',
@@ -30,14 +31,7 @@ export default {
 
 const Template = ({ label, ...args }) => {
   const div = document.createElement('div');
-
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
   div.appendChild(container);
 
   // Creates the graph inside the given container using a model

--- a/packages/html/stories/LoD.stories.js
+++ b/packages/html/stories/LoD.stories.js
@@ -17,6 +17,7 @@ limitations under the License.
 
 import { Graph, DomHelpers } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Zoom_OffPage/LoD',
@@ -30,14 +31,7 @@ export default {
 
 const Template = ({ label, ...args }) => {
   const div = document.createElement('div');
-
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
   div.appendChild(container);
 
   // Creates the graph inside the given container

--- a/packages/html/stories/Manhattan.stories.js
+++ b/packages/html/stories/Manhattan.stories.js
@@ -17,6 +17,7 @@ limitations under the License.
 
 import { EdgeStyle, Graph, InternalEvent, SelectionHandler } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Connections/Manhattan',
@@ -29,13 +30,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   // Enables guides
   SelectionHandler.prototype.guidesEnabled = true;

--- a/packages/html/stories/Markers.stories.js
+++ b/packages/html/stories/Markers.stories.js
@@ -26,6 +26,7 @@ import {
   Point,
 } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Icon_Images/Markers',
@@ -38,13 +39,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   // Enables guides
   SelectionHandler.prototype.guidesEnabled = true;

--- a/packages/html/stories/MenuStyle.stories.js
+++ b/packages/html/stories/MenuStyle.stories.js
@@ -40,6 +40,7 @@ import {
   PanningHandler,
 } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -87,7 +88,7 @@ const HTML_TEMPLATE = `
 <body onload="main(document.getElementById('graphContainer'))">
   <!-- Creates a container for the graph with a grid wallpaper -->
   <div id="graphContainer"
-    style="overflow:hidden;width:321px;height:241px;background:url('editors/images/grid.gif');cursor:default;">
+    style="overflow:hidden;width:321px;height:241px;background:url('./images/grid.gif');cursor:default;">
   </div>
 </body>
 </html>
@@ -108,13 +109,7 @@ const Template = ({ label, ...args }) => {
   styleElm.innerText = CSS_TEMPLATE;
   document.head.appendChild(styleElm);
 
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   // Disables built-in context menu
   InternalEvent.disableContextMenu(container);
@@ -229,7 +224,7 @@ const Template = ({ label, ...args }) => {
   // Creates a new overlay with an image and a tooltip and makes it "transparent" to events
   // and sets the overlay for the cell in the graph
   let overlay = new CellOverlay(
-    new ImageBox('editors/images/overlays/check.png', 16, 16),
+    new ImageBox('images/overlays/check.png', 16, 16),
     'Overlay tooltip'
   );
   graph.addCellOverlay(v1, overlay);

--- a/packages/html/stories/Merge.stories.ts
+++ b/packages/html/stories/Merge.stories.ts
@@ -22,6 +22,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -38,13 +39,7 @@ export default {
 };
 
 const Template = ({ label, ...args }: Record<string, any>) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   // Should we allow overriding constants?
   // constants.SHADOWCOLOR = '#c0c0c0';

--- a/packages/html/stories/Monitor.stories.ts
+++ b/packages/html/stories/Monitor.stories.ts
@@ -17,7 +17,6 @@ limitations under the License.
 
 import {
   CellOverlay,
-  Client,
   cloneUtils,
   DomHelpers,
   Graph,
@@ -28,6 +27,7 @@ import {
   xmlUtils,
 } from '@maxgraph/core';
 import { globalTypes } from './shared/args.js';
+import { configureImagesBasePath, createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Misc/Monitor',
@@ -40,17 +40,12 @@ export default {
   },
 };
 
-const Template = ({ label, ...args }: Record<string, any>) => {
-  Client.setImageBasePath('/images');
+const Template = ({ label, ...args }: Record<string, string>) => {
+  configureImagesBasePath();
 
   const div = document.createElement('div');
-
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
+  container.style.background = ''; // no grid
   div.appendChild(container);
 
   // Should we allow overriding constants?

--- a/packages/html/stories/Morph.stories.js
+++ b/packages/html/stories/Morph.stories.js
@@ -28,6 +28,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -45,14 +46,7 @@ export default {
 
 const Template = ({ label, ...args }) => {
   const div = document.createElement('div');
-
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
   div.appendChild(container);
 
   // Disables the built-in context menu

--- a/packages/html/stories/OffPage.stories.js
+++ b/packages/html/stories/OffPage.stories.js
@@ -17,6 +17,7 @@ limitations under the License.
 
 import { Graph, CellTracker, constants, InternalEvent } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Zoom_OffPage/OffPage',
@@ -29,13 +30,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   // Use complete cell as highlight region
   // TODO how do we set the constants.ACTIVE_REGION?

--- a/packages/html/stories/OrgChart.stories.js
+++ b/packages/html/stories/OrgChart.stories.js
@@ -37,6 +37,7 @@ import {
   globalTypes,
   globalValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Layouts/OrgChart',
@@ -52,14 +53,7 @@ export default {
 
 const Template = ({ label, ...args }) => {
   const div = document.createElement('div');
-
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
   div.appendChild(container);
 
   // Should we allow overriding constants?
@@ -126,7 +120,7 @@ const Template = ({ label, ...args }) => {
   style.rounded = '1';
   style.glass = '1';
 
-  style.image = '/images/dude3.png';
+  style.image = 'images/dude3.png';
   style.imageWidth = '48';
   style.imageHeight = '48';
   style.spacing = 8;
@@ -228,7 +222,7 @@ const Template = ({ label, ...args }) => {
       20,
       140,
       60,
-      { image: '/images/house.png' }
+      { image: 'images/house.png' }
     );
     graph.updateCellSize(v1);
     addOverlays(graph, v1, false);
@@ -272,17 +266,17 @@ const Template = ({ label, ...args }) => {
 
     if (cell != null) {
       if (cell.isVertex()) {
-        menu.addItem('Add child', '/images/overlays/check.png', function () {
+        menu.addItem('Add child', 'images/overlays/check.png', function () {
           addChild(graph, cell);
         });
       }
 
-      menu.addItem('Edit label', '/images/text.gif', function () {
+      menu.addItem('Edit label', 'images/text.gif', function () {
         graph.startEditingAtCell(cell);
       });
 
       if (cell.id != 'treeRoot' && cell.isVertex()) {
-        menu.addItem('Delete', '/images/delete.gif', function () {
+        menu.addItem('Delete', 'images/delete.gif', function () {
           deleteSubtree(graph, cell);
         });
       }
@@ -290,22 +284,22 @@ const Template = ({ label, ...args }) => {
       menu.addSeparator();
     }
 
-    menu.addItem('Fit', '/images/zoom.gif', function () {
+    menu.addItem('Fit', 'images/zoom.gif', function () {
       graph.fit();
     });
 
-    menu.addItem('Actual', '/images/zoomactual.gif', function () {
+    menu.addItem('Actual', 'images/zoomactual.gif', function () {
       graph.zoomActual();
     });
 
     menu.addSeparator();
 
-    menu.addItem('Print', '/images/print.gif', function () {
+    menu.addItem('Print', 'images/print.gif', function () {
       const preview = new PrintPreview(graph, 1);
       preview.open();
     });
 
-    menu.addItem('Poster Print', '/images/print.gif', function () {
+    menu.addItem('Poster Print', 'images/print.gif', function () {
       const pageCount = utils.prompt('Enter maximum page count', '1');
 
       if (pageCount != null) {

--- a/packages/html/stories/Orthogonal.stories.js
+++ b/packages/html/stories/Orthogonal.stories.js
@@ -33,6 +33,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -49,13 +50,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   // Enables guides
   SelectionHandler.prototype.guidesEnabled = true;

--- a/packages/html/stories/Overlays.stories.js
+++ b/packages/html/stories/Overlays.stories.js
@@ -24,6 +24,7 @@ import {
   ImageBox,
 } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Effects/Overlays',
@@ -36,13 +37,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   // Creates the graph inside the given container
   const graph = new Graph(container);
@@ -74,7 +69,7 @@ const Template = ({ label, ...args }) => {
       if (overlays.length === 0) {
         // Creates a new overlay with an image and a tooltip
         const overlay = new CellOverlay(
-          new ImageBox('/images/check.png', 16, 16),
+          new ImageBox('images/check.png', 16, 16),
           'Overlay tooltip',
           pickAlignValueRandomly(),
           pickVerticalAlignValueRandomly()

--- a/packages/html/stories/PageBreaks.stories.js
+++ b/packages/html/stories/PageBreaks.stories.js
@@ -31,6 +31,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -50,14 +51,7 @@ export default {
 
 const Template = ({ label, ...args }) => {
   const div = document.createElement('div');
-
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
   div.appendChild(container);
 
   if (!args.contextMenu) InternalEvent.disableContextMenu(container);

--- a/packages/html/stories/PerimeterOnLabelBounds.stories.ts
+++ b/packages/html/stories/PerimeterOnLabelBounds.stories.ts
@@ -30,6 +30,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -46,13 +47,7 @@ export default {
 };
 
 const Template = ({ label, ...args }: Record<string, any>) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   InternalEvent.disableContextMenu(container);
 

--- a/packages/html/stories/PerimeterVariousImplementations.stories.ts
+++ b/packages/html/stories/PerimeterVariousImplementations.stories.ts
@@ -26,6 +26,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -49,13 +50,7 @@ export default {
 const withoutPerimeter = (style: CellStateStyle) => ({ ...style, perimeter: null });
 
 const Template = ({ label, ...args }: Record<string, any>) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   InternalEvent.disableContextMenu(container);
 

--- a/packages/html/stories/Permissions.stories.js
+++ b/packages/html/stories/Permissions.stories.js
@@ -29,6 +29,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -46,14 +47,7 @@ export default {
 
 const Template = ({ label, ...args }) => {
   const div = document.createElement('div');
-
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
   div.appendChild(container);
 
   // Defines an icon for creating new connections in the connection handler.

--- a/packages/html/stories/PortRefs.stories.js
+++ b/packages/html/stories/PortRefs.stories.js
@@ -24,9 +24,7 @@ import {
   ImageBox,
   Shape,
   TriangleShape,
-  constants,
   ConnectionConstraint,
-  Client,
 } from '@maxgraph/core';
 import {
   globalTypes,
@@ -34,6 +32,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { configureImagesBasePath, createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -50,18 +49,11 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  Client.setImageBasePath('/images');
-
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  configureImagesBasePath();
+  const container = createGraphContainer(args);
 
   // Replaces the port image
-  ConstraintHandler.prototype.pointImage = new ImageBox('/images/dot.gif', 10, 10);
+  ConstraintHandler.prototype.pointImage = new ImageBox('images/dot.gif', 10, 10);
 
   const graph = new Graph(container);
   graph.setConnectable(true);

--- a/packages/html/stories/RadialTreeLayout.stories.ts
+++ b/packages/html/stories/RadialTreeLayout.stories.ts
@@ -22,6 +22,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -38,13 +39,7 @@ export default {
 };
 
 const Template = ({ label, ...args }: Record<string, any>) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   // Creates the graph inside the given container
   const graph = new Graph(container);

--- a/packages/html/stories/Scrollbars.stories.js
+++ b/packages/html/stories/Scrollbars.stories.js
@@ -49,6 +49,7 @@ import {
   globalValues,
   globalTypes,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -94,7 +95,7 @@ const HTML_TEMPLATE = `
 
   <!-- Creates a container for the graph with a grid wallpaper. Width, height and cursor in the style are for IE only -->
   <div id="graphContainer"
-    style="cursor:default;position:absolute;top:30px;left:0px;bottom:0px;right:0px;background:url('editors/images/grid.gif')">
+    style="cursor:default;position:absolute;top:30px;left:0px;bottom:0px;right:0px;background:url('./images/grid.gif')">
   </div>
 </body>
 `;
@@ -116,13 +117,7 @@ const Template = ({ label, ...args }) => {
   styleElm.innerText = CSS_TEMPLATE;
   document.head.appendChild(styleElm);
 
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   // Disables foreignObjects
   Client.NO_FO = true;

--- a/packages/html/stories/SecondLabel.stories.js
+++ b/packages/html/stories/SecondLabel.stories.js
@@ -30,6 +30,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -47,14 +48,8 @@ export default {
 
 const Template = ({ label, ...args }) => {
   const div = document.createElement('div');
+  const container = createGraphContainer(args);
 
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
   div.appendChild(container);
 
   // Simple solution to add additional text to the rectangle shape definition:

--- a/packages/html/stories/Shape.stories.js
+++ b/packages/html/stories/Shape.stories.js
@@ -17,6 +17,7 @@ limitations under the License.
 
 import { Graph, CylinderShape, CellRenderer } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Shapes/Shape',
@@ -29,13 +30,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   /*
     The example shape is a "3D box" that looks like this:

--- a/packages/html/stories/ShowRegion.stories.js
+++ b/packages/html/stories/ShowRegion.stories.js
@@ -37,6 +37,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 
 const CSS_TEMPLATE = `
 body div.mxPopupMenu {
@@ -84,7 +85,7 @@ const HTML_TEMPLATE = `
 
   <!-- Creates a container for the graph with a grid wallpaper -->
   <div id="graphContainer"
-    style="overflow:hidden;width:321px;height:241px;background:url('editors/images/grid.gif');cursor:default;">
+    style="overflow:hidden;width:321px;height:241px;background:url('./images/grid.gif');cursor:default;">
   </div>
   Use the right mouse button to select a region of the diagram and select <i>Show this</i>.
 </body>
@@ -107,13 +108,7 @@ const Template = ({ label, ...args }) => {
   styleElm.innerText = CSS_TEMPLATE;
   document.head.appendChild(styleElm);
 
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   // Disables built-in context menu
   InternalEvent.disableContextMenu(container);

--- a/packages/html/stories/Stencils.stories.js
+++ b/packages/html/stories/Stencils.stories.js
@@ -41,6 +41,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -60,14 +61,7 @@ export default {
 
 const Template = ({ label, ...args }) => {
   const div = document.createElement('div');
-
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
   div.appendChild(container);
 
   // Allow overriding constants?

--- a/packages/html/stories/Stylesheet.stories.js
+++ b/packages/html/stories/Stylesheet.stories.js
@@ -17,6 +17,7 @@ limitations under the License.
 
 import { Graph, Perimeter, Point } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Styles/Stylesheet',
@@ -29,13 +30,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   // Creates the graph inside the DOM node.
   const graph = new Graph(container);

--- a/packages/html/stories/SwimLanes.stories.js
+++ b/packages/html/stories/SwimLanes.stories.js
@@ -27,9 +27,9 @@ import {
   StackLayout,
   LayoutManager,
   Graph,
-  Client,
 } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
+import { configureImagesBasePath, createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Layouts/SwimLanes',
@@ -42,15 +42,9 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  Client.setImageBasePath('/images');
-
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  configureImagesBasePath();
+  const container = createGraphContainer(args);
+  container.style.background = ''; // no grid
 
   InternalEvent.disableContextMenu(container);
 
@@ -89,7 +83,7 @@ const Template = ({ label, ...args }) => {
   style.horizontal = false;
   style.fontColor = 'black';
   style.strokeColor = 'black';
-  // delete style.fillColor;
+  delete style.fillColor;
   style.foldable = true;
 
   style = cloneUtils.clone(style);

--- a/packages/html/stories/Thread.stories.js
+++ b/packages/html/stories/Thread.stories.js
@@ -15,8 +15,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Graph, Client } from '@maxgraph/core';
+import { Graph } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
+import { configureImagesBasePath, createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Misc/Thread',
@@ -29,15 +30,8 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  Client.setImageBasePath('/images');
-
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  configureImagesBasePath();
+  const container = createGraphContainer(args);
 
   // Creates the graph inside the given container
   const graph = new Graph(container);

--- a/packages/html/stories/Toolbar.stories.ts
+++ b/packages/html/stories/Toolbar.stories.ts
@@ -35,6 +35,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -52,23 +53,12 @@ export default {
 
 const Template = ({ label, ...args }: { [p: string]: any }) => {
   const div = document.createElement('div');
-
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
   div.appendChild(container);
 
   // Defines an icon for creating new connections in the connection handler.
   // This will automatically disable the highlighting of the source vertex.
-  ConnectionHandler.prototype.connectImage = new ImageBox(
-    '/images/connector.gif',
-    16,
-    16
-  );
+  ConnectionHandler.prototype.connectImage = new ImageBox('images/connector.gif', 16, 16);
 
   // Creates the div for the toolbar
   const tbContainer = document.createElement('div');
@@ -122,14 +112,14 @@ const Template = ({ label, ...args }: { [p: string]: any }) => {
     addToolbarItem(graph, toolbar, vertex, icon);
   }
 
-  addVertex('/images/swimlane.gif', 120, 160, { shape: 'swimlane', startSize: 20 });
-  addVertex('/images/rectangle.gif', 100, 40, {});
-  addVertex('/images/rounded.gif', 100, 40, { rounded: true });
-  addVertex('/images/ellipse.gif', 40, 40, { shape: 'ellipse' });
-  addVertex('/images/rhombus.gif', 40, 40, { shape: 'rhombus' });
-  addVertex('/images/triangle.gif', 40, 40, { shape: 'triangle' });
-  addVertex('/images/cylinder.gif', 40, 40, { shape: 'cylinder' });
-  addVertex('/images/actor.gif', 30, 40, { shape: 'actor' });
+  addVertex('images/swimlane.gif', 120, 160, { shape: 'swimlane', startSize: 20 });
+  addVertex('images/rectangle.gif', 100, 40, {});
+  addVertex('images/rounded.gif', 100, 40, { rounded: true });
+  addVertex('images/ellipse.gif', 40, 40, { shape: 'ellipse' });
+  addVertex('images/rhombus.gif', 40, 40, { shape: 'rhombus' });
+  addVertex('images/triangle.gif', 40, 40, { shape: 'triangle' });
+  addVertex('images/cylinder.gif', 40, 40, { shape: 'cylinder' });
+  addVertex('images/actor.gif', 30, 40, { shape: 'actor' });
   toolbar.addLine();
 
   const button = DomHelpers.button('Create toolbar entry from selection', (evt) => {
@@ -152,7 +142,7 @@ const Template = ({ label, ...args }: { [p: string]: any }) => {
       };
 
       // Creates the image which is used as the drag icon (preview)
-      const img = toolbar.addMode(null, '/images/outline.gif', funct, '');
+      const img = toolbar.addMode(null, 'images/outline.gif', funct, '');
       gestureUtils.makeDraggable(img, graph, funct);
     }
   });

--- a/packages/html/stories/Tree.stories.js
+++ b/packages/html/stories/Tree.stories.js
@@ -21,7 +21,6 @@ import {
   CellRenderer,
   GraphView,
   ImageBox,
-  Client,
   EdgeStyle,
   KeyHandler,
   CompactTreeLayout,
@@ -30,6 +29,7 @@ import {
   Point,
 } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
+import { configureImagesBasePath, createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Layouts/Tree',
@@ -42,15 +42,8 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
-
-  Client.setImageBasePath('/images');
+  configureImagesBasePath();
+  const container = createGraphContainer(args);
 
   /*
     Defines a custom shape for the tree node that includes the

--- a/packages/html/stories/Validation.stories.js
+++ b/packages/html/stories/Validation.stories.js
@@ -29,6 +29,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -45,13 +46,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   const xmlDocument = xmlUtils.createXmlDocument();
   const sourceNode = xmlDocument.createElement('Source');

--- a/packages/html/stories/Visibility.stories.js
+++ b/packages/html/stories/Visibility.stories.js
@@ -22,6 +22,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -39,14 +40,7 @@ export default {
 
 const Template = ({ label, ...args }) => {
   const div = document.createElement('div');
-
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
   div.appendChild(container);
 
   // Creates the graph inside the given container

--- a/packages/html/stories/Window.stories.js
+++ b/packages/html/stories/Window.stories.js
@@ -23,7 +23,6 @@ import {
   InternalEvent,
   MaxLog,
   domUtils,
-  Client,
 } from '@maxgraph/core';
 import {
   contextMenuTypes,
@@ -33,6 +32,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { configureImagesBasePath, createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -51,15 +51,8 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  Client.setImageBasePath('/images');
-
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  configureImagesBasePath();
+  const container = createGraphContainer(args);
 
   // Note that we're using the container scrollbars for the graph so that the
   // container extends to the parent div inside the window

--- a/packages/html/stories/Wires.stories.js
+++ b/packages/html/stories/Wires.stories.js
@@ -91,6 +91,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -120,14 +121,7 @@ const HTML_TEMPLATE = `
 
 const Template = ({ label, ...args }) => {
   const parentContainer = document.createElement('div');
-  const container = document.createElement('div');
-
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
   parentContainer.appendChild(container);
 
   // Changes some default colors
@@ -985,7 +979,7 @@ const Template = ({ label, ...args }) => {
 
   InternalEvent.addListener(checkbox2, 'click', function (evt) {
     if (checkbox2.checked) {
-      container.style.background = 'url(/images/grid.gif)';
+      container.style.background = 'url(./images/grid.gif)';
     } else {
       container.style.background = '';
     }

--- a/packages/html/stories/Wrapping.stories.js
+++ b/packages/html/stories/Wrapping.stories.js
@@ -17,6 +17,7 @@ limitations under the License.
 
 import { Graph } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Labels/Wrapping',
@@ -29,13 +30,7 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
-  const container = document.createElement('div');
-  container.style.position = 'relative';
-  container.style.overflow = 'hidden';
-  container.style.width = `${args.width}px`;
-  container.style.height = `${args.height}px`;
-  container.style.background = 'url(/images/grid.gif)';
-  container.style.cursor = 'default';
+  const container = createGraphContainer(args);
 
   // Creates the graph inside the given container
   const graph = new Graph(container);

--- a/packages/html/stories/shared/configure.js
+++ b/packages/html/stories/shared/configure.js
@@ -1,0 +1,37 @@
+/*
+Copyright 2024-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { Client } from '@maxgraph/core';
+
+export const configureImagesBasePath = () => {
+  Client.setImageBasePath('./images');
+};
+
+/**
+ * @param args {Record<string, string>}
+ * @return {HTMLDivElement}
+ */
+export const createGraphContainer = (args) => {
+  const container = document.createElement('div');
+  const style = container.style;
+  style.position = 'relative';
+  style.overflow = 'hidden';
+  style.width = `${args.width}px`;
+  style.height = `${args.height}px`;
+  style.background = 'url(./images/grid.gif)';
+  style.cursor = 'default';
+  return container;
+};


### PR DESCRIPTION
This prepares the deployment to GitHub Pages. Previously, images were correctly served only when Storybook was deployed in the root context, for example when accessing http://localhost:8080 but not for http://localhost:8080/maxGraph.
The problem was due to the usage of leading / in images path. Some paths that involved "editors" images (not available) have been fixed as well.

The creation of the "div" container used to display the Graph is now managed at a single place to remove duplications.

Additional fix in SwimLanes.stories.js to restore some restore mxGraph behaviors:
  - no fill color
  - no background grid image The story is still not working as in mxGraph, mainly because it doesn't use the Editor and key bindings defined in a xml configuration file that was provided in mxGraph examples.
