### PR TITLE
feat: allow to drag edge in the Toolbar story

### DIFF
--- a/packages/core/src/view/geometry/Geometry.ts
+++ b/packages/core/src/view/geometry/Geometry.ts
@@ -121,31 +121,34 @@ class Geometry extends Rectangle {
    * Array of {@link Point} which specifies the control points along the edge.
    * These points are the intermediate points on the edge, for the endpoints
    * use {@link targetPoint} and {@link sourcePoint} or set the terminals of the edge to
-   * a non-null value. Default is null.
+   * a non-null value.
+   * @default null
    */
   points: Point[] | null = null;
 
   /**
-   * For edges, this holds the offset (in pixels) from the position defined
-   * by {@link x} and {@link y} on the edge. For relative geometries (for vertices), this
-   * defines the absolute offset from the point defined by the relative
-   * coordinates. For absolute geometries (for vertices), this defines the
-   * offset for the label. Default is null.
+   * For edges, this holds the offset (in pixels) from the position defined by {@link x} and {@link y} on the edge.
+   *
+   * For relative geometries (for vertices), this defines the absolute offset from the point defined by the relative
+   * coordinates.
+   *
+   * For absolute geometries (for vertices), this defines the offset for the label.
+   * @default null
    */
   offset: Point | null = null;
 
   /**
-   * Specifies if the coordinates in the geometry are to be interpreted as
-   * relative coordinates. For edges, this is used to define the location of
-   * the edge label relative to the edge as rendered on the display. For
-   * vertices, this specifies the relative location inside the bounds of the
-   * parent cell.
+   * Specifies if the coordinates in the geometry are to be interpreted as relative coordinates.
    *
-   * If this is false, then the coordinates are relative to the origin of the
-   * parent cell or, for edges, the edge label position is relative to the
-   * center of the edge as rendered on screen.
+   * For edges, this is used to define the location of the edge label relative to the edge
+   * as rendered on the display.
    *
-   * Default is false.
+   * For vertices, this specifies the relative location inside the bounds of the parent cell.
+   *
+   * If this is `false`, then the coordinates are relative to the origin of the parent cell or,
+   * for edges, the edge label position is relative to the center of the edge as rendered on screen.
+   *
+   * @default false.
    */
   relative = false;
 
@@ -160,7 +163,7 @@ class Geometry extends Rectangle {
    * existing geometry instance. If this operation is called during a graph
    * model transactional change, then the geometry should be cloned before
    * calling this method and setting the geometry of the cell using
-   * {@link mxGraphModel.setGeometry}.
+   * {@link GraphDataModel.setGeometry}.
    */
   swap() {
     if (this.alternateBounds) {

--- a/packages/core/src/view/geometry/Geometry.ts
+++ b/packages/core/src/view/geometry/Geometry.ts
@@ -23,10 +23,6 @@ import { equalPoints } from '../../util/arrayUtils';
 import { clone } from '../../util/cloneUtils';
 
 /**
- * @class Geometry
- *
- * @extends {Rectangle}
- *
  * For vertices, the geometry consists of the x- and y-location, and the width
  * and height. For edges, the geometry consists of the optional terminal- and
  * control points. The terminal points are only required if an edge is
@@ -49,8 +45,7 @@ import { clone } from '../../util/cloneUtils';
  * be ignored or interpreted differently depending on the edge's {@link edgeStyle}.
  *
  * To disable automatic reset of control points after a cell has been moved or
- * resized, the the {@link graph.resizeEdgesOnMove} and
- * {@link graph.resetEdgesOnResize} may be used.
+ * resized, {@link graph.resetEdgesOnMove} and {@link graph.resetEdgesOnResize} may be used.
  *
  * ### Edge Labels
  *

--- a/packages/core/src/view/geometry/Geometry.ts
+++ b/packages/core/src/view/geometry/Geometry.ts
@@ -105,15 +105,15 @@ class Geometry extends Rectangle {
 
   /**
    * Defines the source {@link Point} of the edge. This is used if the
-   * corresponding edge does not have a source vertex. Otherwise it is
-   * ignored. Default is  null.
+   * corresponding edge does not have a source vertex. Otherwise, it is ignored.
+   * @default null
    */
   sourcePoint: Point | null = null;
 
   /**
-   * Defines the target {@link Point} of the edge. This is used if the
-   * corresponding edge does not have a target vertex. Otherwise it is
-   * ignored. Default is null.
+   * Defines the source {@link Point} of the edge. This is used if the
+   * corresponding edge does not have a target vertex. Otherwise, it is ignored.
+   * @default null
    */
   targetPoint: Point | null = null;
 

--- a/packages/core/src/view/handler/ConnectionHandler.ts
+++ b/packages/core/src/view/handler/ConnectionHandler.ts
@@ -145,11 +145,11 @@ type FactoryMethod = (
  * mxConstants.HIGHLIGHT_COLOR = null;
  * ```
  *
- * To install the image, the connectImage field of the mxConnectionHandler must
+ * To install the image, the connectImage field of the ConnectionHandler must
  * be assigned a new {@link Image} instance:
  *
  * ```javascript
- * connectImage = new mxImage('images/green-dot.gif', 14, 14);
+ * connectImage = new ImageBox('images/green-dot.gif', 14, 14);
  * ```
  *
  * This will use the green-dot.gif with a width and height of 14 pixels as the
@@ -593,9 +593,9 @@ class ConnectionHandler extends EventSource implements GraphPlugin {
 
   /**
    * Hook to return the {@link Image} used for the connection icon of the given
-   * <CellState>. This implementation returns <connectImage>.
+   * {@link CellState}. This implementation returns {@link connectImage}.
    *
-   * @param state <CellState> whose connect image should be returned.
+   * @param state {@link CellState} whose connect image should be returned.
    */
   getConnectImage(state: CellState) {
     return this.connectImage;
@@ -615,10 +615,10 @@ class ConnectionHandler extends EventSource implements GraphPlugin {
   }
 
   /**
-   * Creates the array {@link ImageShapes} that represent the connect icons for
-   * the given <CellState>.
+   * Creates the array {@link ImageShape}s that represent the connect icons for
+   * the given {@link CellState}.
    *
-   * @param state <CellState> whose connect icons should be returned.
+   * @param state {@link CellState} whose connect icons should be returned.
    */
   createIcons(state: CellState) {
     const image = this.getConnectImage(state);

--- a/packages/html/stories/DynamicToolbar.stories.ts
+++ b/packages/html/stories/DynamicToolbar.stories.ts
@@ -20,7 +20,7 @@ import {
   Graph,
   type HTMLImageElementWithProps,
   RubberBandHandler,
-  ConnectionHandler,
+  type ConnectionHandler,
   ImageBox,
   MaxToolbar,
   GraphDataModel,
@@ -29,6 +29,7 @@ import {
   InternalEvent,
   styleUtils,
   gestureUtils,
+  Client,
 } from '@maxgraph/core';
 import {
   globalTypes,
@@ -36,9 +37,8 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
-import { createGraphContainer } from './shared/configure.js';
-// style required by RubberBand
-import '@maxgraph/core/css/common.css';
+import { configureImagesBasePath, createGraphContainer } from './shared/configure.js';
+import '@maxgraph/core/css/common.css'; // style required by RubberBand
 
 export default {
   title: 'Toolbars/DynamicToolbar',
@@ -57,6 +57,7 @@ type InternalHTMLImageElementWithProps = HTMLImageElementWithProps & {
 };
 
 const Template = ({ label, ...args }: Record<string, string>) => {
+  configureImagesBasePath();
   const div = document.createElement('div');
   div.style.display = 'flex';
 
@@ -75,14 +76,19 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   const container = createGraphContainer(args);
   div.appendChild(container);
 
-  // Defines an icon for creating new connections in the connection handler.
-  // This will automatically disable the highlighting of the source vertex.
-  ConnectionHandler.prototype.connectImage = new ImageBox('images/connector.gif', 16, 16);
-
   // Creates the model and the graph inside the container
   // using the fastest rendering available on the browser
   const model = new GraphDataModel();
   const graph = new Graph(container, model);
+
+  // Defines an icon for creating new connections in the connection handler.
+  // This will automatically disable the highlighting of the source vertex.
+  const connectionHandler = graph.getPlugin('ConnectionHandler') as ConnectionHandler;
+  connectionHandler.connectImage = new ImageBox(
+    `${Client.imageBasePath}/connector.gif`,
+    16,
+    16
+  );
 
   // Enables new connections in the graph
   graph.setConnectable(true);

--- a/packages/html/stories/HoverIcons.stories.js
+++ b/packages/html/stories/HoverIcons.stories.js
@@ -23,7 +23,7 @@ import {
   Rectangle,
   mathUtils,
   domUtils,
-  ConnectionHandler,
+  Client,
 } from '@maxgraph/core';
 import {
   globalTypes,
@@ -31,9 +31,8 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
-import { createGraphContainer } from './shared/configure.js';
-// style required by RubberBand
-import '@maxgraph/core/css/common.css';
+import { configureImagesBasePath, createGraphContainer } from './shared/configure.js';
+import '@maxgraph/core/css/common.css'; // style required by RubberBand
 
 export default {
   title: 'Icon_Images/HoverIcons',
@@ -48,11 +47,8 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
+  configureImagesBasePath();
   const container = createGraphContainer(args);
-
-  // Defines an icon for creating new connections in the connection handler.
-  // This will automatically disable the highlighting of the source vertex.
-  ConnectionHandler.prototype.connectImage = new ImageBox('images/connector.gif', 16, 16);
 
   // Defines a new class for all icons
   class mxIconSet {
@@ -122,6 +118,15 @@ const Template = ({ label, ...args }) => {
   // Creates the graph inside the given container
   const graph = new Graph(container);
   graph.setConnectable(true);
+
+  // Defines an icon for creating new connections in the connection handler.
+  // This will automatically disable the highlighting of the source vertex.
+  const connectionHandler = graph.getPlugin('ConnectionHandler');
+  connectionHandler.connectImage = new ImageBox(
+    `${Client.imageBasePath}/connector.gif`,
+    16,
+    16
+  );
 
   // Enables rubberband selection
   if (args.rubberBand) new RubberBandHandler(graph);

--- a/packages/html/stories/Permissions.stories.js
+++ b/packages/html/stories/Permissions.stories.js
@@ -17,11 +17,11 @@ limitations under the License.
 
 import {
   Graph,
-  ConnectionHandler,
   ImageBox,
   RubberBandHandler,
   KeyHandler,
   DomHelpers,
+  Client,
 } from '@maxgraph/core';
 import {
   globalTypes,
@@ -30,8 +30,7 @@ import {
   rubberBandValues,
 } from './shared/args.js';
 import { createGraphContainer } from './shared/configure.js';
-// style required by RubberBand
-import '@maxgraph/core/css/common.css';
+import '@maxgraph/core/css/common.css'; // style required by RubberBand
 
 export default {
   title: 'Misc/Permissions',
@@ -50,12 +49,16 @@ const Template = ({ label, ...args }) => {
   const container = createGraphContainer(args);
   div.appendChild(container);
 
-  // Defines an icon for creating new connections in the connection handler.
-  // This will automatically disable the highlighting of the source vertex.
-  ConnectionHandler.prototype.connectImage = new ImageBox('images/connector.gif', 16, 16);
-
   // Creates the graph inside the given container
   const graph = new Graph(container);
+  // Defines an icon for creating new connections in the connection handler.
+  // This will automatically disable the highlighting of the source vertex.
+  const connectionHandler = graph.getPlugin('ConnectionHandler');
+  connectionHandler.connectImage = new ImageBox(
+    `${Client.imageBasePath}/connector.gif`,
+    16,
+    16
+  );
 
   // Enable tooltips, disables mutligraphs, enable loops
   graph.setMultigraph(false);

--- a/packages/html/stories/SwimLanes.stories.ts
+++ b/packages/html/stories/SwimLanes.stories.ts
@@ -16,7 +16,7 @@ limitations under the License.
 */
 
 import {
-  ConnectionHandler,
+  type ConnectionHandler,
   ImageBox,
   Perimeter,
   Point,
@@ -32,6 +32,7 @@ import {
   type EventObject,
   type SelectionHandler,
   type VertexParameters,
+  Client,
 } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
 import {
@@ -56,10 +57,6 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   container.style.background = ''; // no grid
 
   InternalEvent.disableContextMenu(container);
-
-  // Defines an icon for creating new connections in the connection handler.
-  // This will automatically disable the highlighting of the source vertex.
-  ConnectionHandler.prototype.connectImage = new ImageBox('images/connector.gif', 16, 16);
 
   // Creates a wrapper editor around a new graph inside
   // the given container using an XML config for the
@@ -86,6 +83,15 @@ const Template = ({ label, ...args }: Record<string, string>) => {
 
   const graphHandler = graph.getPlugin('SelectionHandler') as SelectionHandler;
   graphHandler.setRemoveCellsFromParent(false);
+
+  // Defines an icon for creating new connections in the connection handler.
+  // This will automatically disable the highlighting of the source vertex.
+  const connectionHandler = graph.getPlugin('ConnectionHandler') as ConnectionHandler;
+  connectionHandler.connectImage = new ImageBox(
+    `${Client.imageBasePath}/connector.gif`,
+    16,
+    16
+  );
 
   // Changes the default vertex style in-place
   let style = graph.getStylesheet().getDefaultVertexStyle();

--- a/packages/html/stories/Toolbar.stories.ts
+++ b/packages/html/stories/Toolbar.stories.ts
@@ -16,18 +16,20 @@ limitations under the License.
 */
 
 import {
-  Graph,
-  RubberBandHandler,
+  Cell,
   type CellStyle,
-  ConnectionHandler,
+  Client,
+  type ConnectionHandler,
+  DomHelpers,
+  DragSource,
+  Geometry,
+  gestureUtils,
+  Graph,
+  GraphDataModel,
   ImageBox,
   MaxToolbar,
-  GraphDataModel,
-  Cell,
-  Geometry,
-  DragSource,
-  DomHelpers,
-  gestureUtils,
+  Point,
+  RubberBandHandler,
 } from '@maxgraph/core';
 import {
   globalTypes,
@@ -40,8 +42,7 @@ import {
   configureImagesBasePath,
   createGraphContainer,
 } from './shared/configure.js';
-// style required by RubberBand
-import '@maxgraph/core/css/common.css';
+import '@maxgraph/core/css/common.css'; // style required by RubberBand
 
 export default {
   title: 'Toolbars/Toolbar',
@@ -58,24 +59,20 @@ export default {
 const Template = ({ label, ...args }: { [p: string]: any }) => {
   configureImagesBasePath();
   const div = document.createElement('div');
-  const container = createGraphContainer(args);
-  div.appendChild(container);
+  div.style.display = 'flex';
+  div.style.flexDirection = 'column-reverse';
 
-  // Defines an icon for creating new connections in the connection handler.
-  // This will automatically disable the highlighting of the source vertex.
-  ConnectionHandler.prototype.connectImage = new ImageBox('images/connector.gif', 16, 16);
+  const toolbarAndGraphParentContainer = document.createElement('div');
+  toolbarAndGraphParentContainer.style.display = 'flex';
+  div.appendChild(toolbarAndGraphParentContainer);
 
   // Creates the div for the toolbar
   const tbContainer = document.createElement('div');
-  tbContainer.style.position = 'absolute';
-  tbContainer.style.overflow = 'hidden';
-  tbContainer.style.padding = '2px';
-  tbContainer.style.left = '0px';
-  tbContainer.style.top = '0px';
-  tbContainer.style.width = '24px';
-  tbContainer.style.bottom = '0px';
+  tbContainer.style.display = 'flex';
+  tbContainer.style.flexDirection = 'column';
+  tbContainer.style.marginRight = '.5rem';
 
-  div.appendChild(tbContainer);
+  toolbarAndGraphParentContainer.appendChild(tbContainer);
 
   // Creates new toolbar without event processing
   const toolbar = new MaxToolbar(tbContainer);
@@ -83,10 +80,22 @@ const Template = ({ label, ...args }: { [p: string]: any }) => {
 
   // Creates the model and the graph inside the container
   // using the fastest rendering available on the browser
+  const container = createGraphContainer(args);
+  toolbarAndGraphParentContainer.appendChild(container);
+
   const model = new GraphDataModel();
   const graph = new Graph(container, model);
   configureExpandedAndCollapsedImages(graph);
   graph.dropEnabled = true;
+
+  // Defines an icon for creating new connections in the connection handler.
+  // This will automatically disable the highlighting of the source vertex.
+  const connectionHandler = graph.getPlugin('ConnectionHandler') as ConnectionHandler;
+  connectionHandler.connectImage = new ImageBox(
+    `${Client.imageBasePath}/connector.gif`,
+    16,
+    16
+  );
 
   // Matches DnD inside the graph
   DragSource.prototype.getDropTarget = function (
@@ -111,11 +120,31 @@ const Template = ({ label, ...args }: { [p: string]: any }) => {
 
   if (args.rubberBand) new RubberBandHandler(graph);
 
-  function addVertex(icon: string, w: number, h: number, style: CellStyle) {
-    const vertex = new Cell(null, new Geometry(0, 0, w, h), style);
-    vertex.setVertex(true);
+  function addCell(
+    isVertex: boolean,
+    icon: string,
+    w: number,
+    h: number,
+    style: CellStyle
+  ) {
+    const cell = new Cell(null, new Geometry(0, 0, w, h), style);
+    cell.setVertex(isVertex);
+    cell.setEdge(!isVertex);
 
-    addToolbarItem(graph, toolbar, vertex, icon);
+    addToolbarItem(graph, toolbar, cell, icon, !isVertex ? 'Edge' : undefined);
+  }
+
+  function addVertex(icon: string, w: number, h: number, style: CellStyle) {
+    addCell(true, icon, w, h, style);
+  }
+
+  // the line is not correctly display when calling toolbar.addLine() when the toolbar is in a flex container
+  function addToolbarLine() {
+    const hr = document.createElement('hr');
+    hr.style.maxHeight = '0';
+    hr.style.minWidth = '100%';
+    hr.setAttribute('size', '1');
+    tbContainer.appendChild(hr);
   }
 
   addVertex('images/swimlane.gif', 120, 160, { shape: 'swimlane', startSize: 20 });
@@ -126,7 +155,13 @@ const Template = ({ label, ...args }: { [p: string]: any }) => {
   addVertex('images/triangle.gif', 40, 40, { shape: 'triangle' });
   addVertex('images/cylinder.gif', 40, 40, { shape: 'cylinder' });
   addVertex('images/actor.gif', 30, 40, { shape: 'actor' });
-  toolbar.addLine();
+  addToolbarLine();
+
+  function addEdge(icon: string, w: number, h: number, style: CellStyle) {
+    addCell(false, icon, w, h, style);
+  }
+  addEdge('images/entity.gif', 30, 40, {});
+  addToolbarLine();
 
   const button = DomHelpers.button('Create toolbar entry from selection', (evt) => {
     if (!graph.isSelectionEmpty()) {
@@ -153,13 +188,16 @@ const Template = ({ label, ...args }: { [p: string]: any }) => {
     }
   });
 
-  tbContainer.appendChild(button);
+  button.style.marginBottom = '1rem';
+  button.style.alignSelf = 'flex-start';
+  div.appendChild(button);
 
   function addToolbarItem(
     graph: Graph,
     toolbar: MaxToolbar,
     prototype: Cell,
-    image: string
+    image: string,
+    title?: string
   ) {
     // Function that is executed when the image is dropped on
     // the graph. The cell argument points to the cell under
@@ -168,18 +206,24 @@ const Template = ({ label, ...args }: { [p: string]: any }) => {
       graph.stopEditing(false);
 
       const pt = graph.getPointForEvent(evt);
-      const vertex = graph.getDataModel().cloneCell(prototype);
-      if (!vertex) return;
+      const cellToImport = graph.getDataModel().cloneCell(prototype);
+      if (!cellToImport) return;
 
-      if (vertex.geometry) {
-        vertex.geometry.x = pt.x;
-        vertex.geometry.y = pt.y;
+      if (cellToImport.geometry) {
+        cellToImport.geometry.x = pt.x;
+        cellToImport.geometry.y = pt.y;
+
+        if (cellToImport.isEdge()) {
+          cellToImport.geometry.sourcePoint = new Point(pt.x, pt.y);
+          cellToImport.geometry.targetPoint = new Point(pt.x + 50, pt.y + 50);
+        }
       }
-      graph.setSelectionCells(graph.importCells([vertex], 0, 0, cell));
+
+      graph.setSelectionCells(graph.importCells([cellToImport], 0, 0, cell));
     };
 
     // Creates the image which is used as the drag icon (preview)
-    const img = toolbar.addMode(null, image, funct, '');
+    const img = toolbar.addMode(title, image, funct, '');
     gestureUtils.makeDraggable(img, graph, funct);
   }
 

--- a/packages/html/stories/Toolbar.stories.ts
+++ b/packages/html/stories/Toolbar.stories.ts
@@ -160,7 +160,7 @@ const Template = ({ label, ...args }: { [p: string]: any }) => {
   function addEdge(icon: string, w: number, h: number, style: CellStyle) {
     addCell(false, icon, w, h, style);
   }
-  addEdge('images/entity.gif', 30, 40, {});
+  addEdge('images/entity.gif', 50, 50, {});
   addToolbarLine();
 
   const button = DomHelpers.button('Create toolbar entry from selection', (evt) => {
@@ -215,7 +215,10 @@ const Template = ({ label, ...args }: { [p: string]: any }) => {
 
         if (cellToImport.isEdge()) {
           cellToImport.geometry.sourcePoint = new Point(pt.x, pt.y);
-          cellToImport.geometry.targetPoint = new Point(pt.x + 50, pt.y + 50);
+          cellToImport.geometry.targetPoint = new Point(
+            pt.x + cellToImport.geometry.width,
+            pt.y + cellToImport.geometry.height
+          );
         }
       }
 


### PR DESCRIPTION
In addition, improve the design
  - correctly align the toolbar (use flex as already done in the DynamicToolbar story)
  - display the "Create toolbar entry from selection" button on top of the graph, like it was in the original mxGraph example.

Also ensure that the connect image is correctly displayed in all stories that configure it in `ConnectionHandler`:
  - DynamicToolbar
  - HoverIcons
  - Permissions
  - SwimLanes
  - Toolbar

Also add minor improvements to the JSDoc of the `Geometry` class.

## Notes

Relates to #414

### Toolbar story changes

**New design and features**

![PR_416_toolbar_story](https://github.com/maxGraph/maxGraph/assets/27200110/4ab5fa55-18aa-4ab9-bce2-c040f78d13ca)

**Previous design**

![image](https://github.com/maxGraph/maxGraph/assets/27200110/76f4e66a-51be-4aa3-a70e-5e260035b205)
