### PR TITLE
chore: correctly run eslint on all OSes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,7 @@
 **/dist/**
 **/node_modules/**
+packages/core/build/**
+packages/core/coverage/**
+packages/html/stashed/**
+packages/website/build/**
+packages/website/generated/**

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   ],
   "scripts": {
     "dev": "node ./scripts/dev",
-    "lint": "eslint packages/**/**.ts",
-    "lint:fix": "eslint --fix packages/**/**.ts",
+    "lint": "eslint \"**/*.ts\"",
+    "lint:fix": "eslint --fix \"**/*.ts\"",
     "prettier": "prettier --write packages/*/src/**/*.ts"
   },
   "devDependencies": {


### PR DESCRIPTION
The previous configuration works only for Windows. For Linux and macOS, eslint didn't run on all files.
This was visible with GitHub Actions runs.
