### PR TITLE
fix: correctly set the default CSS class name for MaxWindow

### DIFF
--- a/packages/core/css/common.css
+++ b/packages/core/css/common.css
@@ -25,7 +25,7 @@ div.mxRubberband {
 	padding: 0px;
 	margin: 0px;
 }
-div.MaxWindow {
+div.mxWindow {
 	-webkit-box-shadow: 3px 3px 12px #C0C0C0;
 	-moz-box-shadow: 3px 3px 12px #C0C0C0;
 	box-shadow: 3px 3px 12px #C0C0C0;
@@ -36,7 +36,7 @@ div.MaxWindow {
 	overflow: hidden;
 	z-index: 1;
 }
-table.MaxWindow {
+table.mxWindow {
 	border-collapse: collapse;
 	table-layout: fixed;
   	font-family: Arial;

--- a/packages/core/src/gui/MaxWindow.ts
+++ b/packages/core/src/gui/MaxWindow.ts
@@ -188,7 +188,7 @@ class MaxWindow extends EventSource {
     minimizable = true,
     movable = true,
     replaceNode: HTMLElement | null = null,
-    style = ''
+    style?: string
   ) {
     super();
 
@@ -235,7 +235,7 @@ class MaxWindow extends EventSource {
     y: number,
     width: number | null = null,
     height: number | null = null,
-    style = 'MaxWindow'
+    style = 'mxWindow'
   ): void {
     this.div = document.createElement('div');
     this.div.className = style;

--- a/packages/html/stories/HelloPort.stories.ts
+++ b/packages/html/stories/HelloPort.stories.ts
@@ -32,8 +32,7 @@ import {
   rubberBandValues,
 } from './shared/args.js';
 import { configureImagesBasePath, createGraphContainer } from './shared/configure.js';
-// style required by RubberBand and popup
-import '@maxgraph/core/css/common.css';
+import '@maxgraph/core/css/common.css'; // style required by RubberBand and popup
 
 export default {
   title: 'Connections/HelloPort',

--- a/packages/html/stories/JsonData.stories.ts
+++ b/packages/html/stories/JsonData.stories.ts
@@ -34,8 +34,7 @@ import {
   rubberBandValues,
 } from './shared/args.js';
 import { configureImagesBasePath, createGraphContainer } from './shared/configure.js';
-// style required by RubberBand
-import '@maxgraph/core/css/common.css';
+import '@maxgraph/core/css/common.css'; // style required by RubberBand and popup
 
 export default {
   title: 'Xml_Json/JsonData',

--- a/packages/html/stories/UserObject.stories.ts
+++ b/packages/html/stories/UserObject.stories.ts
@@ -39,6 +39,7 @@ import {
   rubberBandValues,
 } from './shared/args.js';
 import { configureImagesBasePath, createGraphContainer } from './shared/configure.js';
+import '@maxgraph/core/css/common.css'; // style required by popup
 
 export default {
   title: 'Xml_Json/UserObject',

--- a/packages/html/stories/Window.stories.js
+++ b/packages/html/stories/Window.stories.js
@@ -33,8 +33,7 @@ import {
   rubberBandValues,
 } from './shared/args.js';
 import { configureImagesBasePath, createGraphContainer } from './shared/configure.js';
-// style required by RubberBand
-import '@maxgraph/core/css/common.css';
+import '@maxgraph/core/css/common.css'; // style required by RubberBand and MaxWindow/MaxLog
 
 export default {
   title: 'Windows/Windows',

--- a/packages/html/stories/Window.stories.js
+++ b/packages/html/stories/Window.stories.js
@@ -93,6 +93,7 @@ const Template = ({ label, ...args }) => {
   wnd.setMaximizable(true);
   wnd.setResizable(true);
   wnd.setVisible(true);
+  wnd.setClosable(true);
 
   const lorem =
     'Lorem ipsum dolor sit amet, consectetur adipisici elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquid ex ea commodi consequat. Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. ';
@@ -113,6 +114,7 @@ const Template = ({ label, ...args }) => {
   wnd.setScrollable(true);
   wnd.setResizable(true);
   wnd.setVisible(true);
+  wnd.setClosable(true);
 
   content = content.cloneNode(true);
   content.style.width = '400px';
@@ -131,6 +133,7 @@ const Template = ({ label, ...args }) => {
   wnd.setScrollable(true);
   wnd.setResizable(true);
   wnd.setVisible(true);
+  wnd.setClosable(true);
 
   MaxLog.show();
 

--- a/packages/html/stories/Window.stories.ts
+++ b/packages/html/stories/Window.stories.ts
@@ -49,7 +49,7 @@ export default {
   },
 };
 
-const Template = ({ label, ...args }) => {
+const Template = ({ label, ...args }: Record<string, string>) => {
   configureImagesBasePath();
   const container = createGraphContainer(args);
 
@@ -87,7 +87,7 @@ const Template = ({ label, ...args }) => {
   graph.batchUpdate(() => {
     const v1 = graph.insertVertex(parent, null, 'Hello,', 20, 20, 80, 30);
     const v2 = graph.insertVertex(parent, null, 'World!', 200, 150, 80, 30);
-    const e1 = graph.insertEdge(parent, null, '', v1, v2);
+    graph.insertEdge(parent, null, '', v1, v2);
   });
 
   wnd.setMaximizable(true);
@@ -116,7 +116,7 @@ const Template = ({ label, ...args }) => {
   wnd.setVisible(true);
   wnd.setClosable(true);
 
-  content = content.cloneNode(true);
+  content = content.cloneNode(true) as HTMLDivElement;
   content.style.width = '400px';
 
   wnd = new MaxWindow(


### PR DESCRIPTION
Restore the class name used in mxGraph to increase compatibility.
Previously, the default value was empty.

Also update the CSS rules common.css to correctly use the `mxWindow` classes.
This restores the original mxGraph CSS content which should ease the migration.

Notice that this change allows to fix the stories involving `MaxWindow`:
  - HelloPort
  - JSonData
  - UserObjects
  - Windows

The Windows story has been migrated to TypeScript to ease the maintenance.
The popup are now made closable. Currently, when switching from the Windows story to another one, the popup are not destroyed and are still displayed in the other story. Making them closable provide a visual workaround to remove them manually.
Solving this problem is outside the scope of the changes proposed here. It also has an impact on all stories using `MaxWindow` or other additions of graphical elements to the graph (like `MaxPopupMenu`, for example).

## Notes

mxGraph implementation: https://github.com/jgraph/mxgraph/blob/v4.2.2/javascript/src/js/util/mxWindow.js#L311
About popup not removed when quiting the story, see also #400.


### Fixes in Stories

Story | before fix | after fix
---- | ---- | ----
UserObjects | ![maxGraph_story_UserObjects_01_before_fix](https://github.com/maxGraph/maxGraph/assets/27200110/b0e2a978-1d09-46ca-afe1-c2dd27c8f55c) | ![maxGraph_story_UserObjects_02_after_fix](https://github.com/maxGraph/maxGraph/assets/27200110/0cc4bd62-f437-48e1-a85f-f15ffa1d6c78)
Windows | ![maxgraph_story_windows_01_before_fix](https://github.com/maxGraph/maxGraph/assets/27200110/53ba63d1-7b0f-406a-a486-82c7fbd6d462) | ![maxgraph_story_windows_02_after_fix](https://github.com/maxGraph/maxGraph/assets/27200110/9abf9d6c-095e-4a74-a99f-c53d9f29b107)


