### PR TITLE
fix: correctly set the flag value in `setStyleFlag`

### DIFF
--- a/packages/core/__tests__/util/styleUtils.test.ts
+++ b/packages/core/__tests__/util/styleUtils.test.ts
@@ -15,8 +15,9 @@ limitations under the License.
 */
 
 import { describe, expect, test } from '@jest/globals';
-import { matchBinaryMask } from '../../src/util/styleUtils';
+import { matchBinaryMask, setStyleFlag } from '../../src/util/styleUtils';
 import { FONT } from '../../src/util/Constants';
+import { type CellStyle } from '../../src/types';
 
 describe('matchBinaryMask', () => {
   test('match self', () => {
@@ -30,5 +31,66 @@ describe('matchBinaryMask', () => {
   });
   test('no match', () => {
     expect(matchBinaryMask(46413, FONT.ITALIC)).toBeFalsy();
+  });
+});
+
+describe('setStyleFlag', () => {
+  test('fontStyle undefined, set bold, no value', () => {
+    const style: CellStyle = {};
+    setStyleFlag(style, 'fontStyle', FONT.BOLD);
+    expect(style.fontStyle).toBe(1);
+  });
+  test('fontStyle undefined, set bold, value is false', () => {
+    const style: CellStyle = {};
+    setStyleFlag(style, 'fontStyle', FONT.BOLD, false);
+    expect(style.fontStyle).toBe(0);
+  });
+  test('fontStyle undefined, set italic, value is false', () => {
+    const style: CellStyle = {};
+    setStyleFlag(style, 'fontStyle', FONT.ITALIC, false);
+    expect(style.fontStyle).toBe(0);
+  });
+  test('fontStyle undefined, set underline, value is true', () => {
+    const style: CellStyle = {};
+    setStyleFlag(style, 'fontStyle', FONT.UNDERLINE, true);
+    expect(style.fontStyle).toBe(4);
+  });
+  test('fontStyle undefined, set strike-through, value is true', () => {
+    const style: CellStyle = {};
+    setStyleFlag(style, 'fontStyle', FONT.STRIKETHROUGH, true);
+    expect(style.fontStyle).toBe(8);
+  });
+
+  test('fontStyle set without bold, toggle bold', () => {
+    const style: CellStyle = { fontStyle: 2 };
+    setStyleFlag(style, 'fontStyle', FONT.BOLD);
+    expect(style.fontStyle).toBe(3);
+  });
+  test('fontStyle set with bold, toggle bold', () => {
+    const style: CellStyle = { fontStyle: 9 };
+    setStyleFlag(style, 'fontStyle', FONT.BOLD);
+    expect(style.fontStyle).toBe(8);
+  });
+
+  test('fontStyle set without strike-through, set strike-through', () => {
+    const style: CellStyle = { fontStyle: 7 };
+    setStyleFlag(style, 'fontStyle', FONT.STRIKETHROUGH, true);
+    expect(style.fontStyle).toBe(15);
+  });
+  test('fontStyle set without strike-through, unset strike-through', () => {
+    const style: CellStyle = { fontStyle: 7 };
+    setStyleFlag(style, 'fontStyle', FONT.STRIKETHROUGH, false);
+    expect(style.fontStyle).toBe(7);
+  });
+
+  test('fontStyle set with underline, set underline', () => {
+    const style: CellStyle = { fontStyle: 6 };
+    setStyleFlag(style, 'fontStyle', FONT.UNDERLINE, true);
+    expect(style.fontStyle).toBe(6);
+  });
+  test('fontStyle set with underline, unset underline', () => {
+    const style: CellStyle = { fontStyle: 6 };
+    setStyleFlag(style, 'fontStyle', FONT.UNDERLINE, false);
+    expect(style.fontStyle).toBe(2);
   });
 });

--- a/packages/core/src/util/styleUtils.ts
+++ b/packages/core/src/util/styleUtils.ts
@@ -388,7 +388,6 @@ export const setCellStyleFlags = (
 };
 
 /**
- * Sets or removes the given key from the specified style and returns the new style.
  * Sets or toggles the flag bit for the given key in the cell's style.
  * If the `value` parameter is not set, then the flag is toggled.
  *

--- a/packages/core/src/util/styleUtils.ts
+++ b/packages/core/src/util/styleUtils.ts
@@ -348,22 +348,20 @@ export const setCellStyles = (
 
 /**
  * Sets or toggles the flag bit for the given key in the cell's styles.
- * If value is null then the flag is toggled.
+ * If the `value` parameter is not set, then the flag is toggled.
  *
- * Example:
+ * Example that toggles the bold font style:
  *
  * ```javascript
- * let cells = graph.getSelectionCells();
- * mxUtils.setCellStyleFlags(graph.model,
+ * const cells = graph.getSelectionCells();
+ * setCellStyleFlags(graph.model,
  *       cells,
- *       mxConstants.STYLE_FONTSTYLE,
- *       mxConstants.FONT_BOLD);
+ *       'fontStyle',
+ *       constants.FONT.BOLD);
  * ```
  *
- * Toggles the bold font style.
- *
  * @param model <Transactions> that contains the cells.
- * @param cells Array of {@link Cells} to change the style for.
+ * @param cells Array of {@link Cell}s to change the style for.
  * @param key Key of the style to be changed.
  * @param flag Integer for the bit to be changed.
  * @param value Optional boolean value for the flag.
@@ -373,7 +371,7 @@ export const setCellStyleFlags = (
   cells: Cell[],
   key: NumericCellStateStyleKeys,
   flag: number,
-  value: boolean
+  value?: boolean
 ) => {
   if (cells.length > 0) {
     model.batchUpdate(() => {
@@ -390,8 +388,9 @@ export const setCellStyleFlags = (
 };
 
 /**
- * Sets or removes the given key from the specified style and returns the
- * new style. If value is null then the flag is toggled.
+ * Sets or removes the given key from the specified style and returns the new style.
+ * Sets or toggles the flag bit for the given key in the cell's style.
+ * If the `value` parameter is not set, then the flag is toggled.
  *
  * @param style The style of the Cell.
  * @param key Key of the style to be changed.
@@ -407,7 +406,7 @@ export const setStyleFlag = (
   const v = style[key];
 
   if (v === undefined) {
-    style[key] = value === undefined ? flag : 0;
+    style[key] = value === undefined || value ? flag : 0;
   } else {
     if (value === undefined) {
       style[key] = v ^ flag;


### PR DESCRIPTION
Previously, when the style value was undefined for the given key, the function set the style value to 0 when the value parameter was `true` instead of setting the flag value. This problem had been introduced during the migration from `mxGraph`.

The function is now fully covered by automatic tests to validate that the entire implementation behaves correctly.

In addition:
  - improve the JSDoc of the `setCellStyleFlag` and `setCellStyleFlags` functions
  - fix the signature of the `setCellStyleFlags` function. The `value` parameter is optional.

### Notes

Original mxGraph implementation https://github.com/jgraph/mxgraph/blob/v4.2.2/javascript/src/js/util/mxUtils.js#L3586-L3662

It was setting the flag value when the value parameter was true
-  https://github.com/jgraph/mxgraph/blob/v4.2.2/javascript/src/js/util/mxUtils.js#L3603
```javascript
if (value || value == null)
{
	style = key+'='+flag;
}
```
- https://github.com/jgraph/mxgraph/blob/v4.2.2/javascript/src/js/util/mxUtils.js#L3620
```javascript
if (value || value == null)
{
	style = style + sep + key + '=' + flag;
}
```
