### PR TITLE
fix: add null check to GraphDataModel::isLayer

### DIFF
--- a/packages/core/__tests__/GraphDataModel.test.ts
+++ b/packages/core/__tests__/GraphDataModel.test.ts
@@ -1,0 +1,42 @@
+/*
+Copyright 2022-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, expect, test } from '@jest/globals';
+import { Cell, GraphDataModel } from '../src';
+
+describe('isLayer', () => {
+  const dm: GraphDataModel = new GraphDataModel();
+  const root: Cell = new Cell();
+  dm.setRoot(root);
+
+  test('Child is null', () => {
+    // @ts-ignore
+    const child: Cell = null;
+    expect(dm.isLayer(child)).toBe(false);
+  });
+
+  test('Child is not null and is not layer', () => {
+    const child: Cell = new Cell();
+    expect(dm.isLayer(child)).toBe(false);
+  });
+
+  test('Child is not null and is layer', () => {
+    const child: Cell = new Cell();
+    root.children.push(child);
+    child.setParent(root);
+    expect(dm.isLayer(child)).toBe(true);
+  });
+});

--- a/packages/core/src/view/GraphDataModel.ts
+++ b/packages/core/src/view/GraphDataModel.ts
@@ -399,7 +399,7 @@ export class GraphDataModel extends EventSource {
    * @param {Cell} cell  that represents the possible layer.
    */
   isLayer(cell: Cell) {
-    return this.isRoot(cell.getParent());
+    return cell ? this.isRoot(cell.getParent()) : false;
   }
 
   /**

--- a/packages/core/src/view/handler/ConnectionHandler.ts
+++ b/packages/core/src/view/handler/ConnectionHandler.ts
@@ -2048,10 +2048,7 @@ class ConnectionHandlerCellMarker extends CellMarker {
             cell
           );
 
-          if (
-            this.connectionHandler.error !== null &&
-            this.connectionHandler.error.length === 0
-          ) {
+          if (this.connectionHandler.error && this.connectionHandler.error.length === 0) {
             cell = null;
 
             // Enables create target inside groups

--- a/packages/core/src/view/handler/ConnectionHandler.ts
+++ b/packages/core/src/view/handler/ConnectionHandler.ts
@@ -2048,7 +2048,10 @@ class ConnectionHandlerCellMarker extends CellMarker {
             cell
           );
 
-          if (this.connectionHandler.error && this.connectionHandler.error.length === 0) {
+          if (
+            this.connectionHandler.error !== null &&
+            this.connectionHandler.error.length === 0
+          ) {
             cell = null;
 
             // Enables create target inside groups


### PR DESCRIPTION
**Summary**
`GraphDataModel::isLayer` throws an error if the argument is null, whereas mxgraph would return false. Added a null check to return false in that case, and added some jest tests for `isLayer`. This was noticed in #357

closes #357

**Description for the changelog**
Add null check to GraphDataModel::isLayer
