### PR TITLE
chore: declare @maxgraph/core as a module package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,7 @@
   "license": "Apache-2.0",
   "private": false,
   "version": "0.10.0",
+  "type": "module",
   "description": "maxGraph is a fully client side JavaScript diagramming library that uses SVG and HTML for rendering.",
   "keywords": [
     "browser",


### PR DESCRIPTION
The dist folder only contains ESM files and the package.json only declare ESM exports with properties:
  - module
  - exports

Declaring the package as a module will help application that want to add test written in ESM (for example with Jest) to correctly import and run the maxGraph dependency.

### Notes

Full ESM exports were introduced in  #266