### PR TITLE
fix: correctly detect parent in SwimlaneMixin.dropTarget

### DIFF
--- a/packages/core/src/view/mixins/SwimlaneMixin.ts
+++ b/packages/core/src/view/mixins/SwimlaneMixin.ts
@@ -372,14 +372,14 @@ const SwimlaneMixin: PartialType = {
     }
 
     // Checks if parent is dropped into child if not cloning
+    let parentCell = cell;
     if (!clone) {
-      let parent = cell;
-      while (parent && cells.indexOf(parent) < 0) {
-        parent = parent.getParent();
+      while (parentCell && cells.indexOf(parentCell) < 0) {
+        parentCell = parentCell.getParent();
       }
     }
 
-    return !this.getDataModel().isLayer(cell) && !parent ? cell : null;
+    return !this.getDataModel().isLayer(cell) && !parentCell ? cell : null;
   },
 
   /**


### PR DESCRIPTION
The target was not detected as a valid target so, the targeted swimlane was never highlighted while panning the cell over the potential target.

The problem was visible in the Swimlanes and Folding stories, the targeted swimlanes are now correctly highlighted.

The problem was introduced during the mxGraph migration, the parent variable scope change during the migration and the parent variable used to validate if the target was valid didn't refer to a Cell in maxGraph but to Window.parent.

###  Notes

The issue in the Folding story was visible in #385

An alternate fix was proposed in #88, see https://github.com/maxGraph/maxGraph/pull/88/commits/8546ca99aa8d7b58122364d17392ee3a764e1e42

Fix in the Swimlanes story

![PR_390_fix_swimlanes_stroy_dropTarget](https://github.com/maxGraph/maxGraph/assets/27200110/15148327-fe99-4923-b955-5602e0fea224)

