### PR TITLE
refactor: drop side effect in default edge markers registration

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -16,6 +16,7 @@ limitations under the License.
 
 import { DIRECTION, IDENTITY_FIELD_NAME } from './util/Constants';
 import type { Graph } from './view/Graph';
+import type AbstractCanvas2D from './view/canvas/AbstractCanvas2D';
 import type Cell from './view/cell/Cell';
 import type CellState from './view/cell/CellState';
 import type EventSource from './view/event/EventSource';
@@ -1155,3 +1156,16 @@ export type EdgeStyleFunction = (
   points: Point[],
   result: Point[]
 ) => void;
+
+export type MarkerFactoryFunction = (
+  canvas: AbstractCanvas2D,
+  shape: Shape,
+  type: StyleArrowValue,
+  pe: Point,
+  unitX: number,
+  unitY: number,
+  size: number,
+  source: boolean,
+  sw: number,
+  filled: boolean
+) => () => void;

--- a/packages/core/src/view/Graph.ts
+++ b/packages/core/src/view/Graph.ts
@@ -62,6 +62,7 @@ import Multiplicity from './other/Multiplicity';
 import ImageBundle from './image/ImageBundle';
 import GraphSelectionModel from './GraphSelectionModel';
 import { registerDefaultShapes } from './cell/register-shapes';
