### PR TITLE
refactor: GraphDataModel.isLayer signature accepts `null` Cell

### DIFF
--- a/packages/core/__tests__/GraphDataModel.test.ts
+++ b/packages/core/__tests__/GraphDataModel.test.ts
@@ -23,18 +23,15 @@ describe('isLayer', () => {
   dm.setRoot(root);
 
   test('Child is null', () => {
-    // @ts-ignore
-    const child: Cell = null;
-    expect(dm.isLayer(child)).toBe(false);
+    expect(dm.isLayer(null)).toBe(false);
   });
 
   test('Child is not null and is not layer', () => {
-    const child: Cell = new Cell();
-    expect(dm.isLayer(child)).toBe(false);
+    expect(dm.isLayer(new Cell())).toBe(false);
   });
 
   test('Child is not null and is layer', () => {
-    const child: Cell = new Cell();
+    const child = new Cell();
     root.children.push(child);
     child.setParent(root);
     expect(dm.isLayer(child)).toBe(true);

--- a/packages/core/src/view/GraphDataModel.ts
+++ b/packages/core/src/view/GraphDataModel.ts
@@ -396,9 +396,9 @@ export class GraphDataModel extends EventSource {
   /**
    * Returns true if {@link isRoot} returns true for the parent of the given cell.
    *
-   * @param {Cell} cell  that represents the possible layer.
+   * @param cell  that represents the possible layer.
    */
-  isLayer(cell: Cell) {
+  isLayer(cell: Cell | null) {
     return cell ? this.isRoot(cell.getParent()) : false;
   }
 

--- a/packages/core/src/view/mixins/SwimlaneMixin.ts
+++ b/packages/core/src/view/mixins/SwimlaneMixin.ts
@@ -379,7 +379,7 @@ const SwimlaneMixin: PartialType = {
       }
     }
 
-    return !this.getDataModel().isLayer(<Cell>cell) && !parent ? cell : null;
+    return !this.getDataModel().isLayer(cell) && !parent ? cell : null;
   },
 
   /**


### PR DESCRIPTION
This complements the fix that manages `null` Cell in the implementation.

## Notes

Complements #365
This has been suggested in #88, see https://github.com/maxGraph/maxGraph/pull/88/files/d44b8819a75e22e73638b16c17956281d5fd52b4#diff-631ee06893c04c0fd73eb2248abff6724ddbe1c1629011af79d40e4570e693d8


