### PR TITLE
docs: declare JSDoc of `SwimlaneMixin` in type definition

### DIFF
--- a/packages/core/src/view/mixins/SwimlaneMixin.ts
+++ b/packages/core/src/view/mixins/SwimlaneMixin.ts
@@ -27,27 +27,137 @@ import { CellStateStyle, DirectionValue } from '../../types';
 
 declare module '../Graph' {
   interface Graph {
+    /**
+     * Specifies if swimlanes should be selectable via the content if the mouse is released.
+     * @default true
+     */
     swimlaneSelectionEnabled: boolean;
+
+    /**
+     * Specifies if nesting of swimlanes is allowed.
+     * @default true
+     */
     swimlaneNesting: boolean;
+
+    /**
+     * The attribute used to find the color for the indicator if the indicator color is set to 'swimlane'.
+     * @default {@link 'fillColor'}
+     */
     swimlaneIndicatorColorAttribute: string;
 
+    /**
+     * Returns the nearest ancestor of the given cell which is a swimlane, or the given cell, if it is itself a swimlane.
+     *
+     * @param cell {@link Cell} for which the ancestor swimlane should be returned.
+     */
     getSwimlane: (cell: Cell | null) => Cell | null;
+
+    /**
+     * Returns the bottom-most swimlane that intersects the given point (x, y) in the cell hierarchy that starts at the given parent.
+     *
+     * @param x X-coordinate of the location to be checked.
+     * @param y Y-coordinate of the location to be checked.
+     * @param parent {@link mxCell} that should be used as the root of the recursion. Default is {@link defaultParent}.
+     */
     getSwimlaneAt: (x: number, y: number, parent?: Cell | null) => Cell | null;
+
+    /**
+     * Returns `true` if the given coordinate pair is inside the content are of the given swimlane.
+     *
+     * @param swimlane {@link Cell} that specifies the swimlane.
+     * @param x X-coordinate of the mouse event.
+     * @param y Y-coordinate of the mouse event.
+     */
     hitsSwimlaneContent: (swimlane: Cell, x: number, y: number) => boolean;
+
+    /**
+     * Returns the start size of the given swimlane, that is, the width or height of the part that contains the title, depending on the horizontal style.
+     * The return value is an {@link Rectangle} with either width or height set as appropriate.
+     *
+     * @param swimlane {@link mxCell} whose start size should be returned.
+     * @param ignoreState Optional boolean that specifies if cell state should be ignored.
+     */
     getStartSize: (swimlane: Cell, ignoreState?: boolean) => Rectangle;
+
+    /**
+     * Returns the direction for the given swimlane style.
+     */
     getSwimlaneDirection: (style: CellStateStyle) => DirectionValue;
+
+    /**
+     * Returns the actual start size of the given swimlane taking into account direction and horizontal and vertical flip styles.
+     * The start size is returned as an {@link Rectangle} where top, left, bottom, right start sizes are returned as x, y, height and width, respectively.
+     *
+     * @param swimlane {@link mxCell} whose start size should be returned.
+     * @param ignoreState Optional boolean that specifies if cell state should be ignored.
+     */
     getActualStartSize: (swimlane: Cell, ignoreState: boolean) => Rectangle;
+
+    /**
+     * Returns `true` if the given cell is a swimlane in the graph.
+     * A swimlane is a container cell with some specific behaviour. This implementation
+     * checks if the shape associated with the given cell is a {@link SwimlaneShape}.
+     *
+     * @param cell {@link Cell} to be checked.
+     * @param ignoreState Optional boolean that specifies if the cell state should be ignored.
+     */
     isSwimlane: (cell: Cell, ignoreState?: boolean) => boolean;
+
+    /**
+     * Returns `true` if the given cell is a valid drop target for the specified cells.
+     *
+     * If {@link splitEnabled} is true then this returns {@link isSplitTarget} for the given arguments else it returns true if the cell is not collapsed
+     * and its child count is greater than 0.
+     *
+     * @param cell {@link Cell} that represents the possible drop target.
+     * @param cells {@link Cell} that should be dropped into the target.
+     * @param evt Mouseevent that triggered the invocation.
+     */
     isValidDropTarget: (cell: Cell, cells?: Cell[], evt?: MouseEvent | null) => boolean;
+
+    /**
+     * Returns the given cell if it is a drop target for the given cells or the nearest ancestor that may be used as a drop target for the given cells.
+     *
+     * If the given array contains a swimlane and {@link swimlaneNesting} is `false` then this always returns `null`.
+     * If no cell is given, then the bottommost swimlane at the location of the given event is returned.
+     *
+     * This function should only be used if {@link isDropEnabled} returns true.
+     *
+     * @param cells Array of {@link Cell} which are to be dropped onto the target.
+     * @param evt Mouse event for the drag and drop.
+     * @param cell {@link Cell} that is under the mouse pointer.
+     * @param clone Optional boolean to indicate of cells will be cloned.
+     */
     getDropTarget: (
       cells: Cell[],
       evt: MouseEvent,
       cell: Cell | null,
       clone?: boolean
     ) => Cell | null;
+
+    /**
+     * Returns {@link swimlaneNesting} as a boolean.
+     */
     isSwimlaneNesting: () => boolean;
+
+    /**
+     * Specifies if swimlanes can be nested by drag and drop.
+     * This is only taken into account if dropEnabled is true.
+     *
+     * @param value Boolean indicating if swimlanes can be nested.
+     */
     setSwimlaneNesting: (value: boolean) => void;
+
+    /**
+     * Returns {@link swimlaneSelectionEnabled} as a boolean.
+     */
     isSwimlaneSelectionEnabled: () => boolean;
+
+    /**
+     * Specifies if swimlanes should be selected if the mouse is released over their content area.
+     *
+     * @param value Boolean indicating if swimlanes content areas should be selected when the mouse is released over them.
+     */
     setSwimlaneSelectionEnabled: (value: boolean) => void;
   }
 }