+import { registerDefaultEdgeMarkers } from './geometry/edge/MarkerShape';
 import { registerDefaultStyleElements } from './style/register';
 
 export const defaultPlugins: GraphPluginConstructor[] = [
@@ -494,6 +495,7 @@ class Graph extends EventSource {
   protected registerDefaults(): void {
     registerDefaultShapes();
     registerDefaultStyleElements();
+    registerDefaultEdgeMarkers();
   }
 
   constructor(

--- a/packages/core/src/view/geometry/edge/MarkerShape.ts
+++ b/packages/core/src/view/geometry/edge/MarkerShape.ts
@@ -16,11 +16,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ArrowValue } from '../../../types';
-import AbstractCanvas2D from '../../canvas/AbstractCanvas2D';
+import type { MarkerFactoryFunction, StyleArrowValue } from '../../../types';
+import type AbstractCanvas2D from '../../canvas/AbstractCanvas2D';
 import { ARROW } from '../../../util/Constants';
-import Point from '../Point';
-import Shape from '../Shape';
+import type Point from '../Point';
+import type Shape from '../Shape';
 
 /**
  * A static class that implements all markers for VML and SVG using a registry.
@@ -33,13 +33,13 @@ class MarkerShape {
    *
    * Mapping: the attribute name on the object is the marker type, the associated value is the function to paint the marker
    */
-  static markers: Record<string, Function> = {};
+  static markers: Record<string, MarkerFactoryFunction> = {};
 
   /**
    * Adds a factory method that updates a given endpoint and returns a
    * function to paint the marker onto the given canvas.
    */
-  static addMarker(type: string, funct: Function) {
+  static addMarker(type: string, funct: MarkerFactoryFunction) {
     MarkerShape.markers[type] = funct;
   }
 
@@ -49,7 +49,7 @@ class MarkerShape {
   static createMarker(
     canvas: AbstractCanvas2D,
     shape: Shape,
-    type: ArrowValue | string,
+    type: StyleArrowValue,
     pe: Point,
     unitX: number,
     unitY: number,
@@ -58,179 +58,36 @@ class MarkerShape {
     sw: number,
     filled: boolean
   ) {
-    const funct = MarkerShape.markers[type];
-    return funct
-      ? funct(canvas, shape, type, pe, unitX, unitY, size, source, sw, filled)
+    const markerFunction = MarkerShape.markers[type];
+    return markerFunction
+      ? markerFunction(canvas, shape, type, pe, unitX, unitY, size, source, sw, filled)
       : null;
   }
 }
 
+export default MarkerShape;
+
 /**
- * Adds the classic and block marker factory method.
+ * For the classic and block marker factory methods.
  */
-(() => {
-  function createArrow(widthFactor = 2) {
-    return (
-      canvas: AbstractCanvas2D,
-      shape: Shape,
-      type: ArrowValue,
-      pe: Point,
-      unitX: number,
-      unitY: number,
-      size: number,
-      source: boolean,
-      sw: number,
-      filled: boolean
-    ) => {
-      // The angle of the forward facing arrow sides against the x axis is
-      // 26.565 degrees, 1/sin(26.565) = 2.236 / 2 = 1.118 ( / 2 allows for
-      // only half the strokewidth is processed ).
-      const endOffsetX = unitX * sw * 1.118;
-      const endOffsetY = unitY * sw * 1.118;
-
-      unitX *= size + sw;
-      unitY *= size + sw;
-
-      const pt = pe.clone();
-      pt.x -= endOffsetX;
-      pt.y -= endOffsetY;
-
-      const f = type !== ARROW.CLASSIC && type !== ARROW.CLASSIC_THIN ? 1 : 3 / 4;
-      pe.x += -unitX * f - endOffsetX;
-      pe.y += -unitY * f - endOffsetY;
-
-      return () => {
-        canvas.begin();
-        canvas.moveTo(pt.x, pt.y);
-        canvas.lineTo(
-          pt.x - unitX - unitY / widthFactor,
-          pt.y - unitY + unitX / widthFactor
-        );
-
-        if (type === ARROW.CLASSIC || type === ARROW.CLASSIC_THIN) {
-          canvas.lineTo(pt.x - (unitX * 3) / 4, pt.y - (unitY * 3) / 4);
-        }
-
-        canvas.lineTo(
-          pt.x + unitY / widthFactor - unitX,
-          pt.y - unitY - unitX / widthFactor
-        );
-        canvas.close();
-
-        if (filled) {
-          canvas.fillAndStroke();
-        } else {
-          canvas.stroke();
-        }
-      };
-    };
-  }
-
-  MarkerShape.addMarker('classic', createArrow(2));
-  MarkerShape.addMarker('classicThin', createArrow(3));
-  MarkerShape.addMarker('block', createArrow(2));
-  MarkerShape.addMarker('blockThin', createArrow(3));
-
-  function createOpenArrow(widthFactor = 2) {
-    return (
-      canvas: AbstractCanvas2D,
-      shape: Shape,
-      type: ArrowValue,
-      pe: Point,
-      unitX: number,
-      unitY: number,
-      size: number,
-      source: boolean,
-      sw: number,
-      filled: boolean
-    ) => {
-      // The angle of the forward facing arrow sides against the x axis is
-      // 26.565 degrees, 1/sin(26.565) = 2.236 / 2 = 1.118 ( / 2 allows for
-      // only half the strokewidth is processed ).
-      const endOffsetX = unitX * sw * 1.118;
-      const endOffsetY = unitY * sw * 1.118;
-
-      unitX *= size + sw;
-      unitY *= size + sw;
-
-      const pt = pe.clone();
-      pt.x -= endOffsetX;
-      pt.y -= endOffsetY;
-
-      pe.x += -endOffsetX * 2;
-      pe.y += -endOffsetY * 2;
-
-      return () => {
-        canvas.begin();
-        canvas.moveTo(
-          pt.x - unitX - unitY / widthFactor,
-          pt.y - unitY + unitX / widthFactor
-        );
-        canvas.lineTo(pt.x, pt.y);
-        canvas.lineTo(
-          pt.x + unitY / widthFactor - unitX,
-          pt.y - unitY - unitX / widthFactor
-        );
-        canvas.stroke();
-      };
-    };
-  }
-
-  MarkerShape.addMarker('open', createOpenArrow(2));
-  MarkerShape.addMarker('openThin', createOpenArrow(3));
-
-  MarkerShape.addMarker(
-    'oval',
-    (
-      canvas: AbstractCanvas2D,
-      shape: Shape,
-      type: ArrowValue,
-      pe: Point,
-      unitX: number,
-      unitY: number,
-      size: number,
-      source: boolean,
-      sw: number,
-      filled: boolean
-    ) => {
-      const a = size / 2;
-
-      const pt = pe.clone();
-      pe.x -= unitX * a;
-      pe.y -= unitY * a;
-
-      return () => {
-        canvas.ellipse(pt.x - a, pt.y - a, size, size);
-
-        if (filled) {
-          canvas.fillAndStroke();
-        } else {
-          canvas.stroke();
-        }
-      };
-    }
-  );
-
-  function diamond(
+function createArrow(widthFactor: number) {
+  return (
     canvas: AbstractCanvas2D,
-    shape: Shape,
-    type: ArrowValue,
+    _shape: Shape,
+    type: StyleArrowValue,
     pe: Point,
     unitX: number,
     unitY: number,
     size: number,
-    source: boolean,
+    _source: boolean,
     sw: number,
     filled: boolean
-  ) {
+  ) => {
     // The angle of the forward facing arrow sides against the x axis is
-    // 45 degrees, 1/sin(45) = 1.4142 / 2 = 0.7071 ( / 2 allows for
-    // only half the strokewidth is processed ). Or 0.9862 for thin diamond.
-    // Note these values and the tk variable below are dependent, update
-    // both together (saves trig hard coding it).
-    const swFactor = type === ARROW.DIAMOND ? 0.7071 : 0.9862;
-    const endOffsetX = unitX * sw * swFactor;
-    const endOffsetY = unitY * sw * swFactor;
+    // 26.565 degrees, 1/sin(26.565) = 2.236 / 2 = 1.118 ( / 2 allows for
+    // only half the strokewidth is processed ).
+    const endOffsetX = unitX * sw * 1.118;
+    const endOffsetY = unitY * sw * 1.118;
 
     unitX *= size + sw;
     unitY *= size + sw;
@@ -239,18 +96,26 @@ class MarkerShape {
     pt.x -= endOffsetX;
     pt.y -= endOffsetY;
 
-    pe.x += -unitX - endOffsetX;
-    pe.y += -unitY - endOffsetY;
-
-    // thickness factor for diamond
-    const tk = type === ARROW.DIAMOND ? 2 : 3.4;
+    const f = type !== ARROW.CLASSIC && type !== ARROW.CLASSIC_THIN ? 1 : 3 / 4;
+    pe.x += -unitX * f - endOffsetX;
+    pe.y += -unitY * f - endOffsetY;
 
     return () => {
       canvas.begin();
       canvas.moveTo(pt.x, pt.y);
-      canvas.lineTo(pt.x - unitX / 2 - unitY / tk, pt.y + unitX / tk - unitY / 2);
-      canvas.lineTo(pt.x - unitX, pt.y - unitY);
-      canvas.lineTo(pt.x - unitX / 2 + unitY / tk, pt.y - unitY / 2 - unitX / tk);
+      canvas.lineTo(
+        pt.x - unitX - unitY / widthFactor,
+        pt.y - unitY + unitX / widthFactor
+      );
+
+      if (type === ARROW.CLASSIC || type === ARROW.CLASSIC_THIN) {
+        canvas.lineTo(pt.x - (unitX * 3) / 4, pt.y - (unitY * 3) / 4);
+      }
+
+      canvas.lineTo(
+        pt.x + unitY / widthFactor - unitX,
+        pt.y - unitY - unitX / widthFactor
+      );
       canvas.close();
 
       if (filled) {
@@ -259,10 +124,149 @@ class MarkerShape {
         canvas.stroke();
       }
     };
+  };
+}
+
+function createOpenArrow(widthFactor: number) {
+  return (
+    canvas: AbstractCanvas2D,
+    _shape: Shape,
+    _type: StyleArrowValue,
+    pe: Point,
+    unitX: number,
+    unitY: number,
+    size: number,
+    _source: boolean,
+    sw: number,
+    _filled: boolean
+  ) => {
+    // The angle of the forward facing arrow sides against the x axis is
+    // 26.565 degrees, 1/sin(26.565) = 2.236 / 2 = 1.118 ( / 2 allows for
+    // only half the strokewidth is processed ).
+    const endOffsetX = unitX * sw * 1.118;
+    const endOffsetY = unitY * sw * 1.118;
+
+    unitX *= size + sw;
+    unitY *= size + sw;
+
+    const pt = pe.clone();
+    pt.x -= endOffsetX;
+    pt.y -= endOffsetY;
+
+    pe.x += -endOffsetX * 2;
+    pe.y += -endOffsetY * 2;
+
+    return () => {
+      canvas.begin();
+      canvas.moveTo(
+        pt.x - unitX - unitY / widthFactor,
+        pt.y - unitY + unitX / widthFactor
+      );
+      canvas.lineTo(pt.x, pt.y);
+      canvas.lineTo(
+        pt.x + unitY / widthFactor - unitX,
+        pt.y - unitY - unitX / widthFactor
+      );
+      canvas.stroke();
+    };
+  };
+}
+
+const oval = (
+  canvas: AbstractCanvas2D,
+  _shape: Shape,
+  _type: StyleArrowValue,
+  pe: Point,
+  unitX: number,
+  unitY: number,
+  size: number,
+  _source: boolean,
+  _sw: number,
+  filled: boolean
+) => {
+  const a = size / 2;
+
+  const pt = pe.clone();
+  pe.x -= unitX * a;
+  pe.y -= unitY * a;
+
+  return () => {
+    canvas.ellipse(pt.x - a, pt.y - a, size, size);
+
+    if (filled) {
+      canvas.fillAndStroke();
+    } else {
+      canvas.stroke();
+    }
+  };
+};
+
+function diamond(
+  canvas: AbstractCanvas2D,
+  _shape: Shape,
+  type: StyleArrowValue,
+  pe: Point,
+  unitX: number,
+  unitY: number,
+  size: number,
+  _source: boolean,
+  sw: number,
+  filled: boolean
+) {
+  // The angle of the forward facing arrow sides against the x axis is
+  // 45 degrees, 1/sin(45) = 1.4142 / 2 = 0.7071 ( / 2 allows for
+  // only half the strokewidth is processed ). Or 0.9862 for thin diamond.
+  // Note these values and the tk variable below are dependent, update
+  // both together (saves trig hard coding it).
+  const swFactor = type === ARROW.DIAMOND ? 0.7071 : 0.9862;
+  const endOffsetX = unitX * sw * swFactor;
+  const endOffsetY = unitY * sw * swFactor;
+
+  unitX *= size + sw;
+  unitY *= size + sw;
+
+  const pt = pe.clone();
+  pt.x -= endOffsetX;
+  pt.y -= endOffsetY;
+
+  pe.x += -unitX - endOffsetX;
+  pe.y += -unitY - endOffsetY;
+
+  // thickness factor for diamond
+  const tk = type === ARROW.DIAMOND ? 2 : 3.4;
+
+  return () => {
+    canvas.begin();
+    canvas.moveTo(pt.x, pt.y);
+    canvas.lineTo(pt.x - unitX / 2 - unitY / tk, pt.y + unitX / tk - unitY / 2);
+    canvas.lineTo(pt.x - unitX, pt.y - unitY);
+    canvas.lineTo(pt.x - unitX / 2 + unitY / tk, pt.y - unitY / 2 - unitX / tk);
+    canvas.close();
+
+    if (filled) {
+      canvas.fillAndStroke();
+    } else {
+      canvas.stroke();
+    }
+  };
+}
+
+let isDefaultMarkersRegistered = false;
+export const registerDefaultEdgeMarkers = (): void => {
+  if (!isDefaultMarkersRegistered) {
+    MarkerShape.addMarker('classic', createArrow(2));
+    MarkerShape.addMarker('classicThin', createArrow(3));
+    MarkerShape.addMarker('block', createArrow(2));
+    MarkerShape.addMarker('blockThin', createArrow(3));
+
+    MarkerShape.addMarker('open', createOpenArrow(2));
+    MarkerShape.addMarker('openThin', createOpenArrow(3));
+
+    MarkerShape.addMarker('oval', oval);
+
+    MarkerShape.addMarker('diamond', diamond);
+    MarkerShape.addMarker('diamondThin', diamond);
+
+    isDefaultMarkersRegistered = true;
   }
-
-  MarkerShape.addMarker('diamond', diamond);
-  MarkerShape.addMarker('diamondThin', diamond);
-})();
-
-export default MarkerShape;
+};

--- a/packages/html/stories/Markers.stories.ts
+++ b/packages/html/stories/Markers.stories.ts
@@ -25,7 +25,7 @@ import {
   ArrowShape,
   Point,
 } from '@maxgraph/core';
-import type { AbstractCanvas2D, ArrowValue, Shape } from '@maxgraph/core';
+import type { AbstractCanvas2D, Shape, StyleArrowValue } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
 import { createGraphContainer } from './shared/configure.js';
 
@@ -52,7 +52,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
     function (
       canvas: AbstractCanvas2D,
       _shape: Shape,
-      _type: ArrowValue,
+      _type: StyleArrowValue,
       pe: Point,
       unitX: number,
       unitY: number,


### PR DESCRIPTION
Explicitly call a function in charge of registering the edge markers instead of using IIFE.
This prepares the package to be declared without side-effects and will later allow markers not to be loaded by default.

In addition, introduce the `MarkerFactoryFunction` type to better guide implementers of new edge markers.


## Notes

There are now less side effects by explicitly call the registry, like done in https://github.com/maxGraph/maxGraph/pull/311/files.
This is what was done in a POC that migrate mxGraph to ES6, see:
  - https://github.com/adrianhdezm/mxgraph-es6/blob/cafafa9/src/shape/mxMarker.js
  - https://github.com/adrianhdezm/mxgraph-es6/blob/cafafa9212e51062d5ac96c0e1d03ce334bb28f5/src/bootstrap.js#L157

The changes have been tested by running the Markers story.

The  types are consistent with typed-mxgraph: https://github.com/typed-mxgraph/typed-mxgraph/blob/187dd4f0dc7644c0cfbc998dae5fc90879597d81/lib/shape/mxMarker.d.ts#L19

ts-example size
- before: 461.23 kB
- after: 461.50 kB


