### PR TITLE
Add documentation for parameters in AbstractCanvas2D::arcTo

### DIFF
--- a/packages/core/src/view/canvas/AbstractCanvas2D.ts
+++ b/packages/core/src/view/canvas/AbstractCanvas2D.ts
@@ -479,6 +479,12 @@ abstract class AbstractCanvas2D {
   /**
    * Adds the given arc to the current path. This is a synthetic operation that
    * is broken down into curves.
+   * @param rx: The x distance between the current position
+   *            and the center of the ellipse around which to arc
+   * @param ry: The y distance between the current position
+   *            and the center of the ellipse around which to arc
+   * @param x: The x position of the end point of the arc
+   * @param y: The y position of the end point of the arc
    */
   arcTo(
     rx: number,


### PR DESCRIPTION
**Summary**
Add docstring parameters for the rx, ry, x, and y parameters in AbstractCanvas2D::arcTo. I had to do some experimentation with them to figure out what they actually did since it's not immediately clear. I couldn't figure out what the middle 3 parameters did and don't have time to figure it out right now -- they don't seem to do what I would have expected based on their names. Either way, adding a little bit of documentation for the 4 main parameters will hopefully be helpful for others in the future. 

**Description for the changelog**
Add documentation for parameters in AbstractCanvas2D::arcTo

