### PR TITLE
docs: declare JSDoc of TooltipMixin in type definition

### DIFF
--- a/packages/core/src/util/Dictionary.ts
+++ b/packages/core/src/util/Dictionary.ts
@@ -19,21 +19,15 @@ limitations under the License.
 import { IdentityFunction, IdentityObject } from '../types';
 import ObjectIdentity from './ObjectIdentity';
 
-//type Dictionary<T, U> = {
-//  [key: string]: U;
-//};
-
 type MapKey = string;
 
 type Visitor<MapKey, U> = (key: MapKey, value: U) => void;
 
 /**
- * A wrapper class for an associative array with object keys. Note: This
- * implementation uses {@link ObjectIdentitiy} to turn object keys into strings.
+ * A wrapper class for an associative array with object keys.
  *
- * Constructor: mxEventSource
+ * Note: This implementation uses {@link IdentityObject} to turn object keys into strings.
  *
- * Constructs a new dictionary which allows object to be used as keys.
  */
 class Dictionary<T extends IdentityObject | IdentityFunction | null, U> {
   constructor() {

--- a/packages/core/src/util/Dictionary.ts
+++ b/packages/core/src/util/Dictionary.ts
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IdentityFunction, IdentityObject } from '../types';
+import type { IdentityFunction, IdentityObject } from '../types';
 import ObjectIdentity from './ObjectIdentity';
 
 type MapKey = string;
@@ -26,7 +26,7 @@ type Visitor<MapKey, U> = (key: MapKey, value: U) => void;
 /**
  * A wrapper class for an associative array with object keys.
  *
- * Note: This implementation uses {@link IdentityObject} to turn object keys into strings.
+ * Note: This implementation uses {@link ObjectIdentity} to turn object keys into strings.
  *
  */
 class Dictionary<T extends IdentityObject | IdentityFunction | null, U> {

--- a/packages/core/src/view/Graph.ts
+++ b/packages/core/src/view/Graph.ts
@@ -1285,13 +1285,12 @@ class Graph extends EventSource {
   }
 
   /**
-   * Returns the textual representation for the given cell. This
-   * implementation returns the nodename or string-representation of the user
-   * object.
+   * Returns the textual representation for the given cell.
+   *
+   * This implementation returns the node name or string-representation of the user object.
    *
    *
-   * The following returns the label attribute from the cells user
-   * object if it is an XML node.
+   * The following returns the label attribute from the cells user object if it is an XML node.
    *
    * @example
    * ```javascript
@@ -1303,7 +1302,7 @@ class Graph extends EventSource {
    *
    * See also: {@link cellLabelChanged}.
    *
-   * @param cell {@link mxCell} whose textual representation should be returned.
+   * @param cell {@link Cell} whose textual representation should be returned.
    */
   convertValueToString(cell: Cell): string {
     const value = cell.getValue();
@@ -1320,10 +1319,11 @@ class Graph extends EventSource {
   }
 
   /**
-   * Returns the string to be used as the link for the given cell. This
-   * implementation returns null.
+   * Returns the string to be used as the link for the given cell.
    *
-   * @param cell {@link mxCell} whose tooltip should be returned.
+   * This implementation returns null.
+   *
+   * @param cell {@link Cell} whose link should be returned.
    */
   getLinkForCell(cell: Cell): string | null {
     return null;

--- a/packages/html/stories/HelloPort.stories.ts
+++ b/packages/html/stories/HelloPort.stories.ts
@@ -70,8 +70,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
     return geo?.relative ?? false;
   };
 
-  // Implements a tooltip that shows the actual
-  // source and target of an edge
+  // Implements a tooltip that shows the actual source and target of an edge
   graph.getTooltipForCell = function (cell) {
     if (cell && cell.isEdge()) {
       const source = cell.getTerminal(true);


### PR DESCRIPTION
This makes the JSDoc available for consumer.
It was previously set on the implementation which is hidden, so it was useless.

Also add minor JSDoc improvement in `Dictionary` and `Graph`.