### PR TITLE
fix: restore the `GraphCodec` implementation

### DIFF
--- a/packages/core/src/serialization/ModelXmlSerializer.ts
+++ b/packages/core/src/serialization/ModelXmlSerializer.ts
@@ -65,7 +65,7 @@ export class ModelXmlSerializer {
   }
 
   /**
-   * Hook for replacing codecs registered by default (core codecs).
+   * Hook for replacing codecs registered by default (model codecs).
    */
   protected registerCodecs(): void {
     registerModelCodecs();

--- a/packages/core/src/serialization/codecs/GraphCodec.ts
+++ b/packages/core/src/serialization/codecs/GraphCodec.ts
@@ -1,0 +1,51 @@
+/*
+Copyright 2024-present The maxGraph project Contributors
+Copyright (c) 2006-2015, JGraph Ltd
+Copyright (c) 2006-2015, Gaudenz Alder
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import ObjectCodec from '../ObjectCodec';
+import GraphView from '../../view/GraphView';
+import { Graph } from '../../view/Graph';
+
+/**
+ * Codec for {@link Graph}s.
+ * This class is created and registered dynamically at load time and used implicitly via {@link Codec} and the {@link CodecRegistry}.
+ *
+ * Transient Fields:
+ *
+ * - graphListeners
+ * - eventListeners
+ * - view
+ * - container
+ * - cellRenderer
+ * - editor
+ * - selection
+ */
+export class GraphCodec extends ObjectCodec {
+  constructor() {
+    const __dummy: any = undefined;
+    // TODO: Register every possible plugin (i.e. all not being excluded via tree-shaking(?))
+    super(new Graph(__dummy), [
+      'graphListeners',
+      'eventListeners',
+      'view',
+      'container',
+      'cellRenderer',
+      'editor',
+      'selection',
+    ]);
+  }
+}

--- a/packages/core/src/serialization/codecs/index.ts
+++ b/packages/core/src/serialization/codecs/index.ts
@@ -18,6 +18,7 @@ export * from './editor';
 export * from './CellCodec';
 export * from './ChildChangeCodec';
 export * from './GenericChangeCodec';
+export * from './GraphCodec';
 export * from './GraphViewCodec';
 export * from './ModelCodec';
 export * from './RootChangeCodec';

--- a/packages/core/src/serialization/register.ts
+++ b/packages/core/src/serialization/register.ts
@@ -23,6 +23,7 @@ import {
   EditorPopupMenuCodec,
   EditorToolbarCodec,
   GenericChangeCodec,
+  GraphCodec,
   GraphViewCodec,
   ModelCodec,
   mxCellCodec,
@@ -116,6 +117,7 @@ let isCoreCodecsRegistered = false;
 export const registerCoreCodecs = (force = false) => {
   if (!isCoreCodecsRegistered || force) {
     CodecRegistry.register(new ChildChangeCodec());
+    CodecRegistry.register(new GraphCodec());
     CodecRegistry.register(new GraphViewCodec());
     CodecRegistry.register(new RootChangeCodec());
     CodecRegistry.register(new StylesheetCodec());

--- a/packages/core/src/view/Graph.ts
+++ b/packages/core/src/view/Graph.ts
@@ -1508,36 +1508,4 @@ class Graph extends EventSource {
   }
 }
 
-/**
- * Codec for {@link Graph}s. This class is created and registered
- * dynamically at load time and used implicitly via <Codec>
- * and the <CodecRegistry>.
- *
- * Transient Fields:
- *
- * - graphListeners
- * - eventListeners
- * - view
- * - container
- * - cellRenderer
- * - editor
- * - selection
- */
-
-/*export class GraphCodec extends ObjectCodec {
-  constructor() {
-    // TODO: Register every possible plugin (i.e. all not being excluded via tree-shaking(?))
-    super(new Graph(), [
-      'graphListeners',
-      'eventListeners',
-      'view',
-      'container',
-      'cellRenderer',
-      'editor',
-      'selection',
-    ]);
-  }
-}*/
-
-//CodecRegistry.register(new GraphCodec());
 export { Graph };


### PR DESCRIPTION
It was provided in `mxGraph` and was commented in the previous `maxGraph` implementation.
The codec is registered with other core codecs.


## Notes

The code of this codec has been commented since 413796ad (January 2022).

I have no way to test this codec for now. It should not cause side effects if it is not used.
I have check that registering this codec has no effect on the model serialization. I registered core codecs instead of model codecs: jest tests pass, stories and js-example are still working.

