### PR TITLE
fix: remove circular dependency in ModelXmlSerializer

### DIFF
--- a/packages/core/src/serialization/ModelXmlSerializer.ts
+++ b/packages/core/src/serialization/ModelXmlSerializer.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { registerModelCodecs } from './register';
 import { getPrettyXml, parseXml } from '../util/xmlUtils';
-import { Codec } from '../index';
+import Codec from './Codec';
 import type GraphDataModel from '../view/GraphDataModel';
 
 /**


### PR DESCRIPTION
The circular path was
  - node_modules/@maxgraph/core/dist/index.js
  - -> node_modules/@maxgraph/core/dist/serialization/ModelXmlSerializer.js
  - -> node_modules/@maxgraph/core/dist/index.js

It was due to a wrong import of the Codec class. It was not directly imported but it used the main entry point of maxGraph instead.
