### PR TITLE
feat: allow to only register "model" codecs

### DIFF
--- a/packages/core/src/serialization/ModelXmlSerializer.ts
+++ b/packages/core/src/serialization/ModelXmlSerializer.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { registerCoreCodecs } from './register';
+import { registerModelCodecs } from './register';
 import { getPrettyXml, parseXml } from '../util/xmlUtils';
 import { Codec } from '../index';
 import type GraphDataModel from '../view/GraphDataModel';
@@ -68,6 +68,6 @@ export class ModelXmlSerializer {
    * Hook for replacing codecs registered by default (core codecs).
    */
   protected registerCodecs(): void {
-    registerCoreCodecs();
+    registerModelCodecs();
   }
 }

--- a/packages/core/src/serialization/register.ts
+++ b/packages/core/src/serialization/register.ts
@@ -69,25 +69,18 @@ const createObjectCodec = (template: any, name: string): ObjectCodec => {
   return objectCodec;
 };
 
-let isCoreCodecsRegistered = false;
-
+let isModelCodecsRegistered = false;
 /**
- * Register core editor i.e. codecs that don't relate to editor.
+ * Register model codecs i.e. codecs used to import/export the Graph Model, see {@link GraphDataModel}.
  *
  * @param force if `true` register the codecs even if they were already registered. If false, only register them
  *              if they have never been registered before.
- * @since 0.6.0
+ * @since 0.10.0
  */
-export const registerCoreCodecs = (force = false) => {
-  if (!isCoreCodecsRegistered || force) {
+export const registerModelCodecs = (force = false) => {
+  if (!isModelCodecsRegistered || force) {
     CodecRegistry.register(new CellCodec());
-    CodecRegistry.register(new ChildChangeCodec());
-    CodecRegistry.register(new GraphViewCodec());
     CodecRegistry.register(new ModelCodec());
-    CodecRegistry.register(new RootChangeCodec());
-    CodecRegistry.register(new StylesheetCodec());
-    CodecRegistry.register(new TerminalChangeCodec());
-    registerGenericChangeCodecs();
 
     // To support decode/import executed before encode/export (see https://github.com/maxGraph/maxGraph/issues/178)
     // Codecs are currently only registered automatically during encode/export
@@ -107,6 +100,29 @@ export const registerCoreCodecs = (force = false) => {
     CodecRegistry.addAlias('mxPoint', 'Point');
     CodecRegistry.register(new mxCellCodec(), false);
     CodecRegistry.register(new mxGeometryCodec(), false);
+
+    isModelCodecsRegistered = true;
+  }
+};
+
+let isCoreCodecsRegistered = false;
+/**
+ * Register core codecs i.e. codecs that don't relate to editor. This includes model codecs that can be registered individually with {@link registerModelCodecs}.
+ *
+ * @param force if `true` register the codecs even if they were already registered. If false, only register them
+ *              if they have never been registered before.
+ * @since 0.6.0
+ */
+export const registerCoreCodecs = (force = false) => {
+  if (!isCoreCodecsRegistered || force) {
+    CodecRegistry.register(new ChildChangeCodec());
+    CodecRegistry.register(new GraphViewCodec());
+    CodecRegistry.register(new RootChangeCodec());
+    CodecRegistry.register(new StylesheetCodec());
+    CodecRegistry.register(new TerminalChangeCodec());
+    registerGenericChangeCodecs();
+
+    registerModelCodecs(force);
 
     isCoreCodecsRegistered = true;
   }
@@ -131,7 +147,7 @@ export const registerEditorCodecs = (force = false) => {
 };
 
 /**
- * Register all editors i.e. core codecs (as done by {@link registerCoreCodecs}) and editor codecs (as done by {@link registerEditorCodecs}).
+ * Register all codecs i.e. core codecs (as done by {@link registerCoreCodecs}) and editor codecs (as done by {@link registerEditorCodecs}).
  *
  * @param force if `true` register the codecs even if they were already registered. If false, only register them
  *              if they have never been registered before.


### PR DESCRIPTION
Previously, even though the application integrating maxGraph only needed to import/export the model, some additional codecs were registered by the registration functions.
A new registration function is now available to register only the "model" codecs.
This reduces the size of applications that rely solely on import/export of the "template".
