### PR TITLE
docs: declare JSDoc of `OverlaysMixin` in type definition

### DIFF
--- a/packages/core/src/view/mixins/OverlaysMixin.ts
+++ b/packages/core/src/view/mixins/OverlaysMixin.ts
@@ -25,11 +25,71 @@ import { mixInto } from '../../util/Utils';
 
 declare module '../Graph' {
   interface Graph {
+    /**
+     * Adds an {@link CellOverlay} for the specified cell.
+     *
+     * This method fires an {@link InternalEvent.ADD_OVERLAY} event and returns the new {@link CellOverlay}.
+     *
+     * @param cell {@link Cell} to add the overlay for.
+     * @param overlay {@link CellOverlay} to be added for the cell.
+     */
     addCellOverlay: (cell: Cell, overlay: CellOverlay) => CellOverlay;
+
+    /**
+     * Returns an array of {@link CellOverlay}s for the given cell or `null`, if no overlays are defined.
+     *
+     * @param cell {@link Cell} whose overlays should be returned.
+     */
     getCellOverlays: (cell: Cell) => CellOverlay[];
+
+    /**
+     * Removes and returns the given {@link CellOverlay} from the given cell.
+     *
+     * This method fires a {@link InternalEvent.REMOVE_OVERLAY} event.
+     *
+     * If no overlay is given, then all overlays are removed using {@link removeCellOverlays}.
+     *
+     * @param cell {@link Cell} whose overlay should be removed.
+     * @param overlay Optional {@link CellOverlay} to be removed.
+     */
     removeCellOverlay: (cell: Cell, overlay: CellOverlay | null) => CellOverlay | null;
+
+    /**
+     * Removes all {@link CellOverlay}s from the given cell.
+     *
+     * This method fires a {@link InternalEvent.REMOVE_OVERLAY} event for each {@link CellOverlay}
+     * and returns an array of {@link CellOverlay}s that was removed from the cell.
+     *
+     * @param cell {@link Cell} whose overlays should be removed
+     */
     removeCellOverlays: (cell: Cell) => CellOverlay[];
+
+    /**
+     * Removes all {@link CellOverlay}s in the graph for the given cell and all its descendants.
+     *
+     * If no cell is specified then all overlays are removed from the graph.
+     *
+     * This implementation uses {@link removeCellOverlays} to remove the overlays from the individual cells.
+     *
+     * @param cell Optional {@link Cell} that represents the root of the subtree to remove the overlays from. Default is the root in the model.
+     */
     clearCellOverlays: (cell: Cell | null) => void;
+
+    /**
+     * Creates an overlay for the given cell using the warning and image or {@link warningImage} and returns the new {@link CellOverlay}.
+     * The warning is displayed as a tooltip in a red font and may contain HTML markup.
+     * If the warning is `null` or a zero length string, then all overlays are removed from the cell.
+     *
+     * @example
+     * ```javascript
+     * graph.setCellWarning(cell, '<b>Warning:</b>: Hello, World!');
+     * ```
+     *
+     * @param cell {@link Cell} whose warning should be set.
+     * @param warning String that represents the warning to be displayed.
+     * @param img Optional {@link Image} to be used for the overlay. Default is {@link warningImage}.
+     * @param isSelect Optional boolean indicating if a click on the overlay should select the corresponding cell. Default is `false`.
+     */
     setCellWarning: (
       cell: Cell,
       warning: string | null,
@@ -62,17 +122,6 @@ type PartialType = PartialGraph & PartialOverlays;
 
 // @ts-expect-error The properties of PartialGraph are defined elsewhere.
 const OverlaysMixin: PartialType = {
-  /*****************************************************************************
-   * Group: Overlays
-   *****************************************************************************/
-
-  /**
-   * Adds an {@link CellOverlay} for the specified cell. This method fires an
-   * {@link addoverlay} event and returns the new {@link CellOverlay}.
-   *
-   * @param cell {@link mxCell} to add the overlay for.
-   * @param overlay {@link CellOverlay} to be added for the cell.
-   */
   addCellOverlay(cell, overlay) {
     cell.overlays.push(overlay);
 
@@ -87,25 +136,10 @@ const OverlaysMixin: PartialType = {
     return overlay;
   },
 
-  /**
-   * Returns the array of {@link mxCellOverlays} for the given cell or null, if
-   * no overlays are defined.
-   *
-   * @param cell {@link mxCell} whose overlays should be returned.
-   */
   getCellOverlays(cell) {
     return cell.overlays;
   },
 
-  /**
-   * Removes and returns the given {@link CellOverlay} from the given cell. This
-   * method fires a {@link removeoverlay} event. If no overlay is given, then all
-   * overlays are removed using {@link removeOverlays}.
-   *
-   * @param cell {@link mxCell} whose overlay should be removed.
-   * @param overlay Optional {@link CellOverlay} to be removed.
-   */
-  // removeCellOverlay(cell: mxCell, overlay: CellOverlay): CellOverlay;
   removeCellOverlay(cell, overlay = null) {
     if (!overlay) {
       this.removeCellOverlays(cell);
@@ -131,13 +165,6 @@ const OverlaysMixin: PartialType = {
     return overlay;
   },
 
-  /**
-   * Removes all {@link mxCellOverlays} from the given cell. This method
-   * fires a {@link removeoverlay} event for each {@link CellOverlay} and returns
-   * the array of {@link mxCellOverlays} that was removed from the cell.
-   *
-   * @param cell {@link mxCell} whose overlays should be removed
-   */
   removeCellOverlays(cell) {
     const { overlays } = cell;
 
@@ -165,15 +192,6 @@ const OverlaysMixin: PartialType = {
     return overlays;
   },
 
-  /**
-   * Removes all {@link mxCellOverlays} in the graph for the given cell and all its
-   * descendants. If no cell is specified then all overlays are removed from
-   * the graph. This implementation uses {@link removeCellOverlays} to remove the
-   * overlays from the individual cells.
-   *
-   * @param cell Optional {@link Cell} that represents the root of the subtree to
-   * remove the overlays from. Default is the root in the model.
-   */
   clearCellOverlays(cell = null) {
     cell = cell ?? this.getDataModel().getRoot();
 
@@ -190,25 +208,6 @@ const OverlaysMixin: PartialType = {
     }
   },
 
-  /**
-   * Creates an overlay for the given cell using the warning and image or
-   * {@link warningImage} and returns the new {@link CellOverlay}. The warning is
-   * displayed as a tooltip in a red font and may contain HTML markup. If
-   * the warning is null or a zero length string, then all overlays are
-   * removed from the cell.
-   *
-   * @example
-   * ```javascript
-   * graph.setCellWarning(cell, '{@link b}Warning:</b>: Hello, World!');
-   * ```
-   *
-   * @param cell {@link mxCell} whose warning should be set.
-   * @param warning String that represents the warning to be displayed.
-   * @param img Optional {@link Image} to be used for the overlay. Default is
-   * {@link warningImage}.
-   * @param isSelect Optional boolean indicating if a click on the overlay
-   * should select the corresponding cell. Default is `false`.
-   */
   setCellWarning(cell, warning = null, img, isSelect = false) {
     img = img ?? this.getWarningImage();
 


### PR DESCRIPTION
This makes the JSDoc available for consumers.
It was previously set on the implementation which is hidden, so it was useless.


## Notes

Covers #442 