### PR TITLE
feat!: introduce configurable logger

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,6 +32,7 @@
                 "selector": "TSEnumDeclaration[const=true]",
                 "message": "Const enums are forbidden to increase interoperability. Use regular enums instead."
             }
-        ]
+        ],
+        "no-console": "error"
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # `maxGraph` Change Log
 
+## UNRELEASED
+
+**Breaking Changes**
+- Logs are no longer sent to `MaxLog` by default. To restore the previous behavior, change maxGraph's global configuration with:
+```js
+GlobalConfig.logger = new MaxLogAsLogger();
+```
+- `MaxWindow.activeWindow` is no longer available; it was intended for internal use only, so there's no reason to make it public.
+
 ## 0.10.3
 
 Release date: `2024-05-29`

--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -859,7 +859,7 @@ export class Editor extends EventSource {
   movePropertiesDialog = false;
 
   /**
-   * Specifies if <{@link xGraph.validateGraph} should automatically be invoked after
+   * Specifies if {@link Graph.validateGraph} should automatically be invoked after
    * each change. Default is false.
    * @default false
    */

--- a/packages/core/src/gui/MaxLog.ts
+++ b/packages/core/src/gui/MaxLog.ts
@@ -22,7 +22,7 @@ import { getInnerHtml, write } from '../util/domUtils';
 import { toString } from '../util/StringUtils';
 import MaxWindow, { popup } from './MaxWindow';
 import { KeyboardEventListener, MouseEventListener } from '../types';
-import { copyTextToClipboard } from '../util/Utils';
+import { copyTextToClipboard, getElapseMillisecondsMessage } from '../util/Utils';
 
 /**
  * A singleton class that implements a simple console.
@@ -178,20 +178,20 @@ class MaxLog {
   static consoleName = 'Console';
 
   /**
-   * Specified if the output for <enter> and <leave> should be visible in the
-   * console. Default is false.
+   * Specified if the output for {@link enter} and {@link leave} should be visible in the console.
+   * @default false
    */
   static TRACE = false;
 
   /**
-   * Specifies if the output for <debug> should be visible in the console.
-   * Default is true.
+   * Specifies if the output for {@link debug} should be visible in the console.
+   * @default true
    */
   static DEBUG = true;
 
   /**
-   * Specifies if the output for <warn> should be visible in the console.
-   * Default is true.
+   * Specifies if the output for {@link warn} should be visible in the console.
+   * @default true
    */
   static WARN = true;
 
@@ -264,9 +264,9 @@ class MaxLog {
    *
    * @see {@link enter} for an example.
    */
-  static leave(string: string, t0: number) {
+  static leave(string: string, t0?: number) {
     if (MaxLog.TRACE) {
-      const dt = t0 !== 0 ? ` (${new Date().getTime() - t0} ms)` : '';
+      const dt = getElapseMillisecondsMessage(t0);
       MaxLog.writeln(`Leaving ${string}${dt}`);
     }
   }
@@ -276,6 +276,15 @@ class MaxLog {
    */
   static debug(...args: string[]) {
     if (MaxLog.DEBUG) {
+      MaxLog.writeln(...args);
+    }
+  }
+
+  /**
+   * Adds all arguments to the console if {@link TRACE} is enabled.
+   */
+  static trace(...args: string[]) {
+    if (MaxLog.TRACE) {
       MaxLog.writeln(...args);
     }
   }

--- a/packages/core/src/gui/MaxLogAsLogger.ts
+++ b/packages/core/src/gui/MaxLogAsLogger.ts
@@ -24,6 +24,7 @@ import MaxLog from './MaxLog';
  *
  * @experimental subject to change or removal. The logging system may be modified in the future without prior notice.
  * @since 0.11.0
+ * @category Logging
  */
 export class MaxLogAsLogger implements Logger {
   enter(message: string): number | undefined {

--- a/packages/core/src/gui/MaxLogAsLogger.ts
+++ b/packages/core/src/gui/MaxLogAsLogger.ts
@@ -1,0 +1,61 @@
+/*
+Copyright 2024-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { Logger } from '../types';
+import MaxLog from './MaxLog';
+
+/**
+ * A {@link Logger} that uses {@link MaxLog} to log messages.
+ *
+ * Notice that the log level for this logger are configured in {@link MaxLog}.
+ *
+ * @experimental subject to change or removal. The logging system may be modified in the future without prior notice.
+ * @since 0.11.0
+ */
+export class MaxLogAsLogger implements Logger {
+  enter(message: string): number | undefined {
+    return MaxLog.enter(message);
+  }
+
+  leave(message: string, baseTimestamp?: number): void {
+    MaxLog.leave(message, baseTimestamp);
+  }
+
+  show(): void {
+    MaxLog.show();
+  }
+
+  info(message: string): void {
+    MaxLog.writeln(message);
+  }
+
+  debug(message: string): void {
+    MaxLog.debug(message);
+  }
+
+  error(message: string, ...optionalParams: any[]): void {
+    const args = optionalParams?.map((param) => String(param));
+    MaxLog.writeln(`[ERROR] ${message}`, ...args);
+  }
+
+  trace(message: string): void {
+    MaxLog.trace(message);
+  }
+
+  warn(message: string): void {
+    MaxLog.warn(message);
+  }
+}

--- a/packages/core/src/gui/MaxWindow.ts
+++ b/packages/core/src/gui/MaxWindow.ts
@@ -29,6 +29,8 @@ import { getClientX, getClientY } from '../util/EventUtils';
 import { htmlEntities } from '../util/StringUtils';
 import { utils } from '../util/Utils';
 
+let activeWindow: MaxWindow | null = null;
+
 /**
  * Basic window inside a document.
  *
@@ -213,8 +215,6 @@ class MaxWindow extends EventSource {
       }
     }
   }
-
-  static activeWindow: MaxWindow | null = null;
 
   td!: HTMLElement;
   div!: HTMLElement;
@@ -404,21 +404,22 @@ class MaxWindow extends EventSource {
    * Puts the window on top of all other windows.
    */
   activate(): void {
-    if (MaxWindow.activeWindow !== this) {
+    if (activeWindow !== this) {
       const style = getCurrentStyle(this.getElement());
       const index = style != null ? parseInt(style.zIndex) : 3;
 
-      if (MaxWindow.activeWindow) {
-        const elt = MaxWindow.activeWindow.getElement();
+      if (activeWindow) {
+        const elt = activeWindow.getElement();
 
-        if (elt != null && elt.style != null) {
+        if (elt?.style) {
           elt.style.zIndex = String(index);
         }
       }
 
-      const previousWindow = MaxWindow.activeWindow;
+      const previousWindow = activeWindow;
       this.getElement().style.zIndex = String(index + 1);
-      MaxWindow.activeWindow = this;
+      // eslint-disable-next-line @typescript-eslint/no-this-alias -- we need to maintain the reference to the current window
+      activeWindow = this;
 
       this.fireEvent(new EventObject(InternalEvent.ACTIVATE, { previousWindow }));
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -156,6 +156,8 @@ export * as xmlUtils from './util/xmlUtils';
 export * as styleUtils from './util/styleUtils';
 export * as mathUtils from './util/mathUtils';
 export * as cellArrayUtils from './util/cellArrayUtils';
+export { GlobalConfig } from './util/config';
+export * from './util/logger';
 
 export { default as Animation } from './view/animate/Animation';
 export { default as Effects } from './view/animate/Effects';
@@ -188,6 +190,7 @@ export { default as InternalMouseEvent } from './view/event/InternalMouseEvent';
 
 export { default as MaxForm } from './gui/MaxForm';
 export { default as MaxLog } from './gui/MaxLog';
+export { MaxLogAsLogger } from './gui/MaxLogAsLogger';
 export { default as MaxPopupMenu } from './gui/MaxPopupMenu';
 export { default as MaxToolbar } from './gui/MaxToolbar';
 export { default as MaxWindow } from './gui/MaxWindow';

--- a/packages/core/src/serialization/Codec.ts
+++ b/packages/core/src/serialization/Codec.ts
@@ -20,7 +20,7 @@ import CellPath from '../view/cell/CellPath';
 import CodecRegistry from './CodecRegistry';
 import { NODETYPE } from '../util/Constants';
 import Cell from '../view/cell/Cell';
-import MaxLog from '../gui/MaxLog';
+import { GlobalConfig } from '../util/config';
 import { getFunctionName } from '../util/StringUtils';
 import { importNode, isNode } from '../util/domUtils';
 
@@ -108,8 +108,8 @@ const createXmlDocument = () => {
  * const oldEncode = encode;
  * encode(obj)
  * {
- *   MaxLog.show();
- *   MaxLog.debug('Codec.encode: obj='+StringUtils.getFunctionName(obj.constructor));
+ *   GlobalConfig.logger.show();
+ *   GlobalConfig.logger.debug('Codec.encode: obj=' + StringUtils.getFunctionName(obj.constructor));
  *
  *   return oldEncode.apply(this, arguments);
  * };
@@ -323,7 +323,9 @@ class Codec {
       } else if (isNode(obj)) {
         node = importNode(this.document, obj, true);
       } else {
-        MaxLog.warn(`Codec.encode: No codec for ${getFunctionName(obj.constructor)}`);
+        GlobalConfig.logger.warn(
+          `Codec.encode: No codec for ${getFunctionName(obj.constructor)}`
+        );
       }
     }
     return node;

--- a/packages/core/src/serialization/ObjectCodec.ts
+++ b/packages/core/src/serialization/ObjectCodec.ts
@@ -17,7 +17,7 @@ limitations under the License.
 */
 
 import ObjectIdentity from '../util/ObjectIdentity';
-import MaxLog from '../gui/MaxLog';
+import { GlobalConfig } from '../util/config';
 import Geometry from '../view/geometry/Geometry';
 import Point from '../view/geometry/Point';
 import { NODETYPE } from '../util/Constants';
@@ -48,11 +48,11 @@ import type Codec from './Codec';
  * const node = enc.encode(obj);
  * ```
  *
- * The output of the encoding may be viewed using {@link MaxLog} as follows.
+ * The output of the encoding may be viewed using {@link GlobalConfig.logger} as follows.
  *
  * ```javascript
- * MaxLog.show();
- * MaxLog.debug(mxUtils.getPrettyXml(node));
+ * GlobalConfig.logger.show();
+ * GlobalConfig.logger.debug(mxUtils.getPrettyXml(node));
  * ```
  *
  * Finally, the result of the encoding looks as follows.
@@ -370,7 +370,7 @@ class ObjectCodec {
    * if the value is a function.
    *
    * If no ID exists for a variable in {@link idrefs} or if an object
-   * cannot be encoded, a warning is issued using {@link MaxLog.warn}.
+   * cannot be encoded, a warning is issued using {@link GlobalConfig.logger}.
    *
    * Returns the resulting XML node that represents the given
    * object.
@@ -436,7 +436,9 @@ class ObjectCodec {
         const tmp = enc.getId(value);
 
         if (tmp == null) {
-          MaxLog.warn(`ObjectCodec.encode: No ID for ${this.getName()}.${name}=${value}`);
+          GlobalConfig.logger.warn(
+            `ObjectCodec.encode: No ID for ${this.getName()}.${name}=${value}`
+          );
           return; // exit
         }
 
@@ -516,7 +518,9 @@ class ObjectCodec {
 
       node.appendChild(child);
     } else {
-      MaxLog.warn(`ObjectCodec.encode: No node for ${this.getName()}.${name}: ${value}`);
+      GlobalConfig.logger.warn(
+        `ObjectCodec.encode: No node for ${this.getName()}.${name}: ${value}`
+      );
     }
   }
 
@@ -669,7 +673,7 @@ class ObjectCodec {
    * ```
    *
    * If no object exists for an ID in {@link idrefs} a warning is issued
-   * using {@link MaxLog.warn}.
+   * using {@link GlobalConfig.logger}.
    *
    * Returns the resulting object that represents the given XML node
    * or the object given to the method as the into parameter.
@@ -760,7 +764,7 @@ class ObjectCodec {
         const tmp = dec.getObject(value);
 
         if (tmp == null) {
-          MaxLog.warn(
+          GlobalConfig.logger.warn(
             `ObjectCodec.decode: No object for ${this.getName()}.${name}=${value}`
           );
           return; // exit

--- a/packages/core/src/serialization/codecs/StylesheetCodec.ts
+++ b/packages/core/src/serialization/codecs/StylesheetCodec.ts
@@ -19,7 +19,7 @@ import { Stylesheet } from '../../view/style/Stylesheet';
 import type Codec from '../Codec';
 import StyleRegistry from '../../view/style/StyleRegistry';
 import { clone } from '../../util/cloneUtils';
-import MaxLog from '../../gui/MaxLog';
+import { GlobalConfig } from '../../util/config';
 import { NODETYPE } from '../../util/Constants';
 import { isNumeric } from '../../util/mathUtils';
 import { getTextContent } from '../../util/domUtils';
@@ -142,7 +142,7 @@ export class StylesheetCodec extends ObjectCodec {
 
           if (style == null) {
             if (extend != null) {
-              MaxLog.warn(
+              GlobalConfig.logger.warn(
                 `StylesheetCodec.decode: stylesheet ${extend} not found to extend`
               );
             }

--- a/packages/core/src/serialization/codecs/editor/EditorToolbarCodec.ts
+++ b/packages/core/src/serialization/codecs/editor/EditorToolbarCodec.ts
@@ -19,7 +19,7 @@ import { EditorToolbar } from '../../../editor/EditorToolbar';
 import type Codec from '../../Codec';
 import type Editor from '../../../editor/Editor';
 import { NODETYPE } from '../../../util/Constants';
-import MaxLog from '../../../gui/MaxLog';
+import { GlobalConfig } from '../../../util/config';
 import { convertPoint } from '../../../util/styleUtils';
 import { getClientX, getClientY } from '../../../util/EventUtils';
 import InternalEvent from '../../../view/event/InternalEvent';
@@ -216,7 +216,7 @@ export class EditorToolbarCodec extends ObjectCodec {
 
                         return clone;
                       }
-                      MaxLog.warn(`Template ${template} not found`);
+                      GlobalConfig.logger.warn(`Template ${template} not found`);
 
                       return null;
                     };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1155,3 +1155,39 @@ export type EdgeStyleFunction = (
   points: Point[],
   result: Point[]
 ) => void;
+
+/**
+ * @experimental subject to change or removal. The logging system may be modified in the future without prior notice.
+ * @since 0.11.0
+ */
+export interface Logger {
+  /**
+   * Log the specified string at TRACE level and returns the current time in milliseconds.
+   *
+   * @return may return `undefined` hen the TRACE level is not enabled.
+   */
+  enter(message: string): number | undefined;
+
+  /**
+   * Log the specified string at TRACE level and also log the difference between the current
+   * time and t0 in milliseconds.
+   *
+   * @see {@link enter} for an example.
+   */
+  leave(message: string, baseTimestamp?: number): void;
+
+  /**
+   * Shows the console in the UI. This may produce no effect in some implementation which doesn't rely on the UI to log.
+   */
+  show(): void;
+
+  trace(message: string): void;
+
+  debug(message: string): void;
+
+  info(message: string): void;
+
+  warn(message: string): void;
+
+  error(message: string, ...optionalParams: any[]): void;
+}

--- a/packages/core/src/util/Utils.ts
+++ b/packages/core/src/util/Utils.ts
@@ -17,6 +17,7 @@ limitations under the License.
 */
 
 import Client from '../Client';
+import { GlobalConfig } from './config';
 
 /**
  * A singleton class that provides cross-browser helper methods.
@@ -69,7 +70,7 @@ export const mixInto = (dest: any) => (mixin: any) => {
       });
     }
   } catch (e) {
-    console.error('Error while mixing', e);
+    GlobalConfig.logger.error('Error while mixing', e);
   }
 };
 
@@ -98,10 +99,10 @@ export const copyTextToClipboard = (text: string): void => {
   }
   navigator.clipboard.writeText(text).then(
     function () {
-      console.log('Async: Copying to clipboard was successful!');
+      GlobalConfig.logger.info('Async: Copying to clipboard was successful!');
     },
     function (err) {
-      console.error('Async: Could not copy text: ', err);
+      GlobalConfig.logger.error('Async: Could not copy text: ', err);
     }
   );
 };
@@ -122,10 +123,18 @@ const fallbackCopyTextToClipboard = (text: string): void => {
   try {
     const successful = document.execCommand('copy');
     const msg = successful ? 'successful' : 'unsuccessful';
-    console.log('Fallback: Copying text command was ' + msg);
+    GlobalConfig.logger.info(`Fallback: Copying text command was ${msg}`);
   } catch (err) {
-    console.error('Fallback: Oops, unable to copy', err);
+    GlobalConfig.logger.error('Fallback: Oops, unable to copy', err);
   }
 
   document.body.removeChild(textArea);
 };
+
+/**
+ * If `baseTimestamp` is provided and not zero, returns a message describing the elapsed milliseconds since this value.
+ * Otherwise, returns an empty string.
+ * @param baseTimestamp the base timestamp to compute the elapsed milliseconds from
+ */
+export const getElapseMillisecondsMessage = (baseTimestamp?: number): string =>
+  baseTimestamp ? ` (${new Date().getTime() - baseTimestamp} ms)` : '';

--- a/packages/core/src/util/Utils.ts
+++ b/packages/core/src/util/Utils.ts
@@ -135,6 +135,8 @@ const fallbackCopyTextToClipboard = (text: string): void => {
  * If `baseTimestamp` is provided and not zero, returns a message describing the elapsed milliseconds since this value.
  * Otherwise, returns an empty string.
  * @param baseTimestamp the base timestamp to compute the elapsed milliseconds from
+ *
+ * @private not part of the public API, can be removed or changed without prior notice
  */
 export const getElapseMillisecondsMessage = (baseTimestamp?: number): string =>
   baseTimestamp ? ` (${new Date().getTime() - baseTimestamp} ms)` : '';

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -1,0 +1,47 @@
+/*
+Copyright 2024-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import type { Logger } from '../types';
+import { NoOpLogger } from './logger';
+
+/**
+ * Global configuration for maxGraph.
+ *
+ * @experimental subject to change or removal. maxGraph's global configuration may be modified in the future without prior notice.
+ * @since 0.11.0
+ * @category Configuration
+ */
+export const GlobalConfig = {
+  /**
+   * Configure the logger to use for all log messages.
+   *
+   * Available implementations provided by maxGraph are:
+   * * {@link ConsoleLogger} - Directs logs to the browser console.
+   * * {@link NoOpLogger} - Default implementation that does nothing.
+   * * {@link MaxLogAsLogger} - Directs logs to {@link MaxLog}.
+   *
+   * To change the logger, set this property to an instance of the desired logger:
+   * ```js
+   * // To direct logs to the browser console
+   * GlobalConfig.logger = new ConsoleLogger();
+   * // To direct logs to MaxLog
+   * GlobalConfig.logger = new MaxLogAsLogger();
+   * ```
+   *
+   * @default `NoOpLogger`
+   */
+  logger: new NoOpLogger() as Logger,
+};

--- a/packages/core/src/util/logger.ts
+++ b/packages/core/src/util/logger.ts
@@ -22,6 +22,7 @@ import { getElapseMillisecondsMessage } from './Utils';
  *
  * @experimental subject to change or removal. The logging system may be modified in the future without prior notice.
  * @since 0.11.0
+ * @category Logging
  */
 export class NoOpLogger implements Logger {
   debug(_message: string): void {}
@@ -48,6 +49,7 @@ export class NoOpLogger implements Logger {
  *
  * @experimental subject to change or removal. The logging system may be modified in the future without prior notice.
  * @since 0.11.0
+ * @category Logging
  */
 export class ConsoleLogger implements Logger {
   debugEnabled = false;

--- a/packages/core/src/util/logger.ts
+++ b/packages/core/src/util/logger.ts
@@ -1,0 +1,101 @@
+/*
+Copyright 2024-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import type { Logger } from '../types';
+import { getElapseMillisecondsMessage } from './Utils';
+
+/**
+ * A {@link Logger} that does nothing.
+ *
+ * @experimental subject to change or removal. The logging system may be modified in the future without prior notice.
+ * @since 0.11.0
+ */
+export class NoOpLogger implements Logger {
+  debug(_message: string): void {}
+
+  enter(_message: string): number | undefined {
+    return undefined;
+  }
+
+  error(_message: string, ..._optionalParams: any[]): void {}
+
+  info(_message: string): void {}
+
+  leave(_message: string, _baseTimestamp?: number): void {}
+
+  show(): void {}
+
+  trace(_message: string): void {}
+
+  warn(_message: string): void {}
+}
+
+/**
+ * A {@link Logger} that directs logs to the browser console.
+ *
+ * @experimental subject to change or removal. The logging system may be modified in the future without prior notice.
+ * @since 0.11.0
+ */
+export class ConsoleLogger implements Logger {
+  debugEnabled = false;
+  infoEnabled = false;
+  traceEnabled = false;
+
+  /* eslint-disable no-console -- we must use "console" to direct logs to the browser console */
+
+  enter(message: string): number | undefined {
+    if (this.traceEnabled) {
+      console.trace(`Entering ${message}`);
+      return new Date().getTime();
+    }
+  }
+
+  leave(message: string, baseTimestamp?: number): void {
+    if (this.traceEnabled) {
+      const dt = getElapseMillisecondsMessage(baseTimestamp);
+      console.trace(`Leaving ${message}${dt}`);
+    }
+  }
+
+  show(): void {}
+
+  trace(message: string): void {
+    if (this.traceEnabled) {
+      console.trace(message);
+    }
+  }
+
+  debug(message: string): void {
+    if (this.debugEnabled) {
+      console.debug(message);
+    }
+  }
+
+  info(message: string): void {
+    if (this.infoEnabled) {
+      console.info(message);
+    }
+  }
+
+  warn(message: string): void {
+    console.warn(message);
+  }
+
+  error(message?: any, ...optionalParams: any[]): void {
+    console.error(message, ...optionalParams);
+  }
+}
+/* eslint-enable no-console */

--- a/packages/core/src/util/treeTraversal.ts
+++ b/packages/core/src/util/treeTraversal.ts
@@ -96,11 +96,11 @@ export function findTreeRoots(
  * Example:
  *
  * ```javascript
- * MaxLog.show();
+ * GlobalConfig.logger.show();
  * let cell = graph.getSelectionCell();
  * graph.traverse(cell, false, (vertex, edge)=>
  * {
- *   MaxLog.debug(graph.getLabel(vertex));
+ *   GlobalConfig.logger.debug(graph.getLabel(vertex));
  * });
  * ```
  *

--- a/packages/core/src/view/GraphView.ts
+++ b/packages/core/src/view/GraphView.ts
@@ -27,7 +27,7 @@ import Client from '../Client';
 import InternalEvent from './event/InternalEvent';
 import { convertPoint, getCurrentStyle, getOffset } from '../util/styleUtils';
 import { getRotatedPoint, ptSegDistSq, relativeCcw, toRadians } from '../util/mathUtils';
-import MaxLog from '../gui/MaxLog';
+import { GlobalConfig } from '../util/config';
 import Translations from '../util/Translations';
 import CellState from './cell/CellState';
 import UndoableEdit from './undoable_changes/UndoableEdit';
@@ -529,7 +529,7 @@ export class GraphView extends EventSource {
    * Default is {@link currentRoot} or the root of the model.
    */
   validate(cell: Cell | null = null) {
-    const t0 = MaxLog.enter('mxGraphView.validate');
+    const t0 = GlobalConfig.logger.enter('GraphView.validate');
     window.status =
       Translations.get(this.updatingDocumentResource) || this.updatingDocumentResource;
 
@@ -549,7 +549,7 @@ export class GraphView extends EventSource {
     }
 
     window.status = Translations.get(this.doneResource) || this.doneResource;
-    MaxLog.leave('mxGraphView.validate', <number>t0);
+    GlobalConfig.logger.leave('GraphView.validate', t0);
   }
 
   /**

--- a/packages/core/src/view/cell/CellRenderer.ts
+++ b/packages/core/src/view/cell/CellRenderer.ts
@@ -73,10 +73,10 @@ const placeholderStyleProperties: (keyof CellStateStyle)[] = [
  * directly inside the graph container for certain browsers.
  *
  * ```javascript
- * MaxLog.show();
+ * GlobalConfig.logger.show();
  * for (var i in mxCellRenderer.defaultShapes)
  * {
- *   MaxLog.debug(i);
+ *   GlobalConfig.logger.debug(i);
  * }
  * ```
  */

--- a/packages/core/src/view/cell/CellTracker.ts
+++ b/packages/core/src/view/cell/CellTracker.ts
@@ -64,15 +64,15 @@ import type { ColorValue } from '../../types';
  *   mouseUp: function(sender, me) { },
  *   dragEnter: function(evt, cell)
  *   {
- *     MaxLog.debug('dragEnter', cell.value);
+ *     GlobalConfig.logger.debug('dragEnter', cell.value);
  *   },
  *   dragOver: function(evt, cell)
  *   {
- *     MaxLog.debug('dragOver', cell.value);
+ *     GlobalConfig.logger.debug('dragOver', cell.value);
  *   },
  *   dragLeave: function(evt, cell)
  *   {
- *     MaxLog.debug('dragLeave', cell.value);
+ *     GlobalConfig.logger.debug('dragLeave', cell.value);
  *   }
  * });
  * ```

--- a/packages/core/src/view/event/InternalEvent.ts
+++ b/packages/core/src/view/event/InternalEvent.ts
@@ -330,8 +330,8 @@ class InternalEvent {
    * ```javascript
    * mxEvent.addMouseWheelListener(function (evt, up)
    * {
-   *   MaxLog.show();
-   *   MaxLog.debug('mouseWheel: up='+up);
+   *   GlobalConfig.logger.show();
+   *   GlobalConfig.logger.debug('mouseWheel: up='+up);
    * });
    * ```
    *

--- a/packages/core/src/view/event/InternalMouseEvent.ts
+++ b/packages/core/src/view/event/InternalMouseEvent.ts
@@ -36,15 +36,15 @@ import Shape from '../geometry/Shape';
  * {
  *   mouseDown: (sender, evt)=>
  *   {
- *     MaxLog.debug('mouseDown');
+ *     GlobalConfig.logger.debug('mouseDown');
  *   },
  *   mouseMove: (sender, evt)=>
  *   {
- *     MaxLog.debug('mouseMove');
+ *     GlobalConfig.logger.debug('mouseMove');
  *   },
  *   mouseUp: (sender, evt)=>
  *   {
- *     MaxLog.debug('mouseUp');
+ *     GlobalConfig.logger.debug('mouseUp');
  *   }
  * });
  * ```

--- a/packages/core/src/view/handler/ConnectionHandler.ts
+++ b/packages/core/src/view/handler/ConnectionHandler.ts
@@ -44,7 +44,7 @@ import ConstraintHandler from './ConstraintHandler';
 import PolylineShape from '../geometry/edge/PolylineShape';
 import EventSource from '../event/EventSource';
 import Rectangle from '../geometry/Rectangle';
-import MaxLog from '../../gui/MaxLog';
+import { GlobalConfig } from '../../util/config';
 import {
   getClientX,
   getClientY,
@@ -194,8 +194,8 @@ type FactoryMethod = (
  *   let sourcePortId = style[mxConstants.STYLE_SOURCE_PORT];
  *   let targetPortId = style[mxConstants.STYLE_TARGET_PORT];
  *
- *   MaxLog.show();
- *   MaxLog.debug('connect', edge, source.id, target.id, sourcePortId, targetPortId);
+ *   GlobalConfig.logger.show();
+ *   GlobalConfig.logger.debug('connect', edge, source.id, target.id, sourcePortId, targetPortId);
  * });
  * ```
  *
@@ -1804,12 +1804,12 @@ class ConnectionHandler extends EventSource implements GraphPlugin {
             )
           );
         }
-      } catch (e) {
-        MaxLog.show();
+      } catch (e: any) {
+        GlobalConfig.logger.show();
         const errorMessage = `Error in ConnectionHandler: ${
           e instanceof Error ? e.message + '\n' + e.stack : 'unknown cause'
         }`;
-        MaxLog.debug(errorMessage);
+        GlobalConfig.logger.debug(errorMessage);
       } finally {
         model.endUpdate();
       }

--- a/packages/core/src/view/layout/GraphLayout.ts
+++ b/packages/core/src/view/layout/GraphLayout.ts
@@ -126,11 +126,11 @@ class GraphLayout {
    * Example:
    *
    * ```javascript
-   * MaxLog.show();
+   * GlobalConfig.logger.show();
    * const cell = graph.getSelectionCell();
    * graph.traverse(cell, false, function(vertex, edge)
    * {
-   *   MaxLog.debug(graph.getLabel(vertex));
+   *   GlobalConfig.logger.debug(graph.getLabel(vertex));
    * });
    * ```
    *

--- a/packages/core/src/view/layout/hierarchical/CoordinateAssignment.ts
+++ b/packages/core/src/view/layout/hierarchical/CoordinateAssignment.ts
@@ -18,7 +18,7 @@ limitations under the License.
 
 import HierarchicalLayoutStage from './HierarchicalLayoutStage';
 import { DIRECTION } from '../../../util/Constants';
-import MaxLog from '../../../gui/MaxLog';
+import { GlobalConfig } from '../../../util/config';
 import WeightedCellSorter from '../util/WeightedCellSorter';
 import Dictionary from '../../../util/Dictionary';
 import Point from '../../geometry/Point';
@@ -28,7 +28,6 @@ import GraphHierarchyModel from './GraphHierarchyModel';
 import Cell from '../../../view/cell/Cell';
 import GraphHierarchyNode from '../datatypes/GraphHierarchyNode';
 import GraphAbstractHierarchyCell from '../datatypes/GraphAbstractHierarchyCell';
-import { _mxCompactTreeLayoutNode } from '../CompactTreeLayout';
 import { Graph } from '../../../view/Graph';
 import Geometry from '../../../view/geometry/Geometry';
 import GraphHierarchyEdge from '../datatypes/GraphHierarchyEdge';
@@ -206,20 +205,20 @@ class CoordinateAssignment extends HierarchicalLayoutStage {
     const model = <GraphHierarchyModel>this.layout.getDataModel();
     const ranks = <GraphAbstractHierarchyCell[][]>model.ranks;
 
-    MaxLog.show();
-    MaxLog.writeln('======Coord assignment debug=======');
+    const logger = GlobalConfig.logger;
+    logger.show();
+    logger.info('======Coord assignment debug=======');
 
     for (let j = 0; j < ranks.length; j++) {
-      MaxLog.write('Rank ', String(j), ' : ');
       const rank = ranks[j];
 
-      for (let k = 0; k < rank.length; k++) {
-        const cell = rank[k];
-        MaxLog.write(String(cell.getGeneralPurposeVariable(j)), '  ');
-      }
-      MaxLog.writeln();
+      const cellsInfo = rank
+        .map((cell) => String(cell.getGeneralPurposeVariable(j)))
+        .join('  ');
+
+      logger.info(`Rank ${j} : ${cellsInfo}`);
     }
-    MaxLog.writeln('====================================');
+    logger.info('====================================');
   }
 
   /**
@@ -733,7 +732,7 @@ class CoordinateAssignment extends HierarchicalLayoutStage {
         if (node.edges != null) {
           numEdges = node.edges.length;
         } else {
-          MaxLog.warn('edge.edges is null');
+          GlobalConfig.logger.warn('edge.edges is null');
         }
 
         node.width = (numEdges - 1) * this.parallelEdgeSpacing;
@@ -747,8 +746,8 @@ class CoordinateAssignment extends HierarchicalLayoutStage {
       localX += this.intraCellSpacing;
     }
 
-    if (boundsWarning == true) {
-      MaxLog.warn('At least one cell has no bounds');
+    if (boundsWarning) {
+      GlobalConfig.logger.warn('At least one cell has no bounds');
     }
   }
 
@@ -810,7 +809,7 @@ class CoordinateAssignment extends HierarchicalLayoutStage {
           if (node.edges != null) {
             numEdges = node.edges.length;
           } else {
-            MaxLog.warn('edge.edges is null');
+            GlobalConfig.logger.warn('edge.edges is null');
           }
 
           node.width = (numEdges - 1) * this.parallelEdgeSpacing;
@@ -831,8 +830,8 @@ class CoordinateAssignment extends HierarchicalLayoutStage {
         this.rankWidths[rankValue] = localX;
       }
 
-      if (boundsWarning == true) {
-        MaxLog.warn('At least one cell has no bounds');
+      if (boundsWarning) {
+        GlobalConfig.logger.warn('At least one cell has no bounds');
       }
 
       this.rankY[rankValue] = y;

--- a/packages/core/src/view/other/AutoSaveManager.ts
+++ b/packages/core/src/view/other/AutoSaveManager.ts
@@ -25,16 +25,12 @@ import { Graph } from '../Graph';
  * implemented.
  *
  * ```javascript
- * var mgr = new AutoSaveManager(editor.graph);
- * mgr.save()
- * {
- *   MaxLog.show();
- *   MaxLog.debug('save');
+ * const mgr = new AutoSaveManager(editor.graph);
+ * mgr.save() {
+ *   GlobalConfig.logger.show();
+ *   GlobalConfig.logger.debug('save');
  * };
  * ```
- *
- * @class AutoSaveManager
- * @extends EventSource
  */
 class AutoSaveManager extends EventSource {
   constructor(graph: Graph) {

--- a/packages/core/src/view/style/edge/Segment.ts
+++ b/packages/core/src/view/style/edge/Segment.ts
@@ -215,9 +215,6 @@ export const SegmentConnector: EdgeStyleFunction = (
       horizontal = !horizontal;
       hint = hints[i];
 
-      //        MaxLog.show();
-      //        MaxLog.debug('hint', i, hint.x, hint.y);
-
       if (horizontal) {
         pt.y = hint.y;
       } else {

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -21,6 +21,6 @@
     "categorizeByGroup": false,
     "navigation": {
       "includeCategories": false, // not enough categories to warrant this
-    }
+    },
   }
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -16,6 +16,11 @@
     "out": "build/api",
     "readme": "none",
     "excludeExternals": true,
-    "excludePrivate": true
+    "excludePrivate": true,
+    "categoryOrder": ["Configuration", "Logging","*"],
+    "categorizeByGroup": false,
+    "navigation": {
+      "includeCategories": false, // not enough categories to warrant this
+    }
   }
 }

--- a/packages/html/.storybook/preview.ts
+++ b/packages/html/.storybook/preview.ts
@@ -1,4 +1,12 @@
 import type { Preview } from '@storybook/html';
+import { GlobalConfig, NoOpLogger } from '@maxgraph/core';
+
+const defaultLogger = new NoOpLogger();
+// if you want to debug using the browser console, use the following configuration
+// const defaultLogger = new ConsoleLogger();
+// defaultLogger.infoEnabled = true;
+// defaultLogger.debugEnabled = true;
+// defaultLogger.traceEnabled = true;
 
 const preview: Preview = {
   parameters: {
@@ -10,6 +18,15 @@ const preview: Preview = {
       },
     },
   },
+  decorators: [
+    // reset the logger to the default NoOpLogger, as it may have been globally changed in a story (for example, in the Window story)
+    // inspired by https://github.com/storybookjs/storybook/issues/4997#issuecomment-447301514
+    (storyFn) => {
+      GlobalConfig.logger = defaultLogger;
+
+      return storyFn();
+    },
+  ],
 };
 
 export default preview;

--- a/packages/html/stories/Clipboard.stories.js
+++ b/packages/html/stories/Clipboard.stories.js
@@ -60,7 +60,6 @@ const Template = ({ label, ...args }) => {
 
   // Public helper method for shared clipboard.
   Clipboard.cellsToString = function (cells) {
-    console.warn('cellsToString', cells);
     const model = new GraphDataModel();
     const parent = model.getRoot().getChildAt(0);
 
@@ -86,8 +85,6 @@ const Template = ({ label, ...args }) => {
 
   // Shows a textarea when control/cmd is pressed to handle native clipboard actions
   InternalEvent.addListener(document, 'keydown', function (evt) {
-    console.warn('CALLED keydown', evt);
-
     // No dialog visible
     const source = eventUtils.getSource(evt);
 
@@ -167,7 +164,6 @@ const Template = ({ label, ...args }) => {
 
   // Handles copy event by putting XML for current selection into text input
   InternalEvent.addListener(textInput, 'copy', (evt) => {
-    console.warn('CALLED copy', evt);
     if (graph.isEnabled() && !graph.isSelectionEmpty()) {
       copyCells(
         graph,

--- a/packages/html/stories/Grid.stories.js
+++ b/packages/html/stories/Grid.stories.js
@@ -19,7 +19,7 @@ import {
   Graph,
   InternalEvent,
   RubberBandHandler,
-  MaxLog,
+  GlobalConfig,
   GraphView,
   Point,
   DomHelpers,
@@ -177,8 +177,8 @@ const Template = ({ label, ...args }) => {
         }
       };
     } catch (e) {
-      MaxLog.show();
-      MaxLog.debug('Using background image');
+      GlobalConfig.logger.show();
+      GlobalConfig.logger.debug('Using background image');
 
       container.style.backgroundImage = "url('./images/grid.gif')";
     }

--- a/packages/html/stories/Window.stories.ts
+++ b/packages/html/stories/Window.stories.ts
@@ -23,6 +23,8 @@ import {
   InternalEvent,
   MaxLog,
   domUtils,
+  GlobalConfig,
+  MaxLogAsLogger,
 } from '@maxgraph/core';
 import {
   contextMenuTypes,
@@ -52,6 +54,9 @@ export default {
 const Template = ({ label, ...args }: Record<string, string>) => {
   configureImagesBasePath();
   const container = createGraphContainer(args);
+
+  GlobalConfig.logger = new MaxLogAsLogger();
+  GlobalConfig.logger.info('Starting the Window story...');
 
   // Note that we're using the container scrollbars for the graph so that the
   // container extends to the parent div inside the window
@@ -136,6 +141,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   wnd.setClosable(true);
 
   MaxLog.show();
+  GlobalConfig.logger.info('MaxLog show done!');
 
   return container;
 };

--- a/packages/ts-example/src/custom-shapes.ts
+++ b/packages/ts-example/src/custom-shapes.ts
@@ -18,12 +18,10 @@ import type { AbstractCanvas2D, ColorValue, Rectangle } from '@maxgraph/core';
 import { CellRenderer, EllipseShape, RectangleShape } from '@maxgraph/core';
 
 export const registerCustomShapes = (): void => {
-  console.info('Registering custom shapes...');
   // @ts-ignore TODO fix CellRenderer. Calls to this function are also marked as 'ts-ignore' in CellRenderer
   CellRenderer.registerShape('customRectangle', CustomRectangleShape);
   // @ts-ignore
   CellRenderer.registerShape('customEllipse', CustomEllipseShape);
-  console.info('Custom shapes registered');
 };
 
 class CustomRectangleShape extends RectangleShape {

--- a/packages/ts-example/vite.config.js
+++ b/packages/ts-example/vite.config.js
@@ -27,7 +27,7 @@ export default defineConfig(({ mode }) => {
           },
         },
       },
-      chunkSizeWarningLimit: 468, // @maxgraph/core
+      chunkSizeWarningLimit: 453, // @maxgraph/core
     },
   };
 });

--- a/packages/ts-example/vite.config.js
+++ b/packages/ts-example/vite.config.js
@@ -27,7 +27,7 @@ export default defineConfig(({ mode }) => {
           },
         },
       },
-      chunkSizeWarningLimit: 453, // @maxgraph/core
+      chunkSizeWarningLimit: 445, // @maxgraph/core
     },
   };
 });

--- a/packages/website/docs/usage/global-configuration.md
+++ b/packages/website/docs/usage/global-configuration.md
@@ -1,5 +1,5 @@
 ---
-description: How-to globally configure maxGraph globally.
+description: How-to configure maxGraph globally.
 ---
 
 # Global Configuration

--- a/packages/website/docs/usage/global-configuration.md
+++ b/packages/website/docs/usage/global-configuration.md
@@ -1,0 +1,35 @@
+---
+description: How-to globally configure maxGraph globally.
+---
+
+# Global Configuration
+
+This guide explains how to configure `maxGraph` globally. This global configuration applies to all instances of `Graph`.
+
+
+## General
+
+The following objects can be used to configure `maxGraph` globally:
+
+  - `Client`: this is the historical entry point for global configuration, coming from the `mxGraph` library.
+  - `StencilShapeConfig`: introduced in version _0.11.0_. This object is used to configure stencil shapes globally.
+  - `GlobalConfig`: introduced in version _0.11.0_.
+
+Notice that the new global configuration elements introduced in version _0.11.0_ are experimental and are subject to change in future versions. 
+
+## Styles
+
+`maxGraph` provides several global registries used to register style configurations.
+
+  - `CellRenderer`: shapes
+  - `MarkerShape`: edge markers (also known as `startArrow` and `endArrow` in `CellStateStyle`)
+  - `StyleRegistry`: edge styles and perimeters
+  - `StencilShapeRegistry`: stencil shapes
+
+When instantiating a `Graph` object, the registries are filled with `maxGraph` default style configurations. There is no default stencil shapes registered by default.
+
+
+## Serialization
+
+`CodecRegistry` is used for serialization and deserialization of objects in XML object.
+By default, no codec is registered. Some functions are provided to register codecs for specific objects.


### PR DESCRIPTION
Previously, logs were sent to the browser console or to `MaxLog`, which was inconsistent across the code base.
This is now configurable and maxGraph no longer produces logs by default.

The logger is configured globally (i.e. it is not specific to a `Graph` instance) and all the examples in the JSDoc have been updated to demonstrate how to use the new logging system (instead of using `MaxLog` directly).
It is also possible to provide your own implementation of the logger.
Please note that this is a first implementation and may change in the future.

This change also improves tree-shaking. `MaxLog` is no longer included in applications using maxGraph, and transitively, `MaxWindow` is not included either.

Sending logs to `MaxLog` by default also posed a problem in terms of user interface.
For example, if an error occurred in `ConnectionHandler`, the `MaxLog` window opened in the application including maxGraph, whereas this was probably not what users wanted.
In addition, if maxGraph's CSS rules were not available (for example, by importing the CSS file supplied by maxGraph), the `MaxLog` window was not displayed correctly: its content was added to the bottom of the page without any styling.

Notes on `ConsoleLogger` logs
By default, only warnings and errors are sent to the browser console to reduce the amount of logs. It is possible to activate info, debug and trace. Remember that traces are produced each time the model is validated.

No direct console logs allowed in maxGraph code
A new eslint rule has been configured to prohibit the use of console logs, as the global log system must be used instead.

Impact on the `Window` story
This is the only story that explicitly uses `MaxLog`, so it is configured to direct maxGraph logs to `MaxLog`. To avoid side-effects on other stories because the logger configuration is global, the storybook configuration has been set to reset the logger to its default value before initializing new stories.

BREAKING CHANGES:
  - Logs are no longer sent to `MaxLog` by default. To restore the previous behavior, change maxGraph's global configuration with: `GlobalConfig.logger = new MaxLogAsLogger();`
  - `MaxWindow.activeWindow` is no longer available; it was intended for internal use only, so there's no reason to make it public.




## Notes

### Tree-shaking improvements

`MaxWindow` improvement includes removing a static property as done in #401

In ts-example, here are the size of the maxGraph chunk (built with Vite/esbuild):
- commit 84f492f:  468.63 kB │ gzip: 123.54 kB
- now: 452.30 kB │ gzip: 119.86 kB

Notice that I haven't seen any change in the bundle size of js-example (built with webpack), which is probably more conservative (remember that maxGraph is currently declared as "not side effects free", so tree-shaking is not optimal).

### Example of UI issues when errors occured in ConnectionHandler without applying maxGraph CSS

Seen while implementing #413

![maxLog_without_styling](https://github.com/maxGraph/maxGraph/assets/27200110/57497515-14c7-4b94-b169-58d75a88b225)

