### PR TITLE
fix: prevent error when not passing "mapping" to Graph.cloneCell

### DIFF
--- a/packages/core/src/view/handler/ConnectionHandler.ts
+++ b/packages/core/src/view/handler/ConnectionHandler.ts
@@ -534,7 +534,7 @@ class ConnectionHandler extends EventSource implements GraphPlugin {
   /**
    * Starts a new connection for the given state and coordinates.
    */
-  start(state: CellState, x: number, y: number, edgeState: CellState) {
+  start(state: CellState, x: number, y: number, edgeState?: CellState) {
     this.previous = state;
     this.first = new Point(x, y);
     this.edgeState = edgeState ?? this.createEdgeState();
@@ -1806,7 +1806,10 @@ class ConnectionHandler extends EventSource implements GraphPlugin {
         }
       } catch (e) {
         MaxLog.show();
-        // MaxLog.debug(e.message);
+        const errorMessage = `Error in ConnectionHandler: ${
+          e instanceof Error ? e.message + '\n' + e.stack : 'unknown cause'
+        }`;
+        MaxLog.debug(errorMessage);
       } finally {
         model.endUpdate();
       }

--- a/packages/core/src/view/mixins/CellsMixin.ts
+++ b/packages/core/src/view/mixins/CellsMixin.ts
@@ -880,20 +880,20 @@ export const CellsMixin: PartialType = {
   /**
    * Returns the clone for the given cell. Uses {@link cloneCells}.
    *
-   * @param cell {@link mxCell} to be cloned.
+   * @param cell {@link Cell} to be cloned.
    * @param allowInvalidEdges Optional boolean that specifies if invalid edges
    * should be cloned. Default is `true`.
    * @param mapping Optional mapping for existing clones.
    * @param keepPosition Optional boolean indicating if the position of the cells should
    * be updated to reflect the lost parent cell. Default is `false`.
    */
-  cloneCell(cell, allowInvalidEdges = false, mapping = null, keepPosition = false) {
+  cloneCell(cell, allowInvalidEdges = false, mapping = {}, keepPosition = false) {
     return this.cloneCells([cell], allowInvalidEdges, mapping, keepPosition)[0];
   },
 
   /**
    * Returns the clones for the given cells. The clones are created recursively
-   * using {@link mxGraphModel.cloneCells}. If the terminal of an edge is not in the
+   * using {@link cloneCells}. If the terminal of an edge is not in the
    * given array, then the respective end is assigned a terminal point and the
    * terminal is removed.
    *


### PR DESCRIPTION
Previously, this generated an error in `ConnectionHandler` because the default mapping value was invalid (null is not allowed) and the error opened a MaxLog without error message. ConnectionHandler has been updated to better track such an error.

The `ContexIcons` story exhibited the problem. It is now fully working. It has also been migrated to TypeScript to ease future maintenance.

Also update the `ConnectionHandler.start` method signature as part of the migration of the story to TypeScript.
The `edgeState` parameter can now be undefined, a default value was already managed in code.


## Notes

Closes #73
The fix was inspired by inspired from https://github.com/maxGraph/maxGraph/pull/88/commits/0bdae3b0ff7ba8e34431c1707876befb2202b940

![ContextIcons_work](https://github.com/maxGraph/maxGraph/assets/27200110/b2f9524c-9ebe-4975-97f7-68705413b094)

