### PR TITLE
ci: fix github release template

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -26,7 +26,7 @@ jobs:
             npm package: [${{ env.VERSION }}](https://www.npmjs.com/package/@maxgraph/core/v/${{ env.VERSION }})
             **Update the milestone URL**
             Issues: [milestone ${{ env.VERSION }}](https://github.com/maxGraph/maxGraph/milestone/x?closed=1)
-            See also the [Changelog](https://github.com/maxGraph/maxGraph/tree/${{ env.VERSION }}/CHANGELOG.md) file.
+            See also the [Changelog](https://github.com/maxGraph/maxGraph/tree/v${{ env.VERSION }}/CHANGELOG.md) file.
 
 
             ## Breaking changes


### PR DESCRIPTION
The link to the CHANGELOG file was wrong. It missed a "v" in the tag part of the URL.
