### PR TITLE
docs(release): attach examples and website

### DIFF
--- a/packages/website/docs/development/release.md
+++ b/packages/website/docs/development/release.md
@@ -93,7 +93,7 @@ Attach the examples and the website to the release (in the "assets" location):
     - location: https://github.com/maxGraph/maxGraph/actions/workflows/build.yml
     - rename the file to: `maxgraph_<version>_website.zip`
   - website:
-    - location: https://github.com/maxGraph/maxGraph/actions/workflows/generate-website.yml. The artifact is now available in the summary of the job. Open the log to get the URL of the artifact.
+    - location: https://github.com/maxGraph/maxGraph/actions/workflows/generate-website.yml. The artifact is not available in the summary of the job. Open the log to get the URL of the artifact.
     - rename the file to: `maxgraph_<version>_examples.zip`
 
 Before you publish the release, make sure that a discussion will be created in the `Announces` category when the release

--- a/packages/website/docs/development/release.md
+++ b/packages/website/docs/development/release.md
@@ -93,7 +93,7 @@ Attach the examples and the website to the release (in the "assets" location):
     - location: https://github.com/maxGraph/maxGraph/actions/workflows/build.yml
     - rename the file to: `maxgraph_<version>_website.zip`
   - website:
-    - location: https://github.com/maxGraph/maxGraph/actions/workflows/generate-website.yml
+    - location: https://github.com/maxGraph/maxGraph/actions/workflows/generate-website.yml. The artifact is now available in the summary of the job. Open the log to get the URL of the artifact.
     - rename the file to: `maxgraph_<version>_examples.zip`
 
 Before you publish the release, make sure that a discussion will be created in the `Announces` category when the release

--- a/packages/website/docs/development/release.md
+++ b/packages/website/docs/development/release.md
@@ -87,6 +87,15 @@ The list of the major changes has been [automatically generated](https://docs.gi
   - If the list is incorrect (for example, an item is not in the correct category), update the label(s) or the associated
 Pull Request and regenerate the list.
 
+Attach the examples and the website to the release (in the "assets" location):
+  - Retrieve the artifacts built by GitHub Actions on the commit of the tag
+  - examples:
+    - location: https://github.com/maxGraph/maxGraph/actions/workflows/build.yml
+    - rename the file to: `maxgraph_<version>_website.zip`
+  - website:
+    - location: https://github.com/maxGraph/maxGraph/actions/workflows/generate-website.yml
+    - rename the file to: `maxgraph_<version>_examples.zip`
+
 Before you publish the release, make sure that a discussion will be created in the `Announces` category when the release
 is published.
 


### PR DESCRIPTION
The live website is for the next version. As the API is not stable for now and breaking changes occur, providing an archive of the website (which includes the documentation for usage and API) let user access to the documentation of the specific version of maxGraph that they are using.
Providing a static archive of the example will help detecting eventual regression, or see the evolution of the library.  



## Notes

Retroactively done in release `0.10.3` to initiate the process: https://github.com/maxGraph/maxGraph/releases/tag/v0.10.3

