### PR TITLE
docs: improve JSDoc of Shape related to edges

### DIFF
--- a/packages/core/src/util/Constants.ts
+++ b/packages/core/src/util/Constants.ts
@@ -588,8 +588,7 @@ export enum SHAPE {
   RHOMBUS = 'rhombus',
 
   /**
-   * Name under which {@link Line} is registered in {@link CellRenderer}.
-   * Default is line.
+   * Name under which {@link LineShape} is registered in {@link CellRenderer} by default.
    */
   LINE = 'line',
 
@@ -600,14 +599,12 @@ export enum SHAPE {
   IMAGE = 'image',
 
   /**
-   * Name under which {@link Arrow} is registered in {@link CellRenderer}.
-   * Default is arrow.
+   * Name under which {@link ArrowShape} is registered in {@link CellRenderer} by default.
    */
   ARROW = 'arrow',
 
   /**
-   * Name under which {@link ArrowConnector} is registered in {@link CellRenderer}.
-   * Default is arrowConnector.
+   * Name under which {@link ArrowConnectorShape} is registered in {@link CellRenderer} by default.
    */
   ARROW_CONNECTOR = 'arrowConnector',
 
@@ -630,8 +627,7 @@ export enum SHAPE {
   SWIMLANE = 'swimlane',
 
   /**
-   * Name under which {@link Connector} is registered in {@link CellRenderer}.
-   * Default is connector.
+   * Name under which {@link ConnectorShape} is registered in {@link CellRenderer} by default.
    */
   CONNECTOR = 'connector',
 

--- a/packages/core/src/view/cell/CellRenderer.ts
+++ b/packages/core/src/view/cell/CellRenderer.ts
@@ -106,7 +106,7 @@ class CellRenderer {
 
   /**
    * Defines the default shape for labels.
-   * @default {@link Text}.
+   * @default {@link TextShape}.
    */
   defaultTextShape: typeof TextShape = TextShape;
 

--- a/packages/core/src/view/geometry/edge/ArrowConnectorShape.ts
+++ b/packages/core/src/view/geometry/edge/ArrowConnectorShape.ts
@@ -26,10 +26,13 @@ import CellState from '../../cell/CellState';
 import { ColorValue } from '../../../types';
 
 /**
- * Extends {@link Shape} to implement an new rounded arrow shape with support for waypoints and double arrows. The
- * shape is used to represent edges, not vertices.
+ * Extends {@link Shape} to implement a new rounded arrow shape with support for waypoints and double arrows.
  *
- * This shape is registered under {@link mxConstants.SHAPE_ARROW_CONNECTOR} in {@link mxCellRenderer}.
+ * The shape is used to represent edges, not vertices.
+ *
+ * By default, this shape is registered under {@link SHAPE.ARROW_CONNECTOR} in {@link CellRenderer}.
+ *
+ * @category Edge Shapes
  */
 class ArrowConnectorShape extends Shape {
   constructor(

--- a/packages/core/src/view/geometry/edge/ArrowShape.ts
+++ b/packages/core/src/view/geometry/edge/ArrowShape.ts
@@ -26,7 +26,9 @@ import { ColorValue } from '../../../types';
 /**
  * Extends {@link Shape} to implement an arrow shape. The shape is used to represent edges, not vertices.
  *
- * This shape is registered under {@link mxConstants.SHAPE_ARROW} in {@link mxCellRenderer}.
+ * By default, this shape is registered under {@link SHAPE.ARROW} in {@link CellRenderer}.
+ *
+ * @category Edge Shapes
  */
 class ArrowShape extends Shape {
   constructor(

--- a/packages/core/src/view/geometry/edge/ConnectorShape.ts
+++ b/packages/core/src/view/geometry/edge/ConnectorShape.ts
@@ -25,12 +25,14 @@ import Rectangle from '../Rectangle';
 import { ArrowValue, ColorValue } from '../../../types';
 
 /**
- * Extends {@link mxShape} to implement a connector shape.
- * The connector shape allows for arrow heads on either side.
- * This shape is registered under {@link mxConstants.SHAPE_CONNECTOR} in {@link mxCellRenderer}.
+ * Extends {@link PolylineShape} to implement a connector shape including a polyline (a line with multiple points)
+ * that allows for arrow heads on either side.
  *
- * @class ConnectorShape
- * @extends {PolylineShape}
+ * The shape is used to represent edges, not vertices.
+ *
+ * This shape is registered under {@link SHAPE.CONNECTOR} in {@link CellRenderer}.
+ *
+ * @category Edge Shapes
  */
 class ConnectorShape extends PolylineShape {
   constructor(points: Point[], stroke: ColorValue, strokewidth: number) {

--- a/packages/core/src/view/geometry/edge/LineShape.ts
+++ b/packages/core/src/view/geometry/edge/LineShape.ts
@@ -23,9 +23,12 @@ import { ColorValue } from '../../../types';
 
 /**
  * Extends {@link Shape} to implement a horizontal line shape.
- * This shape is registered under {@link mxConstants.SHAPE_LINE} in {@link mxCellRenderer}.
- * @class Line
- * @extends {Shape}
+ *
+ * The shape is used to represent edges, not vertices.
+ *
+ * By default, this shape is registered under {@link SHAPE.LINE} in {@link CellRenderer}.
+ *
+ * @category Edge Shapes
  */
 class LineShape extends Shape {
   constructor(bounds: Rectangle, stroke: ColorValue, strokeWidth = 1, vertical = false) {

--- a/packages/core/src/view/geometry/edge/MarkerShape.ts
+++ b/packages/core/src/view/geometry/edge/MarkerShape.ts
@@ -23,9 +23,9 @@ import Point from '../Point';
 import Shape from '../Shape';
 
 /**
- * A static class that implements all markers for VML and SVG using a registry.
+ * A registry that stores all edge markers using .
+ *
  * NOTE: The signatures in this class will change.
- * @class MarkerShape
  */
 class MarkerShape {
   /**

--- a/packages/core/src/view/geometry/edge/PolylineShape.ts
+++ b/packages/core/src/view/geometry/edge/PolylineShape.ts
@@ -24,21 +24,21 @@ import { ColorValue } from '../../../types';
 
 /**
  * Extends {@link Shape} to implement a polyline (a line with multiple points).
- * This shape is registered under {@link Constants#SHAPE_POLYLINE} in
- * {@link CellRenderer}.
  *
- * Constructor: mxPolyline
+ * The shape is used to represent edges, not vertices.
  *
- * Constructs a new polyline shape.
+ * By default, this shape is not registered in {@link CellRenderer}.
  *
- * @param points Array of <Point> that define the points. This is stored in
- * {@link Shape#points}.
- * @param stroke String that defines the stroke color. Default is 'black'. This is
- * stored in <stroke>.
- * @param strokewidth Optional integer that defines the stroke width. Default is
- * 1. This is stored in <strokewidth>.
+ * @category Edge Shapes
  */
 class PolylineShape extends Shape {
+  /**
+   * Constructs a new polyline shape.
+   *
+   * @param points Array of <{@link Point} that define the points. This is stored in {@link Shape.points}.
+   * @param stroke String that defines the stroke color. Default is 'black'. This is stored in {@link Shape.stroke}.
+   * @param strokeWidth Optional integer that defines the stroke width. Default is 1. This is stored in {@link Shape.strokeWidth}.
+   */
   constructor(points: Point[], stroke: ColorValue, strokeWidth = 1) {
     super();
     this.points = points;

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -17,7 +17,7 @@
     "readme": "none",
     "excludeExternals": true,
     "excludePrivate": true,
-    "categoryOrder": ["Configuration", "*"],
+    "categoryOrder": ["Configuration", "Edge Shapes", "*"],
     "categorizeByGroup": false,
     "navigation": {
       "includeCategories": false, // not enough categories to warrant this


### PR DESCRIPTION
Also add a category for "Edge Shapes" to group the related classes in the API docs generated in HTML by `typedoc`.