### PR TITLE
fix: add null check to connection validation message

### DIFF
--- a/packages/core/src/view/handler/ConnectionHandler.ts
+++ b/packages/core/src/view/handler/ConnectionHandler.ts
@@ -2048,7 +2048,10 @@ class ConnectionHandlerCellMarker extends CellMarker {
             cell
           );
 
-          if (this.connectionHandler.error && this.connectionHandler.error.length === 0) {
+          if (
+            this.connectionHandler.error !== null &&
+            this.connectionHandler.error.length === 0
+          ) {
             cell = null;
 
             // Enables create target inside groups

--- a/packages/core/src/view/other/Multiplicity.ts
+++ b/packages/core/src/view/other/Multiplicity.ts
@@ -206,7 +206,7 @@ class Multiplicity {
    * {@link source}. This implementation uses {@link checkType} on the terminal's value.
    */
   checkTerminal(graph: Graph, edge: Cell, terminal: Cell): boolean {
-    const value = terminal.getValue();
+    const value = terminal?.getValue() ?? null;
 
     return this.checkType(graph, value, this.type, this.attr, this.value);
   }

--- a/packages/html/stories/Validation.stories.js
+++ b/packages/html/stories/Validation.stories.js
@@ -29,7 +29,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
-import { createGraphContainer } from './shared/configure.js';
+import { configureImagesBasePath, createGraphContainer } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -46,6 +46,8 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
+  configureImagesBasePath();
+
   const container = createGraphContainer(args);
 
   const xmlDocument = xmlUtils.createXmlDocument();


### PR DESCRIPTION
**Summary**
If-statement in ConnectionHandlerCellMarker was looking for `this.connectionHandler.error` to be an empty string, but used check `this.connectionHandler.error && this.connectionHandler.error.length === 0`, which is false when the string is empty because `""` is falsy. Reverted to the syntax used in mxgraph. This was noticed by issue #362

**Description for the changelog**
Add null check to connection validation message in ConnectionHandlerCellMarker to handler invalid connection targets.

Closes #362
