### PR TITLE
refactor!: configure StencilShape globals with dedicated settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## UNRELEASED
 
 **Breaking Changes**
-- In `StencilShape`, the `allowEval` and `defaultLocalized` static properties have been removed. Configure these properties using `StencilShapeGlobalSettings`. 
+- In `StencilShape`, the `allowEval` and `defaultLocalized` static properties have been removed. Configure these properties using `StencilShapeConfig`. 
 
 ## 0.10.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # `maxGraph` Change Log
 
+## UNRELEASED
+
+**Breaking Changes**
+- In `StencilShape`, the `allowEval` and `defaultLocalized` static properties have been removed. Configure these properties using `StencilShapeGlobalSettings`. 
+
 ## 0.10.1
 
 Release date: `2024-04-23`

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -142,7 +142,7 @@ export { default as RectangleShape } from './view/geometry/node/RectangleShape';
 export { default as RhombusShape } from './view/geometry/node/RhombusShape';
 export {
   default as StencilShape,
-  StencilShapeGlobalSettings,
+  StencilShapeConfig,
 } from './view/geometry/node/StencilShape';
 export { default as StencilShapeRegistry } from './view/geometry/node/StencilShapeRegistry';
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -140,7 +140,10 @@ export { default as HexagonShape } from './view/geometry/node/HexagonShape';
 export { default as ImageShape } from './view/geometry/node/ImageShape';
 export { default as RectangleShape } from './view/geometry/node/RectangleShape';
 export { default as RhombusShape } from './view/geometry/node/RhombusShape';
-export { default as StencilShape } from './view/geometry/node/StencilShape';
+export {
+  default as StencilShape,
+  StencilShapeGlobalSettings,
+} from './view/geometry/node/StencilShape';
 export { default as StencilShapeRegistry } from './view/geometry/node/StencilShapeRegistry';
 
 export * as constants from './util/Constants';

--- a/packages/core/src/view/geometry/Shape.ts
+++ b/packages/core/src/view/geometry/Shape.ts
@@ -32,10 +32,10 @@ import AbstractCanvas2D from '../canvas/AbstractCanvas2D';
 import SvgCanvas2D from '../canvas/SvgCanvas2D';
 import InternalEvent from '../event/InternalEvent';
 import Client from '../../Client';
