### PR TITLE
fix: remove unused `Graph.isFoldingEnabled` property

### DIFF
--- a/packages/core/src/view/Graph.ts
+++ b/packages/core/src/view/Graph.ts
@@ -96,7 +96,6 @@ class Graph extends EventSource {
 
   graphModelChangeListener: Function | null = null;
   paintBackground: Function | null = null;
-  foldingEnabled: null | boolean = null;
   isConstrainedMoving = false;
 
   // ===================================================================================================================

--- a/packages/core/src/view/other/Outline.ts
+++ b/packages/core/src/view/other/Outline.ts
@@ -325,7 +325,7 @@ class Outline {
       defaultPlugins,
       this.source.getStylesheet()
     );
-    graph.foldingEnabled = false;
+    graph.options.foldingEnabled = false;
     graph.autoScroll = false;
     return graph;
   }

--- a/packages/html/stories/Constituent.stories.js
+++ b/packages/html/stories/Constituent.stories.js
@@ -54,9 +54,11 @@ const Template = ({ label, ...args }) => {
   }
 
   class MyCustomGraph extends Graph {
-    foldingEnabled = false;
-
-    recursiveResize = true;
+    constructor(container) {
+      super(container);
+      this.options.foldingEnabled = false;
+      this.recursiveResize = true;
+    }
 
     isPart(cell) {
       // Helper method to mark parts with constituent=1 in the style

--- a/packages/html/stories/Orthogonal.stories.js
+++ b/packages/html/stories/Orthogonal.stories.js
@@ -69,7 +69,7 @@ const Template = ({ label, ...args }) => {
   // Creates the graph inside the given container
   const graph = new Graph(container);
   graph.disconnectOnMove = false;
-  graph.foldingEnabled = false;
+  graph.options.foldingEnabled = false;
   graph.cellsResizable = false;
   graph.extendParents = false;
   graph.setConnectable(true);

--- a/packages/html/stories/Wires.stories.js
+++ b/packages/html/stories/Wires.stories.js
@@ -721,7 +721,7 @@ const Template = ({ label, ...args }) => {
   graph.setConnectable(true);
   graph.setConnectableEdges(true);
   graph.setDisconnectOnMove(false);
-  graph.foldingEnabled = false;
+  graph.options.foldingEnabled = false;
 
   //Maximum size
   graph.maximumGraphBounds = new Rectangle(0, 0, 800, 600);


### PR DESCRIPTION
The property is no longer used to configure folding since version 0.1.0, and the property in the "options" property must be used instead.
It should therefore be deleted to avoid any configuration problems.
