### PR TITLE
fix!: make `cellArrayUtils.getOpposite` return an array of Cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 GlobalConfig.logger = new MaxLogAsLogger();
 ```
 - `MaxWindow.activeWindow` is no longer available; it was intended for internal use only, so there's no reason to make it public.
+- The signature of `cellArrayUtils.getOpposites` has changed. It now returns an array and take an edges Cell array parameter.
+Previously it was returning a function and this was an extra indirection. This is now simpler to use and match the signature of the mxGraph function.
+
 
 ## 0.10.3
 

--- a/packages/core/__tests__/util/cellArrayUtils.test.ts
+++ b/packages/core/__tests__/util/cellArrayUtils.test.ts
@@ -1,0 +1,75 @@
+/*
+Copyright 2024-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, expect, test } from '@jest/globals';
+import { getOpposites } from '../../src/util/cellArrayUtils';
+import Cell from '../../src/view/cell/Cell';
+
+describe('getOpposites', () => {
+  const edges: Cell[] = [];
+  const terminal = new Cell();
+
+  // source == terminal
+  const edge1 = new Cell();
+  edge1.setTerminal(terminal, true);
+  const oppositeOfMatchingSource = new Cell();
+  edge1.setTerminal(oppositeOfMatchingSource, false);
+  edges.push(edge1);
+  // target == terminal
+  const edge2 = new Cell();
+  const oppositeOfMatchingTarget = new Cell();
+  edge2.setTerminal(oppositeOfMatchingTarget, true);
+  edge2.setTerminal(terminal, false);
+  edges.push(edge2);
+  // edge without source and target
+  const edge3 = new Cell();
+  edges.push(edge3);
+
+  // edge with source matching terminal, but no target
+  const edge4 = new Cell();
+  edge4.setTerminal(terminal, true);
+  edges.push(edge4);
+
+  // edge with target matching terminal, but no target
+  const edge5 = new Cell();
+  edge5.setTerminal(terminal, false);
+  edges.push(edge5);
+
+  // edge with no match terminal
+  const edge6 = new Cell();
+  edge6.setTerminal(new Cell(), true);
+  edge6.setTerminal(new Cell(), false);
+  edges.push(edge6);
+
+  test('include sources and targets', () => {
+    expect(getOpposites(edges, terminal)).toStrictEqual([
+      oppositeOfMatchingSource,
+      oppositeOfMatchingTarget,
+    ]);
+  });
+
+  test('include sources', () => {
+    expect(getOpposites(edges, terminal, true, false)).toStrictEqual([
+      oppositeOfMatchingTarget,
+    ]);
+  });
+
+  test('include targets', () => {
+    expect(getOpposites(edges, terminal, false, true)).toStrictEqual([
+      oppositeOfMatchingSource,
+    ]);
+  });
+});

--- a/packages/core/src/util/cellArrayUtils.ts
+++ b/packages/core/src/util/cellArrayUtils.ts
@@ -19,42 +19,41 @@ export const filterCells = (filter: Function) => (cells: Cell[]) => {
 };
 
 /**
- * Returns all opposite vertices wrt terminal for the given edges, only
- * returning sources and/or targets as specified. The result is returned
- * as an array of {@link Cell}.
+ * Returns all opposite vertices terminal for the given edges, only returning sources and/or targets as specified.
+ * The result is returned as an array of {@link Cell}.
  *
+ * @param edges Array of {Cell} that contain the edges to be examined.
  * @param {Cell} terminal  that specifies the known end of the edges.
- * @param sources  Boolean that specifies if source terminals should be contained
- * in the result. Default is true.
- * @param targets  Boolean that specifies if target terminals should be contained
- * in the result. Default is true.
+ * @param includeSources  Boolean that specifies if source terminals should be included in the result. Default is `true`.
+ * @param includeTargets  Boolean that specifies if target terminals should be included in the result. Default is `true`.
  */
-export const getOpposites =
-  (terminal: Cell, sources = true, targets = true) =>
-  (edges: Cell[]) => {
-    const terminals = [] as Cell[];
+export const getOpposites = (
+  edges: Cell[],
+  terminal: Cell,
+  includeSources = true,
+  includeTargets = true
+): Cell[] => {
+  return edges.reduce((terminals, edge) => {
+    const source = edge.getTerminal(true);
+    const target = edge.getTerminal(false);
 
-    for (let i = 0; i < edges.length; i += 1) {
-      const source = edges[i].getTerminal(true);
-      const target = edges[i].getTerminal(false);
-
-      // Checks if the terminal is the source of
-      // the edge and if the target should be
-      // stored in the result
-      if (source === terminal && target != null && target !== terminal && targets) {
-        terminals.push(target);
-      }
-
-      // Checks if the terminal is the taget of
-      // the edge and if the source should be
-      // stored in the result
-      else if (target === terminal && source != null && source !== terminal && sources) {
-        terminals.push(source);
-      }
+    // Checks if the terminal is the source of the edge and if the target should be stored in the result
+    if (source === terminal && target != null && target !== terminal && includeTargets) {
+      terminals.push(target);
+    }
+    // Checks if the terminal is the target of the edge and if the source should be stored in the result
+    else if (
+      target === terminal &&
+      source != null &&
+      source !== terminal &&
+      includeSources
+    ) {
+      terminals.push(source);
     }
 
     return terminals;
-  };
+  }, [] as Cell[]);
+};
 
 /**
  * Returns the topmost cells of the hierarchy in an array that contains no
@@ -163,8 +162,7 @@ const cloneCellImpl = (cell: Cell, mapping: any = {}, includeChildren = false): 
 };
 
 /**
- * Inner helper method for restoring the connections in
- * a network of cloned cells.
+ * Inner helper method for restoring the connections in a network of cloned cells.
  *
  * @private
  */

--- a/packages/website/docs/usage/migrate-from-mxgraph.md
+++ b/packages/website/docs/usage/migrate-from-mxgraph.md
@@ -344,17 +344,15 @@ Moved methods
 
 
 ### Cell manipulation
-Functions that existed in mxGraph and mxGraphModel have been removed. They provided a way to extend/override the default behavior of mxGraphModel or mxCell.
-Only the functions for mxCell/Cell remain. See https://github.com/maxGraph/maxGraph/pull/24
 
-
-Some functions previously available in `mxGraph` and `mxGraphModel` have been removed. These functions allowed for customizing the behavior of `mxGraphModel` and `mxCell`. However, now only the functions specific to `mxCell`/`Cell` remain.  
+Some methods previously available in `mxGraph` and `mxGraphModel` have been removed. These methods allowed for customizing the behavior of `mxGraphModel` and `mxCell`. However, now only the methods specific to `Cell` remain.  
 
 :::note
 
 You can find more information about these changes in the following GitHub pull request: https://github.com/maxGraph/maxGraph/pull/24.
 
 :::
+
 
 #### `mxCell`
 
@@ -372,15 +370,24 @@ Some methods were removed:
 
 #### `mxGraphDataModel`
 
-Several functions from the `mxGraphDataModel` class have been moved to the `Cell` class. These functions no longer need the `cell` parameter:
+Several methods from the `mxGraphDataModel` class have been moved to the `Cell` class. These methods no longer need the `cell` parameter:
 
 - `filterDescendants()`
 - `getGeometry()`
 - `isEdge()`
 - `getParent()`
 
+Some methods in `mxGraphModel` that were general manipulation of cells and independent of the model have been moved to the `cellArrayUtils` namespace and are now available as individual functions.
+- `cloneImpl()` (should not be used, private implementation)
+- `cloneCells()`
+- `getOpposite()`
+- `getParents()`
+- `getTopmostCells()`
+- `restoreClone()` (should not be used, private implementation)
+
 Others were removed:
-- `mxGraphModel.isVisible(cell)` see https://github.com/maxGraph/maxGraph/discussions/179#discussioncomment-5389942 for rationale
+- `isVisible(cell)` see https://github.com/maxGraph/maxGraph/discussions/179#discussioncomment-5389942 for rationale
+- `cloneCell()`
 
 ### Misc
 


### PR DESCRIPTION
Previously, it returned a function which created an extra indirection and make it harder to migrate from mxGraph as it didn't match the original signature.
Also simplify the implementation after having added tests to validate the expected behavior.

BREAKING CHANGES:
- The signature of `cellArrayUtils.getOpposites` has changed. It now returns an array and take an edges Cell array parameter.



## Notes

`mxGraph` original code in `mxGraphModel`: https://github.com/jgraph/mxgraph/blob/v4.2.2/javascript/src/js/model/mxGraphModel.js#L1457

Covers #355