-import CellState from '../cell/CellState';
-import StencilShape from './node/StencilShape';
-import CellOverlay from '../cell/CellOverlay';
-import ImageBox from '../image/ImageBox';
+import type CellState from '../cell/CellState';
+import type StencilShape from './node/StencilShape';
+import type CellOverlay from '../cell/CellOverlay';
+import type ImageBox from '../image/ImageBox';
 
 import type {
   ArrowValue,

--- a/packages/core/src/view/geometry/node/StencilShape.ts
+++ b/packages/core/src/view/geometry/node/StencilShape.ts
@@ -39,6 +39,8 @@ import { getNumber } from '../../../util/StringUtils';
 /**
  * Configure global settings for stencil shapes.
  * @experimental subject to change or removal
+ * @since 0.11.0
+ * @category Configuration
  */
 export const StencilShapeGlobalSettings = {
   /**

--- a/packages/core/src/view/geometry/node/StencilShape.ts
+++ b/packages/core/src/view/geometry/node/StencilShape.ts
@@ -38,7 +38,7 @@ import { getNumber } from '../../../util/StringUtils';
 
 /**
  * Configure global settings for stencil shapes.
- * @experimental subject to change or removal
+ * @experimental subject to change or removal. maxGraph's global configuration may be modified in the future without prior notice.
  * @since 0.11.0
  * @category Configuration
  */

--- a/packages/core/src/view/geometry/node/StencilShape.ts
+++ b/packages/core/src/view/geometry/node/StencilShape.ts
@@ -42,7 +42,7 @@ import { getNumber } from '../../../util/StringUtils';
  * @since 0.11.0
  * @category Configuration
  */
-export const StencilShapeGlobalSettings = {
+export const StencilShapeConfig = {
   /**
    * Specifies if the use of eval is allowed for evaluating text content and images.
    * Set this to `true` if stencils can not contain user input.
@@ -173,7 +173,7 @@ class StencilShape extends Shape {
     let result = this.evaluateAttribute(node, attribute, shape);
     const loc = node.getAttribute('localized');
 
-    if ((StencilShapeGlobalSettings.defaultLocalized && !loc) || loc === '1') {
+    if ((StencilShapeConfig.defaultLocalized && !loc) || loc === '1') {
       result = Translations.get(<string>result);
     }
     return result;
@@ -191,7 +191,7 @@ class StencilShape extends Shape {
     if (!result) {
       const text = getTextContent(<Text>(<unknown>node));
 
-      if (text && StencilShapeGlobalSettings.allowEval) {
+      if (text && StencilShapeConfig.allowEval) {
         const funct = eval(text);
 
         if (typeof funct === 'function') {

--- a/packages/core/src/view/geometry/node/StencilShape.ts
+++ b/packages/core/src/view/geometry/node/StencilShape.ts
@@ -37,6 +37,25 @@ import { AlignValue, ColorValue, VAlignValue } from '../../../types';
 import { getNumber } from '../../../util/StringUtils';
 
 /**
+ * Configure global settings for stencil shapes.
+ * @experimental subject to change or removal
+ */
+export const StencilShapeGlobalSettings = {
+  /**
+   * Specifies if the use of eval is allowed for evaluating text content and images.
+   * Set this to `true` if stencils can not contain user input.
+   * @default false
+   */
+  allowEval: false,
+
+  /**
+   * Specifies the default value for the localized attribute of the text element.
+   * @default false
+   */
+  defaultLocalized: false,
+};
+
+/**
  * Implements a generic shape which is based on a XML node as a description.
  *
  * @class StencilShape
@@ -50,25 +69,12 @@ class StencilShape extends Shape {
   }
 
   /**
-   * Static global variable that specifies the default value for the localized
-   * attribute of the text element. Default is false.
-   */
-  static defaultLocalized = false;
-
-  /**
-   * Static global switch that specifies if the use of eval is allowed for
-   * evaluating text content and images. Default is false. Set this to true
-   * if stencils can not contain user input.
-   */
-  static allowEval = false;
-
-  /**
    * Holds the XML node with the stencil description.
    */
   desc: Element;
 
   /**
-   * Holds an array of {@link ConnectionConstraints} as defined in the shape.
+   * Holds an array of {@link ConnectionConstraint}s as defined in the shape.
    */
   constraints: ConnectionConstraint[] = [];
 
@@ -168,7 +174,7 @@ class StencilShape extends Shape {
     let result = this.evaluateAttribute(node, attribute, shape);
     const loc = node.getAttribute('localized');
 
-    if ((StencilShape.defaultLocalized && !loc) || loc === '1') {
+    if ((StencilShapeGlobalSettings.defaultLocalized && !loc) || loc === '1') {
       result = Translations.get(<string>result);
     }
     return result;
@@ -186,7 +192,7 @@ class StencilShape extends Shape {
     if (!result) {
       const text = getTextContent(<Text>(<unknown>node));
 
-      if (text && StencilShape.allowEval) {
+      if (text && StencilShapeGlobalSettings.allowEval) {
         const funct = eval(text);
 
         if (typeof funct === 'function') {

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -16,6 +16,11 @@
     "out": "build/api",
     "readme": "none",
     "excludeExternals": true,
-    "excludePrivate": true
+    "excludePrivate": true,
+    "categoryOrder": ["Configuration", "*"],
+    "categorizeByGroup": false,
+    "navigation": {
+      "includeCategories": false, // not enough categories to warrant this
+    },
   }
 }

--- a/packages/ts-example/vite.config.js
+++ b/packages/ts-example/vite.config.js
@@ -27,7 +27,7 @@ export default defineConfig(({ mode }) => {
           },
         },
       },
-      chunkSizeWarningLimit: 468, // @maxgraph/core
+      chunkSizeWarningLimit: 462, // @maxgraph/core
     },
   };
 });

--- a/packages/website/docs/usage/migrate-from-mxgraph.md
+++ b/packages/website/docs/usage/migrate-from-mxgraph.md
@@ -141,7 +141,7 @@ Additionally, some shape properties have been renamed:
 
 #### `mxStencil` to `StencilShape`
 
-In maxGraph@0.11.0, the `allowEval` and `defaultLocalized` properties have been removed. Configure these properties using `StencilShapeGlobalSettings`.
+In maxGraph@0.11.0, the `allowEval` and `defaultLocalized` properties have been removed. Configure these properties using `StencilShapeConfig`.
 
 
 ### `mxUtils` split

--- a/packages/website/docs/usage/migrate-from-mxgraph.md
+++ b/packages/website/docs/usage/migrate-from-mxgraph.md
@@ -126,17 +126,23 @@ The `strokewidth` property has been renamed to `strokeWidth` in `maxGraph`.
 
 The shape names in `maxGraph` have been updated to have a consistent postfix. Please update the shape names in your code as follows:
 
-- `mxRectangleShape` should be updated to `RectangleShape`.
-- `mxImageShape` should be updated to `ImageShape`.
-- `mxEllipse` should be updated to `EllipseShape`.
-- `mxRhombus` should be updated to `RhombusShape`.
-- `mxMarker` should be updated to `MarkerShape`.
 - `mxConnector` should be updated to `ConnectorShape`.
+- `mxEllipse` should be updated to `EllipseShape`.
+- `mxImageShape` should be updated to `ImageShape`.
+- `mxRectangleShape` should be updated to `RectangleShape`.
+- `mxMarker` should be updated to `MarkerShape`.
+- `mxRhombus` should be updated to `RhombusShape`.
+- `mxStencil` should be updated to `StencilShape`.
 - `mxText` should be updated to `TextShape`.
 
 Additionally, some shape properties have been renamed:
 
 - The `strokewidth` property should now be replaced by `strokeWidth`.
+
+#### `mxStencil` to `StencilShape`
+
+In maxGraph@0.11.0, the `allowEval` and `defaultLocalized` properties have been removed. Configure these properties using `StencilShapeGlobalSettings`.
+
 
 ### `mxUtils` split
 Several functions in `mxUtils` have been moved to their own namespaces in `maxGraph`. Some remain in `utils`.


### PR DESCRIPTION
Introduce `StencilShapeConfig` value object to replace static properties in `StencilShape`.

This improves the tree-shaking with some bundlers (esbuild, rollup, ...) that don't tree-shake some classes exposing static properties in some cases.
This is the main motivation for this change.


BREAKING CHANGES:
In `StencilShape`, the `allowEval` and `defaultLocalized` static properties have been removed. Configure these properties using `StencilShapeConfig`.


## Notes

In ts-example, here are the size of the maxGraph chunk (built with Vite/esbuild):
- before 468.47 kB (a52e1a31 v0.10.1)
- after  461.07 kB (c52584c)

Notice that I haven't seen any change in the bundle size of js-example (built with webpack), which is probably more conservative (remember that maxGraph is currently declared as "not side effects free", so tree-shaking is not optimal).