@@ -89,32 +199,12 @@ type PartialType = PartialGraph & PartialSwimlane;
 
 // @ts-expect-error The properties of PartialGraph are defined elsewhere.
 const SwimlaneMixin: PartialType = {
-  /**
-   * Specifies if swimlanes should be selectable via the content if the
-   * mouse is released.
-   * @default true
-   */
   swimlaneSelectionEnabled: true,
 
-  /**
-   * Specifies if nesting of swimlanes is allowed.
-   * @default true
-   */
   swimlaneNesting: true,
 
-  /**
-   * The attribute used to find the color for the indicator if the indicator
-   * color is set to 'swimlane'.
-   * @default {@link 'fillColor'}
-   */
   swimlaneIndicatorColorAttribute: 'fillColor',
 
-  /**
-   * Returns the nearest ancestor of the given cell which is a swimlane, or
-   * the given cell, if it is itself a swimlane.
-   *
-   * @param cell {@link mxCell} for which the ancestor swimlane should be returned.
-   */
   getSwimlane(cell = null) {
     while (cell && !this.isSwimlane(cell)) {
       cell = cell.getParent();
@@ -122,15 +212,6 @@ const SwimlaneMixin: PartialType = {
     return cell;
   },
 
-  /**
-   * Returns the bottom-most swimlane that intersects the given point (x, y)
-   * in the cell hierarchy that starts at the given parent.
-   *
-   * @param x X-coordinate of the location to be checked.
-   * @param y Y-coordinate of the location to be checked.
-   * @param parent {@link mxCell} that should be used as the root of the recursion.
-   * Default is {@link defaultParent}.
-   */
   getSwimlaneAt(x, y, parent) {
     if (!parent) {
       parent = this.getCurrentRoot();
@@ -165,14 +246,6 @@ const SwimlaneMixin: PartialType = {
     return null;
   },
 
-  /**
-   * Returns true if the given coordinate pair is inside the content
-   * are of the given swimlane.
-   *
-   * @param swimlane {@link mxCell} that specifies the swimlane.
-   * @param x X-coordinate of the mouse event.
-   * @param y Y-coordinate of the mouse event.
-   */
   hitsSwimlaneContent(swimlane, x, y) {
     const state = this.getView().getState(swimlane);
     const size = this.getStartSize(swimlane);
@@ -192,19 +265,6 @@ const SwimlaneMixin: PartialType = {
     return false;
   },
 
-  /*****************************************************************************
-   * Group: Graph appearance
-   *****************************************************************************/
-
-  /**
-   * Returns the start size of the given swimlane, that is, the width or
-   * height of the part that contains the title, depending on the
-   * horizontal style. The return value is an {@link Rectangle} with either
-   * width or height set as appropriate.
-   *
-   * @param swimlane {@link mxCell} whose start size should be returned.
-   * @param ignoreState Optional boolean that specifies if cell state should be ignored.
-   */
   getStartSize(swimlane, ignoreState = false) {
     const result = new Rectangle();
     const style = this.getCurrentCellStyle(swimlane, ignoreState);
@@ -218,9 +278,6 @@ const SwimlaneMixin: PartialType = {
     return result;
   },
 
-  /**
-   * Returns the direction for the given swimlane style.
-   */
   getSwimlaneDirection(style) {
     const dir = style.direction ?? DIRECTION.EAST;
     const flipH = style.flipH;
@@ -251,15 +308,6 @@ const SwimlaneMixin: PartialType = {
     ] as DirectionValue;
   },
 
-  /**
-   * Returns the actual start size of the given swimlane taking into account
-   * direction and horizontal and vertial flip styles. The start size is
-   * returned as an {@link Rectangle} where top, left, bottom, right start sizes
-   * are returned as x, y, height and width, respectively.
-   *
-   * @param swimlane {@link mxCell} whose start size should be returned.
-   * @param ignoreState Optional boolean that specifies if cell state should be ignored.
-   */
   getActualStartSize(swimlane, ignoreState = false) {
     const result = new Rectangle();
 
@@ -281,14 +329,6 @@ const SwimlaneMixin: PartialType = {
     return result;
   },
 
-  /**
-   * Returns true if the given cell is a swimlane in the graph. A swimlane is
-   * a container cell with some specific behaviour. This implementation
-   * checks if the shape associated with the given cell is a {@link mxSwimlane}.
-   *
-   * @param cell {@link mxCell} to be checked.
-   * @param ignoreState Optional boolean that specifies if the cell state should be ignored.
-   */
   isSwimlane(cell, ignoreState = false) {
     if (cell && cell.getParent() !== this.getDataModel().getRoot() && !cell.isEdge()) {
       return this.getCurrentCellStyle(cell, ignoreState).shape === SHAPE.SWIMLANE;
@@ -296,20 +336,6 @@ const SwimlaneMixin: PartialType = {
     return false;
   },
 
-  /*****************************************************************************
-   * Group: Graph behaviour
-   *****************************************************************************/
-
-  /**
-   * Returns true if the given cell is a valid drop target for the specified
-   * cells. If {@link splitEnabled} is true then this returns {@link isSplitTarget} for
-   * the given arguments else it returns true if the cell is not collapsed
-   * and its child count is greater than 0.
-   *
-   * @param cell {@link mxCell} that represents the possible drop target.
-   * @param cells {@link mxCell} that should be dropped into the target.
-   * @param evt Mouseevent that triggered the invocation.
-   */
   isValidDropTarget(cell, cells, evt) {
     return (
       cell &&
@@ -319,20 +345,6 @@ const SwimlaneMixin: PartialType = {
     );
   },
 
-  /**
-   * Returns the given cell if it is a drop target for the given cells or the
-   * nearest ancestor that may be used as a drop target for the given cells.
-   * If the given array contains a swimlane and {@link swimlaneNesting} is false
-   * then this always returns null. If no cell is given, then the bottommost
-   * swimlane at the location of the given event is returned.
-   *
-   * This function should only be used if {@link isDropEnabled} returns true.
-   *
-   * @param cells Array of {@link Cell} which are to be dropped onto the target.
-   * @param evt Mouseevent for the drag and drop.
-   * @param cell {@link mxCell} that is under the mousepointer.
-   * @param clone Optional boolean to indicate of cells will be cloned.
-   */
   getDropTarget(cells, evt, cell = null, clone = false) {
     if (!this.isSwimlaneNesting()) {
       for (let i = 0; i < cells.length; i += 1) {
@@ -382,37 +394,18 @@ const SwimlaneMixin: PartialType = {
     return !this.getDataModel().isLayer(cell) && !parentCell ? cell : null;
   },
 
-  /**
-   * Returns {@link swimlaneNesting} as a boolean.
-   */
   isSwimlaneNesting() {
     return this.swimlaneNesting;
   },
 
-  /**
-   * Specifies if swimlanes can be nested by drag and drop. This is only
-   * taken into account if dropEnabled is true.
-   *
-   * @param value Boolean indicating if swimlanes can be nested.
-   */
   setSwimlaneNesting(value) {
     this.swimlaneNesting = value;
   },
 
-  /**
-   * Returns {@link swimlaneSelectionEnabled} as a boolean.
-   */
   isSwimlaneSelectionEnabled(): boolean {
     return this.swimlaneSelectionEnabled;
   },
 
-  /**
-   * Specifies if swimlanes should be selected if the mouse is released
-   * over their content area.
-   *
-   * @param value Boolean indicating if swimlanes content areas
-   * should be selected when the mouse is released over them.
-   */
   setSwimlaneSelectionEnabled(value) {
     this.swimlaneSelectionEnabled = value;
   },


### PR DESCRIPTION
This makes the JSDoc available for consumer.
It was previously set on the implementation which is hidden, so it was useless.


## Notes

Covers #442 

