### PR TITLE
feat: let style edge marker fill and stroke colors

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -196,6 +196,18 @@ export type CellStateStyle = {
    */
   endFill?: boolean;
   /**
+   * Set the fill color of the end arrow marker if {@link endFill} is `true`.
+   * If not set, use {@link startStrokeColor}.
+   * @since 0.10.0
+   */
+  endFillColor?: ColorValue;
+  /**
+   * Set the stroke color of the end arrow marker.
+   * If not set, use {@link strokeColor}.
+   * @since 0.10.0
+   */
+  endStrokeColor?: ColorValue;
+  /**
    * The value represents the size of the end marker in pixels.
    * See {@link startSize}.
    */
@@ -702,6 +714,18 @@ export type CellStateStyle = {
    * @default true
    */
   startFill?: boolean;
+  /**
+   * Set the fill color of the start arrow marker if {@link startFill} is `true`.
+   * If not set, use {@link startStrokeColor}.
+   * @since 0.10.0
+   */
+  startFillColor?: ColorValue;
+  /**
+   * Set the stroke color of the start arrow marker.
+   * If not set, use {@link strokeColor}.
+   * @since 0.10.0
+   */
+  startStrokeColor?: ColorValue;
   /**
    * The value represents the size of the start marker, in pixels, or the size of the title region
    * of a `swimlane` depending on the shape it is used for.

--- a/packages/core/src/view/geometry/edge/ConnectorShape.ts
+++ b/packages/core/src/view/geometry/edge/ConnectorShape.ts
@@ -58,16 +58,21 @@ class ConnectorShape extends PolylineShape {
 
     super.paintEdgeShape(c, pts);
 
-    // Disables shadows, dashed styles and fixes fill color for markers
-    c.setFillColor(this.stroke);
+    // Disables shadows, dashed styles
     c.setShadow(false);
     c.setDashed(false);
 
     if (sourceMarker) {
+      const strokeColor = this.style?.startStrokeColor ?? this.stroke;
+      c.setStrokeColor(strokeColor);
+      c.setFillColor(this.style?.startFillColor ?? strokeColor);
       sourceMarker();
     }
 
     if (targetMarker) {
+      const strokeColor = this.style?.endStrokeColor ?? this.stroke;
+      c.setStrokeColor(strokeColor);
+      c.setFillColor(this.style?.endFillColor ?? strokeColor);
       targetMarker();
     }
   }


### PR DESCRIPTION
The Markers story has been updated to demonstrate the new features. It has also been migrated to TypeScript to better check potential code errors.

### Notes

Closes #201

![PR_392_Markers_fill_stroke_colors](https://github.com/maxGraph/maxGraph/assets/27200110/92223064-ca3d-46b6-9500-9e77d5567310)

**_New feature in Marker.stories_**