### PR TITLE
docs: declare JSDoc of `DragDropMixin` in type definition

### DIFF
--- a/packages/core/src/view/mixins/DragDropMixin.ts
+++ b/packages/core/src/view/mixins/DragDropMixin.ts
@@ -20,17 +20,80 @@ import { Graph } from '../Graph';
 
 declare module '../Graph' {
   interface Graph {
+    /**
+     * Specifies the return value for {@link isDropEnabled}.
+     * @default false
+     */
     dropEnabled: boolean;
+
+    /**
+     * Specifies if dropping onto edges should be enabled.
+     *
+     * This is ignored if {@link dropEnabled} is `false`.
+     * If enabled, it will call {@link splitEdge} to carry out the drop operation.
+     * @default true
+     */
     splitEnabled: boolean;
+
+    /**
+     * Specifies if the graph should automatically scroll if the mouse goes near
+     * the container edge while dragging.
+     *
+     * This is only taken into account if the container has scrollbars.
+     *
+     * If you need this to work without scrollbars then set {@link ignoreScrollbars} to
+     * true. Please consult the {@link ignoreScrollbars} for details. In general, with
+     * no scrollbars, the use of {@link allowAutoPanning} is recommended.
+     * @default true
+     */
     autoScroll: boolean;
+
+    /**
+     * Specifies if the size of the graph should be automatically extended if the
+     * mouse goes near the container edge while dragging.
+     *
+     * This is only taken into account if the container has scrollbars.
+     *
+     * See {@link autoScroll}.
+     * @default true
+     */
     autoExtend: boolean;
 
     isAutoScroll: () => boolean;
+
     isAutoExtend: () => boolean;
+
+    /**
+     * Returns {@link dropEnabled} as a boolean.
+     */
     isDropEnabled: () => boolean;
+
+    /**
+     * Specifies if the graph should allow dropping of cells onto or into other cells.
+     *
+     * @param value Boolean indicating if the graph should allow dropping of cells into other cells.
+     */
     setDropEnabled: (value: boolean) => void;
+
+    /**
+     * Returns {@link splitEnabled} as a boolean.
+     */
     isSplitEnabled: () => boolean;
+
+    /**
+     * Specifies if the graph should allow dropping of cells onto or into other cells.
+     *
+     * @param value Boolean indicating if the graph should allow dropping of cells into other cells.
+     */
     setSplitEnabled: (value: boolean) => void;
+
+    /**
+     * Returns `true` if the given edge may be split into two edges with the given cell as a new terminal between the two.
+     *
+     * @param target {@link Cell} that represents the edge to be split.
+     * @param cells {@link Cell} that should split the edge.
+     * @param evt MouseEvent that triggered the invocation.
+     */
     isSplitTarget: (target: Cell, cells?: Cell[], evt?: MouseEvent | null) => boolean;
   }
 }
@@ -54,42 +117,16 @@ type PartialType = PartialGraph & PartialDragDrop;
 
 // @ts-expect-error The properties of PartialGraph are defined elsewhere.
 const DragDropMixin: PartialType = {
-  /**
-   * Specifies the return value for {@link isDropEnabled}.
-   * @default false
-   */
   dropEnabled: false,
 
-  /**
-   * Specifies if dropping onto edges should be enabled. This is ignored if
-   * {@link dropEnabled} is `false`. If enabled, it will call {@link splitEdge} to carry
-   * out the drop operation.
-   * @default true
-   */
   splitEnabled: true,
 
-  /**
-   * Specifies if the graph should automatically scroll if the mouse goes near
-   * the container edge while dragging. This is only taken into account if the
-   * container has scrollbars.
-   *
-   * If you need this to work without scrollbars then set {@link ignoreScrollbars} to
-   * true. Please consult the {@link ignoreScrollbars} for details. In general, with
-   * no scrollbars, the use of {@link allowAutoPanning} is recommended.
-   * @default true
-   */
   autoScroll: true,
 
   isAutoScroll() {
     return this.autoScroll;
   },
 
-  /**
-   * Specifies if the size of the graph should be automatically extended if the
-   * mouse goes near the container edge while dragging. This is only taken into
-   * account if the container has scrollbars. See {@link autoScroll}.
-   * @default true
-   */
   autoExtend: true,
 
   isAutoExtend() {
@@ -100,20 +137,10 @@ const DragDropMixin: PartialType = {
    * Group: Graph behaviour
    *****************************************************************************/
 
-  /**
-   * Returns {@link dropEnabled} as a boolean.
-   */
   isDropEnabled() {
     return this.dropEnabled;
   },
 
-  /**
-   * Specifies if the graph should allow dropping of cells onto or into other
-   * cells.
-   *
-   * @param dropEnabled Boolean indicating if the graph should allow dropping
-   * of cells into other cells.
-   */
   setDropEnabled(value) {
     this.dropEnabled = value;
   },
@@ -122,32 +149,14 @@ const DragDropMixin: PartialType = {
    * Group: Split behaviour
    *****************************************************************************/
 
-  /**
-   * Returns {@link splitEnabled} as a boolean.
-   */
   isSplitEnabled() {
     return this.splitEnabled;
   },
 
-  /**
-   * Specifies if the graph should allow dropping of cells onto or into other
-   * cells.
-   *
-   * @param dropEnabled Boolean indicating if the graph should allow dropping
-   * of cells into other cells.
-   */
   setSplitEnabled(value) {
     this.splitEnabled = value;
   },
 
-  /**
-   * Returns true if the given edge may be splitted into two edges with the
-   * given cell as a new terminal between the two.
-   *
-   * @param target {@link mxCell} that represents the edge to be splitted.
-   * @param cells {@link mxCell} that should split the edge.
-   * @param evt Mouseevent that triggered the invocation.
-   */
   isSplitTarget(target, cells = [], evt) {
     if (
       target.isEdge() &&


### PR DESCRIPTION
This makes the JSDoc available for consumers.
It was previously set on the implementation which is hidden, so it was useless.

## Notes

Covers #442 