### PR TITLE
fix: correctly resolve 'none' values of CellStyle properties

### DIFF
--- a/packages/core/__tests__/view/style/StyleSheet.test.ts
+++ b/packages/core/__tests__/view/style/StyleSheet.test.ts
@@ -199,25 +199,27 @@ describe('getCellStyle', () => {
   });
 
   // This was the mxGraph behaviour, see https://github.com/jgraph/mxgraph/blob/v4.2.2/javascript/src/js/view/mxStylesheet.js#L236-L239
-  test('Setting properties with "none" value fallback to property value of the default and "base" styles', () => {
+  test('Setting properties with "none" value remove the property value', () => {
     const stylesheet = new Stylesheet();
     stylesheet.putCellStyle('style-1', {
       fillColor: 'orange',
+      rounded: true,
     });
 
     const cellStyle = stylesheet.getCellStyle(
       {
         baseStyleNames: ['style-1'],
         fillColor: NONE,
+        gradientColor: NONE, // not set in default and baseStyles
         shape: 'cloud',
         strokeColor: NONE,
       },
-      { strokeColor: 'pink' }
+      { opacity: 50, strokeColor: 'pink' }
     );
     expect(cellStyle).toStrictEqual({
-      fillColor: 'orange',
+      opacity: 50, // from default
+      rounded: true, // from style-1
       shape: 'cloud',
-      strokeColor: 'pink',
     });
   });
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -197,7 +197,7 @@ export type CellStateStyle = {
   endFill?: boolean;
   /**
    * Set the fill color of the end arrow marker if {@link endFill} is `true`.
-   * If not set, use {@link startStrokeColor}.
+   * If not set, use {@link strokeColor}.
    * @since 0.10.0
    */
   endFillColor?: ColorValue;
@@ -257,11 +257,13 @@ export type CellStateStyle = {
    */
   exitY?: number;
   /**
-   * The possible values are all HTML color names or HEX codes, as well as special keywords such
-   * as `swimlane`, `inherit`, `indicated` to use the color code of a related cell or the
-   * indicator shape.
+   * The possible values are all HTML color names or HEX codes, as well as special keywords such as:
+   * - `indicated` to use the color of a related cell or the indicator shape
+   * - `inherit` to use the color of the direct parent cell
+   * - `none` for no color
+   * - `swimlane` to use the color of the parent swimlane if one exists in the parent hierarchy
    */
-  fillColor?: ColorValue;
+  fillColor?: SpecialStyleColorValue;
   /**
    * Possible range is `0-100`.
    */
@@ -290,9 +292,13 @@ export type CellStateStyle = {
    */
   foldable?: boolean;
   /**
-   * The possible values are all HTML color names or HEX codes.
+   * The possible values are all HTML color names or HEX codes, as well as special keywords such as:
+   * - `indicated` to use the color of a related cell or the indicator shape
+   * - `inherit` to use the color of the direct parent cell
+   * - `none` for no color
+   * - `swimlane` to use the color of the parent swimlane if one exists in the parent hierarchy
    */
-  fontColor?: ColorValue;
+  fontColor?: SpecialStyleColorValue;
   /**
    * The possible values are names such as `Arial; Dialog; Verdana; Times New Roman`.
    */
@@ -312,9 +318,13 @@ export type CellStateStyle = {
    */
   glass?: boolean;
   /**
-   * The possible values are all HTML color names or HEX codes.
+   * The possible values are all HTML color names or HEX codes, as well as special keywords such as:
+   * - `indicated` to use the color of a related cell or the indicator shape
+   * - `inherit` to use the color of the direct parent cell
+   * - `none` for no color
+   * - `swimlane` to use the color of the parent swimlane if one exists in the parent hierarchy
    */
-  gradientColor?: ColorValue;
+  gradientColor?: SpecialStyleColorValue;
   /**
    * Generally, and by default in maxGraph, gradient painting is done from the value of {@link fillColor} to the value of {@link gradientColor}.
    * If we take the example of 'north', this means that the {@link fillColor} color is at the bottom of paint pattern
@@ -733,11 +743,13 @@ export type CellStateStyle = {
    */
   startSize?: number;
   /**
-   * The possible values are all HTML color names or HEX codes, as well as special keywords such
-   * as `swimlane`, `inherit`, `indicated` to use the color code of a related cell or the
-   * indicator shape or `none` for no color.
+   * The possible values are all HTML color names or HEX codes, as well as special keywords such as:
+   * - `indicated` to use the color of a related cell or the indicator shape
+   * - `inherit` to use the color of the direct parent cell
+   * - `none` for no color
+   * - `swimlane` to use the color of the parent swimlane if one exists in the parent hierarchy
    */
-  strokeColor?: ColorValue;
+  strokeColor?: SpecialStyleColorValue;
   /**
    * The possible range is `0-100`.
    */
@@ -752,7 +764,7 @@ export type CellStateStyle = {
   /**
    * The fill color of the `swimlane` background.
    * The possible values are all HTML color names or HEX codes.
-   * @default no backgroune
+   * @default no background
    */
   swimlaneFillColor?: ColorValue;
   /**
@@ -841,6 +853,14 @@ export type NumericCellStateStyleKeys = NonNullable<
 >;
 
 export type ColorValue = string;
+/** Color values and special placeholders used to resolve colors (see {@link CellRenderer.resolveColor}) for style properties. */
+export type SpecialStyleColorValue =
+  | 'indicated'
+  | 'inherit'
+  | 'none'
+  | 'swimlane'
+  | (string & {});
+
 export type DirectionValue = 'north' | 'south' | 'east' | 'west';
 export type TextDirectionValue = '' | 'ltr' | 'rtl' | 'auto';
 export type AlignValue = 'left' | 'center' | 'right';

--- a/packages/core/src/view/style/Stylesheet.ts
+++ b/packages/core/src/view/style/Stylesheet.ts
@@ -164,6 +164,9 @@ export class Stylesheet {
    *   - registered styles referenced in `baseStyleNames`, in the order of the array
    *   - `cellStyle` parameter
    *
+   * To fully unset a style property i.e. the property is not set even if a value is set in the default style or in the referenced styles,
+   * set the `cellStyle` property to `none`. For example. `cellStyle.fillColor = 'none'`
+   *
    * @param cellStyle An object that represents the style.
    * @param defaultStyle Default style used as reference to compute the returned style.
    */
@@ -186,15 +189,13 @@ export class Stylesheet {
     }
 
     // Merges cellStyle into style
-    const filteredCellStyle = clone(cellStyle); // Clones the cellStyle to avoid modifying the original object pass as parameter
-    for (const key of Object.keys(filteredCellStyle)) {
-      (filteredCellStyle[key] === undefined || filteredCellStyle[key] == NONE) &&
-        delete filteredCellStyle[key];
+    for (const key of Object.keys(cellStyle)) {
+      // @ts-ignore
+      if (cellStyle[key] !== undefined) {
+        // @ts-ignore
+        cellStyle[key] == NONE ? delete style[key] : (style[key] = cellStyle[key]);
+      }
     }
-    style = {
-      ...style,
-      ...filteredCellStyle,
-    };
 
     // Remove the 'baseStyleNames' that may have been copied from the cellStyle parameter to match the method signature
     'baseStyleNames' in style && delete style.baseStyleNames;

--- a/packages/html/stories/ColorStylePlaceHolders.stories.ts
+++ b/packages/html/stories/ColorStylePlaceHolders.stories.ts
@@ -1,6 +1,5 @@
 /*
-Copyright 2021-present The maxGraph project Contributors
-Copyright (c) 2006-2020, JGraph Ltd
+Copyright 2024-present The maxGraph project Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,11 +16,7 @@ limitations under the License.
 
 import { constants, Graph } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
-import {
-  configureExpandedAndCollapsedImages,
-  configureImagesBasePath,
-  createGraphContainer,
-} from './shared/configure.js';
+import { configureImagesBasePath, createGraphContainer } from './shared/configure.js';
 
 export default {
   title: 'Styles/ColorStylePlaceHolders',
@@ -41,23 +36,12 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   const graph = new Graph(container);
 
   // Disables global features
-  // graph.options.collapseToPreferredSize = false;
-  configureExpandedAndCollapsedImages(graph);
-
-  // graph.constrainChildren = false;
   graph.cellsSelectable = false;
   graph.cellsLocked = true;
-  // graph.extendParentsOnAdd = false;
-  // graph.extendParents = false;
-  // graph.border = 10;
 
   // Sets global styles
   const defaultVertexStyle = graph.getStylesheet().getDefaultVertexStyle();
   defaultVertexStyle.foldable = false;
-
-  const defaultEdgeStyle = graph.getStylesheet().getDefaultEdgeStyle();
-  defaultEdgeStyle.edgeStyle = constants.EDGESTYLE.ELBOW;
-  defaultEdgeStyle.rounded = true;
 
   graph.getStylesheet().putCellStyle('swimlane', {
     shape: constants.SHAPE.SWIMLANE,

--- a/packages/html/stories/ColorStylePlaceHolders.stories.ts
+++ b/packages/html/stories/ColorStylePlaceHolders.stories.ts
@@ -1,0 +1,139 @@
+/*
+Copyright 2021-present The maxGraph project Contributors
+Copyright (c) 2006-2020, JGraph Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { constants, Graph } from '@maxgraph/core';
+import { globalTypes, globalValues } from './shared/args.js';
+import {
+  configureExpandedAndCollapsedImages,
+  configureImagesBasePath,
+  createGraphContainer,
+} from './shared/configure.js';
+
+export default {
+  title: 'Styles/ColorStylePlaceHolders',
+  argTypes: {
+    ...globalTypes,
+  },
+  args: {
+    ...globalValues,
+  },
+};
+
+const Template = ({ label, ...args }: Record<string, string>) => {
+  configureImagesBasePath();
+  const container = createGraphContainer(args);
+
+  // Creates the graph inside the given container
+  const graph = new Graph(container);
+
+  // Disables global features
+  // graph.options.collapseToPreferredSize = false;
+  configureExpandedAndCollapsedImages(graph);
+
+  // graph.constrainChildren = false;
+  graph.cellsSelectable = false;
+  graph.cellsLocked = true;
+  // graph.extendParentsOnAdd = false;
+  // graph.extendParents = false;
+  // graph.border = 10;
+
+  // Sets global styles
+  const defaultVertexStyle = graph.getStylesheet().getDefaultVertexStyle();
+  defaultVertexStyle.foldable = false;
+
+  const defaultEdgeStyle = graph.getStylesheet().getDefaultEdgeStyle();
+  defaultEdgeStyle.edgeStyle = constants.EDGESTYLE.ELBOW;
+  defaultEdgeStyle.rounded = true;
+
+  graph.getStylesheet().putCellStyle('swimlane', {
+    shape: constants.SHAPE.SWIMLANE,
+    startSize: 30,
+    fillColor: '#ffffff',
+    strokeColor: 'red',
+    swimlaneLine: true,
+    swimlaneFillColor: '#ffffff',
+  });
+
+  // Gets the default parent for inserting new cells. This
+  // is normally the first child of the root (ie. layer 0).
+  const parent = graph.getDefaultParent();
+
+  // Adds cells to the model in a single step
+  graph.batchUpdate(() => {
+    const swimlane = graph.insertVertex(parent, null, 'swimlane', 0, 0, 640, 400, {
+      baseStyleNames: ['swimlane'],
+    });
+
+    const parentInSwimlane = graph.insertVertex({
+      parent: swimlane,
+      value: 'Parent in swimlane',
+      position: [20, 80],
+      size: [400, 230],
+      style: { fillColor: '#e8dbdb', strokeColor: 'black' },
+    });
+
+    graph.insertVertex({
+      parent: parentInSwimlane,
+      value: 'child with none stroke color',
+      position: [10, 10],
+      size: [180, 30],
+      style: { strokeColor: 'none' },
+    });
+
+    graph.insertVertex({
+      parent: parentInSwimlane,
+      value: 'child with swimlane stroke color',
+      position: [205, 60],
+      size: [180, 30],
+      style: { strokeColor: 'swimlane' },
+    });
+    graph.insertVertex({
+      parent: parentInSwimlane,
+      value: 'child with swimlane fill color',
+      position: [10, 60],
+      size: [180, 30],
+      style: { fillColor: 'swimlane' },
+    });
+
+    graph.insertVertex({
+      parent: parentInSwimlane,
+      value: 'child with inherit stroke color',
+      position: [10, 160],
+      size: [180, 30],
+      style: { strokeColor: 'inherit' },
+    });
+    graph.insertVertex({
+      parent: parentInSwimlane,
+      value: 'child with inherit fill color',
+      position: [205, 160],
+      size: [180, 30],
+      style: { fillColor: 'inherit' },
+    });
+
+    graph.insertVertex({
+      // parent: swimlane,
+      value: 'vertex with none fill color',
+      position: [10, 410],
+      size: [180, 30],
+      style: { fillColor: 'none' },
+    });
+  });
+
+  return container;
+};
+
+export const Default = Template.bind({});


### PR DESCRIPTION
The 'none' values were previously equivalent to 'undefined' values, so the values fallback to the default or baseStyle values, instead of not being set. The fix restore the documented behavior.

Also introduce
  - a new type for CellStyle color properties that support placeholders
  - a new Story which demonstrates the usage of 'none' and placeholders

## Notes

Detected in #406
Bug introduced in #383, due to a misinterpretation of the former mxGraph implementation.

Original mxGraph's behavior:
- documentation: https://github.com/jgraph/mxgraph/blob/v4.2.2/javascript/src/js/view/mxStylesheet.js#L42-L43
- code: https://github.com/jgraph/mxgraph/blob/v4.2.2/javascript/src/js/view/mxStylesheet.js#L236-L239

## New story

![Styles _ ColorStylePlaceHolders - Default ⋅ Storybook](https://github.com/maxGraph/maxGraph/assets/27200110/c8f743bb-9cda-45a6-925a-e9ac8373ef9c)

