### PR TITLE
fix: display the collapse/expand images in the Toolbar story

### DIFF
--- a/packages/html/stories/Toolbar.stories.ts
+++ b/packages/html/stories/Toolbar.stories.ts
@@ -35,7 +35,11 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
-import { createGraphContainer } from './shared/configure.js';
+import {
+  configureExpandedAndCollapsedImages,
+  configureImagesBasePath,
+  createGraphContainer,
+} from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -52,6 +56,7 @@ export default {
 };
 
 const Template = ({ label, ...args }: { [p: string]: any }) => {
+  configureImagesBasePath();
   const div = document.createElement('div');
   const container = createGraphContainer(args);
   div.appendChild(container);
@@ -80,6 +85,7 @@ const Template = ({ label, ...args }: { [p: string]: any }) => {
   // using the fastest rendering available on the browser
   const model = new GraphDataModel();
   const graph = new Graph(container, model);
+  configureExpandedAndCollapsedImages(graph);
   graph.dropEnabled = true;
 
   // Matches DnD inside the graph


### PR DESCRIPTION
They didn't display when adding children to a swimlane.


## Notes

Covers #73


![Toolbar_story_fix_display_collpase-expand_buttons](https://github.com/maxGraph/maxGraph/assets/27200110/88af1a53-14ab-4b14-b15b-8cd7c2573f72)
