### PR TITLE
docs: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.md
@@ -10,6 +10,9 @@ assignees: ''
 ### Describe the bug
 A clear and concise description of what the bug is.
 
+Please create a single issue for each bug. If you have multiple bugs, please create multiple issues.
+This will help us to track and manage the issues more effectively.
+
 
 ### To Reproduce
 Steps to reproduce the behavior:

--- a/.github/ISSUE_TEMPLATE/01-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.md
@@ -1,0 +1,41 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: bug, triage
+assignees: ''
+
+---
+
+### Describe the bug
+A clear and concise description of what the bug is.
+
+
+### To Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error (if the error is taking from the browser console, please provide the error message in the text form, no image)
+
+If possible provide a repository to reproduce the issue. At minimum, provide the code (in text form, no image) that produces the issue.
+
+### Expected behavior
+A clear and concise description of what you expected to happen.
+
+
+### Screenshots
+If applicable, add screenshots or videos to help explain your problem.
+
+
+### Environment
+- Desktop or mobile:
+- OS and version: [e.g. iOS 14.1]
+- Browser and version: [e.g. chrome 118, safari 15]
+- Node/npm version (if applicable):
+- Used frameworks (if applicable):
+
+
+
+### Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/02-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.md
@@ -10,6 +10,10 @@ assignees: ''
 ### Is your feature request related to a problem? Please describe.
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
+Please create a single issue for each request. If you have multiple requests, please create multiple issues.
+This will help us to track and manage the issues more effectively.
+
+
 ### Describe the solution you'd like
 A clear and concise description of what you want to happen.
 

--- a/.github/ISSUE_TEMPLATE/02-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEAT]"
+labels: enhancement, triage
+assignees: ''
+
+---
+
+### Is your feature request related to a problem? Please describe.
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+### Describe the solution you'd like
+A clear and concise description of what you want to happen.
+
+### Describe alternatives you've considered
+A clear and concise description of any alternative solutions or features you've considered.
+
+### Additional context
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/03-technical-request.md
+++ b/.github/ISSUE_TEMPLATE/03-technical-request.md
@@ -1,0 +1,22 @@
+---
+name: Technical request
+about: Suggest an refactoring, technical change, ... for this project
+title: "[CHORE]"
+labels: chore, triage
+assignees: ''
+
+---
+
+**Please first consider** starting discussion in the [development discussions](https://github.com/maxGraph/maxGraph/discussions/categories/development) prior submitting technical requests.
+
+### Is your technical request related to a problem? Please describe.
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+### Describe the solution you'd like
+A clear and concise description of what you want to happen.
+
+### Describe alternatives you've considered
+A clear and concise description of any alternative solutions or features you've considered.
+
+### Additional context
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+# see https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+blank_issues_enabled: false
+contact_links:
+  - name: Community Support for usage questions
+    url: https://github.com/maxGraph/maxGraph/discussions/categories/development
+    about: Please ask and answer questions about maxGraph usage here.
+  - name: Development Support
+    url: https://github.com/maxGraph/maxGraph/discussions/categories/development
+    about: Please ask questions about maxGraph development here.


### PR DESCRIPTION
This will help structuring the content of the issues, especially for bugs.
This will also highlight the usage of discussions instead of issue for questions.
