### PR TITLE
fix: correctly compute the style when setting undefined/none

### DIFF
--- a/packages/core/src/view/style/Stylesheet.ts
+++ b/packages/core/src/view/style/Stylesheet.ts
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ALIGN, ARROW, SHAPE } from '../../util/Constants';
+import { ALIGN, ARROW, NONE, SHAPE } from '../../util/Constants';
 import { clone } from '../../util/cloneUtils';
 import type { CellStateStyle, CellStyle } from '../../types';
 
@@ -186,9 +186,14 @@ export class Stylesheet {
     }
 
     // Merges cellStyle into style
+    const filteredCellStyle = clone(cellStyle); // Clones the cellStyle to avoid modifying the original object pass as parameter
+    for (const key of Object.keys(filteredCellStyle)) {
+      (filteredCellStyle[key] === undefined || filteredCellStyle[key] == NONE) &&
+        delete filteredCellStyle[key];
+    }
     style = {
       ...style,
-      ...cellStyle,
+      ...filteredCellStyle,
     };
 
     // Remove the 'baseStyleNames' that may have been copied from the cellStyle parameter to match the method signature


### PR DESCRIPTION
Previously, when the value of a property was defined as `undefined`, it was also defined as `undefined` in the calculated style. This was a change from the mxGraph implementation and was not consistent with the style without the same property. 
This has now been corrected: when a value is set to `undefined`, the value calculated is that of the default style or a "base" style.

To match `mxGraph`'s behavior, the same logic applies when the value is set to "none".


### Notes

Original mxGraph's behavior:
- documentation: https://github.com/jgraph/mxgraph/blob/v4.2.2/javascript/src/js/view/mxStylesheet.js#L42-L43
- code: https://github.com/jgraph/mxgraph/blob/v4.2.2/javascript/src/js/view/mxStylesheet.js#L236-L239
