### PR TITLE
ci: build with macos-14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       # we want to run the full build on all os: don't cancel running jobs even if one fails
       fail-fast: false
       matrix:
-        os: ['ubuntu-22.04', 'macos-13', 'windows-2022']
+        os: ['ubuntu-22.04', 'macos-14', 'windows-2022']
     steps:
       - uses: actions/checkout@v4
       - name: Build Setup


### PR DESCRIPTION
The macos-14 GitHub hosted runner is now in GA.

### Notes

https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/
