### PR TITLE
docs: declare JSDoc of `PortsMixin` in type definition

### DIFF
--- a/packages/core/src/view/mixins/PortsMixin.ts
+++ b/packages/core/src/view/mixins/PortsMixin.ts
@@ -20,11 +20,54 @@ import { Graph } from '../Graph';
 
 declare module '../Graph' {
   interface Graph {
+    /**
+     * Specifies if ports are enabled. This is used in {@link cellConnected} to update the respective style.
+     * @default true
+     */
     portsEnabled: boolean;
 
+    /**
+     * Returns `true` if the given cell is a "port", that is, when connecting to it, the cell returned by {@link getTerminalForPort}
+     * should be used as the terminal and the port should be referenced by the ID in either the {@link CellStateStyle.sourcePort} or the {@link CellStateStyle.sourcePort}.
+     *
+     * Note that a port should not be movable.
+     *
+     * This implementation always returns false.
+     *
+     * A typical implementation is the following:
+     *
+     * ```javascript
+     * graph.isPort = function(cell) {
+     *   const geo = cell.getGeometry();
+     *
+     *   return (geo != null) ? geo.relative : false;
+     * };
+     * ```
+     *
+     * @param cell {@link Cell} that represents the port.
+     */
     isPort: (cell: Cell | null) => boolean;
-    getTerminalForPort: (cell: Cell, source: boolean) => Cell | null;
+
+    /**
+     * Returns the terminal to be used for a given port.
+     *
+     * This implementation always returns the parent cell.
+     *
+     * @param cell {@link Cell} that represents the port.
+     * @param source If the cell is the source or target port. Default is `false`.
+     */
+    getTerminalForPort: (cell: Cell, source?: boolean) => Cell | null;
+
+    /**
+     * Returns {@link portsEnabled}.
+     */
     isPortsEnabled: () => boolean;
+
+    /**
+     * Specifies if the ports should be enabled.
+     *
+     * @param value Boolean indicating if the ports should be enabled.
+     */
     setPortsEnabled: (value: boolean) => void;
   }
 }
@@ -36,69 +79,20 @@ type PartialPorts = Pick<
 type PartialType = PartialPorts;
 
 const PortsMixin: PartialType = {
-  /**
-   * Specifies if ports are enabled. This is used in {@link cellConnected} to update
-   * the respective style.
-   * @default true
-   */
   portsEnabled: true,
 
-  /*****************************************************************************
-   * Group: Drilldown
-   *****************************************************************************/
-
-  /**
-   * Returns true if the given cell is a "port", that is, when connecting to
-   * it, the cell returned by getTerminalForPort should be used as the
-   * terminal and the port should be referenced by the ID in either the
-   * mxConstants.STYLE_SOURCE_PORT or the or the
-   * mxConstants.STYLE_TARGET_PORT. Note that a port should not be movable.
-   * This implementation always returns false.
-   *
-   * A typical implementation is the following:
-   *
-   * ```javascript
-   * graph.isPort = function(cell)
-   * {
-   *   var geo = cell.getGeometry();
-   *
-   *   return (geo != null) ? geo.relative : false;
-   * };
-   * ```
-   *
-   * @param cell {@link mxCell} that represents the port.
-   */
   isPort(cell) {
     return false;
   },
 
-  /**
-   * Returns the terminal to be used for a given port. This implementation
-   * always returns the parent cell.
-   *
-   * @param cell {@link mxCell} that represents the port.
-   * @param source If the cell is the source or target port.
-   */
-  getTerminalForPort(cell, source = false) {
+  getTerminalForPort(cell, _source = false) {
     return cell.getParent();
   },
 
-  /*****************************************************************************
-   * Group: Graph behaviour
-   *****************************************************************************/
-
-  /**
-   * Returns {@link portsEnabled} as a boolean.
-   */
   isPortsEnabled() {
     return this.portsEnabled;
   },
 
-  /**
-   * Specifies if the ports should be enabled.
-   *
-   * @param value Boolean indicating if the ports should be enabled.
-   */
   setPortsEnabled(value) {
     this.portsEnabled = value;
   },


### PR DESCRIPTION
This makes the JSDoc available for consumers.
It was previously set on the implementation which is hidden, so it was useless.

## Notes

Covers #442 