### PR TITLE
fix!: `cellArrayUtils.cloneCells` correctly calls `restoreClone`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ GlobalConfig.logger = new MaxLogAsLogger();
 - `MaxWindow.activeWindow` is no longer available; it was intended for internal use only, so there's no reason to make it public.
 - The signature of `cellArrayUtils.getOpposites` has changed. It now returns an array and take an edges Cell array parameter.
 Previously it was returning a function and this was an extra indirection. This is now simpler to use and match the signature of the mxGraph function.
-
+- `cellArrayUtils.restoreClone` is no longer available. It was intended to be private.
 
 ## 0.10.3
 

--- a/packages/core/src/util/cellArrayUtils.ts
+++ b/packages/core/src/util/cellArrayUtils.ts
@@ -112,10 +112,9 @@ export const getParents = (cells: Cell[]) => {
  * Returns an array of clones for the given array of {@link Cell}`.
  * Depending on the value of includeChildren, a deep clone is created for
  * each cell. Connections are restored based if the corresponding
- * cell is contained in the passed in array.
+ * cell is contained in the provided in array.
  *
- * @param includeChildren  Boolean indicating if the cells should be cloned
- * with all descendants.
+ * @param includeChildren  Boolean indicating if the cells should be cloned with all descendants.
  * @param mapping  Optional mapping for existing clones.
  */
 export const cloneCells =
@@ -142,12 +141,12 @@ export const cloneCells =
  * @private
  */
 const cloneCellImpl = (cell: Cell, mapping: any = {}, includeChildren = false): Cell => {
-  const ident = <string>ObjectIdentity.get(cell);
-  let clone = mapping ? mapping[ident] : null;
+  const identity = <string>ObjectIdentity.get(cell);
+  let clone = mapping ? mapping[identity] : null;
 
   if (clone == null) {
     clone = cell.clone();
-    mapping[ident] = clone;
+    mapping[identity] = clone;
 
     if (includeChildren) {
       const childCount = cell.getChildCount();
@@ -166,27 +165,25 @@ const cloneCellImpl = (cell: Cell, mapping: any = {}, includeChildren = false): 
  *
  * @private
  */
-export const restoreClone =
-  (clone: Cell, cell: Cell, mapping: any) => (cells: Cell[]) => {
-    const source = cell.getTerminal(true);
-
-    if (source != null) {
-      const tmp = mapping[<string>ObjectIdentity.get(source)];
-      if (tmp != null) {
-        tmp.insertEdge(clone, true);
-      }
+const restoreClone = (clone: Cell, cell: Cell, mapping: any): void => {
+  const source = cell.getTerminal(true);
+  if (source != null) {
+    const tmp = mapping[<string>ObjectIdentity.get(source)];
+    if (tmp != null) {
+      tmp.insertEdge(clone, true);
     }
+  }
 
-    const target = cell.getTerminal(false);
-    if (target != null) {
-      const tmp = mapping[<string>ObjectIdentity.get(target)];
-      if (tmp != null) {
-        tmp.insertEdge(clone, false);
-      }
+  const target = cell.getTerminal(false);
+  if (target != null) {
+    const tmp = mapping[<string>ObjectIdentity.get(target)];
+    if (tmp != null) {
+      tmp.insertEdge(clone, false);
     }
+  }
 
-    const childCount = clone.getChildCount();
-    for (let i = 0; i < childCount; i += 1) {
-      restoreClone(<Cell>clone.getChildAt(i), <Cell>cell.getChildAt(i), mapping);
-    }
-  };
+  const childCount = clone.getChildCount();
+  for (let i = 0; i < childCount; i += 1) {
+    restoreClone(<Cell>clone.getChildAt(i), <Cell>cell.getChildAt(i), mapping);
+  }
+};

--- a/packages/core/src/view/GraphDataModel.ts
+++ b/packages/core/src/view/GraphDataModel.ts
@@ -1104,7 +1104,6 @@ export class GraphDataModel extends EventSource {
    * id in the target model are reconnected to reflect the terminals of the
    * source edges.
    */
-  // mergeChildren(from: Transactions, to: Transactions, cloneAllEdges?: boolean): void;
   mergeChildren(from: Cell, to: Cell, cloneAllEdges = true): void {
     this.beginUpdate();
     try {
@@ -1141,7 +1140,6 @@ export class GraphDataModel extends EventSource {
    * cell to the target cell with the same id or the clone of the source cell
    * that was inserted into this model.
    */
-  // mergeChildrenImpl(from: Transactions, to: Transactions, cloneAllEdges: boolean, mapping: any): void;
   mergeChildrenImpl(from: Cell, to: Cell, cloneAllEdges: boolean, mapping: any = {}) {
     this.beginUpdate();
     try {
@@ -1184,21 +1182,18 @@ export class GraphDataModel extends EventSource {
     }
   }
 
-  //
-  // Cell Cloning
-  //
-
   /**
-   * Returns a deep clone of the given {@link Cell}` (including
-   * the children) which is created using {@link cloneCells}`.
+   * Returns a deep clone of the given {@link Cell}` (including the children) which is created using {@link cloneCells}`.
    *
-   * @param {Cell} cell  to be cloned.
+   * @param cell {@link Cell} to be cloned. Default is `null`.
+   * @param includeChildren Boolean indicating if the cells should be cloned with all descendants. Default is `true`.
    */
   cloneCell(cell: Cell | null = null, includeChildren = true): Cell | null {
-    if (cell != null) {
-      return cloneCells(includeChildren)([cell])[0];
+    if (!cell) {
+      return null;
     }
-    return null;
+
+    return cloneCells(includeChildren)([cell])[0];
   }
 }
 

--- a/packages/core/src/view/cell/Cell.ts
+++ b/packages/core/src/view/cell/Cell.ts
@@ -377,9 +377,8 @@ export class Cell implements IdentityObject {
   /**
    * Sets the source or target terminal and returns the new terminal.
    *
-   * @param {Cell} terminal     mxCell that represents the new source or target terminal.
-   * @param {boolean} isSource  boolean that specifies if the source or target terminal
-   * should be set.
+   * @param terminal  Cell that represents the new source or target terminal.
+   * @param isSource  boolean that specifies if the source or target terminal should be set.
    */
   setTerminal(terminal: Cell | null, isSource: boolean) {
     if (isSource) {
@@ -401,7 +400,7 @@ export class Cell implements IdentityObject {
   /**
    * Returns the index of the specified child in the child array.
    *
-   * @param childChild whose index should be returned.
+   * @param child Child whose index should be returned.
    */
   getIndex(child: Cell | null) {
     if (child === null) return -1;

--- a/packages/website/docs/usage/migrate-from-mxgraph.md
+++ b/packages/website/docs/usage/migrate-from-mxgraph.md
@@ -378,16 +378,15 @@ Several methods from the `mxGraphDataModel` class have been moved to the `Cell` 
 - `getParent()`
 
 Some methods in `mxGraphModel` that were general manipulation of cells and independent of the model have been moved to the `cellArrayUtils` namespace and are now available as individual functions.
-- `cloneImpl()` (should not be used, private implementation)
 - `cloneCells()`
 - `getOpposite()`
 - `getParents()`
 - `getTopmostCells()`
-- `restoreClone()` (should not be used, private implementation)
 
 Others were removed:
+- `cloneImpl()`
 - `isVisible(cell)` see https://github.com/maxGraph/maxGraph/discussions/179#discussioncomment-5389942 for rationale
-- `cloneCell()`
+- `restoreClone()` (from version 0.11.0)
 
 ### Misc
 


### PR DESCRIPTION
Initiate tests of the function to reproduce the problem and fix it.
The tests don't cover the whole code of the function and could be enriched later.

BREAKING CHANGES: `cellArrayUtils.restoreClone` is no longer available. It was intended to be private.



## Notes

Closes #355


