### PR TITLE
docs: declare JSDoc of `CellsMixin` in type definition

### DIFF
--- a/packages/core/src/view/mixins/CellsMixin.ts
+++ b/packages/core/src/view/mixins/CellsMixin.ts
@@ -187,9 +187,9 @@ declare module '../Graph' {
     setCellStyle: (style: CellStyle, cells?: Cell[]) => void;
 
     /**
-     * Toggles the boolean value for the given key in the style of the given cell
-     * and returns the new value as 0 or 1. If no cell is specified then the
-     * selection cell is used.
+     * Toggles the boolean value for the given key in the style of the given cell and returns the new value as boolean.
+     *
+     * If no cell is specified then the selection cell is used.
      *
      * @param key String representing the key for the boolean value to be toggled.
      * @param defaultValue Optional boolean default value if no value is defined. Default is `false`.
@@ -202,14 +202,14 @@ declare module '../Graph' {
     ) => boolean | null;
 
     /**
-     * Toggles the boolean value for the given key in the style of the given cells
-     * and returns the new value as 0 or 1. If no cells are specified, then the
-     * selection cells are used. For example, this can be used to toggle
-     * {@link 'rounded'} or any other style with a boolean value.
+     * Toggles the boolean value for the given key in the style of the given cells and returns the new value as boolean.
+     *
+     * If no cells are specified, then the selection cells are used.
+     *
+     * For example, this can be used to toggle {@link CellStateStyle.rounded} or any other style with a boolean value.
      *
      * @param key String representing the key for the boolean value to be toggled.
-     * @param defaultValue Optional boolean default value if no value is defined.
-     * Default is `false`.
+     * @param defaultValue Optional boolean default value if no value is defined. Default is `false`.
      * @param cells Optional array of {@link Cell} whose styles should be modified. Default is the selection cells.
      */
     toggleCellStyles: (

--- a/packages/core/src/view/mixins/CellsMixin.ts
+++ b/packages/core/src/view/mixins/CellsMixin.ts
@@ -264,8 +264,7 @@ declare module '../Graph' {
     ) => void;
 
     /**
-     * Aligns the given cells vertically or horizontally according to the given
-     * alignment using the optional parameter as the coordinate.
+     * Aligns the given cells vertically or horizontally according to the given alignment using the optional parameter as the coordinate.
      *
      * @param align Specifies the alignment. Possible values are all entries of the {@link ALIGN} enum.
      * @param cells Array of {@link Cell} to be aligned.
@@ -289,10 +288,9 @@ declare module '../Graph' {
     ) => Cell;
 
     /**
-     * Returns the clones for the given cells. The clones are created recursively
-     * using {@link cloneCells}. If the terminal of an edge is not in the
-     * given array, then the respective end is assigned a terminal point and the
-     * terminal is removed.
+     * Returns the clones for the given cells. The clones are created recursively using {@link cloneCells}.
+     *
+     * If the terminal of an edge is not in the given array, then the respective end is assigned a terminal point and the terminal is removed.
      *
      * @param cells Array of {@link Cell} to be cloned.
      * @param allowInvalidEdges Optional boolean that specifies if invalid edges should be cloned. Default is `true`.
@@ -307,15 +305,16 @@ declare module '../Graph' {
     ) => Cell[];
 
     /**
-     * Adds the cell to the parent and connects it to the given source and
-     * target terminals. This is a shortcut method. Returns the cell that was
-     * added.
+     * Adds the cell to the parent and connects it to the given source and target terminals.
+     *
+     * This is a shortcut method.
      *
      * @param cell {@link mxCell} to be inserted into the given parent.
      * @param parent {@link mxCell} that represents the new parent. If no parent is given then the default parent is used.
      * @param index Optional index to insert the cells at. Default is 'to append'.
      * @param source Optional {@link Cell} that represents the source terminal.
      * @param target Optional {@link Cell} that represents the target terminal.
+     * @returns the cell that was added.
      */
     addCell: (
       cell: Cell,

--- a/packages/core/src/view/mixins/CellsMixin.ts
+++ b/packages/core/src/view/mixins/CellsMixin.ts
@@ -170,7 +170,7 @@ declare module '../Graph' {
 
     /**
      * Tries to resolve the value for the image style in the image bundles and
-     * turns short data URIs as defined in mxImageBundle to data URIs as
+     * turns short data URIs as defined in {@link ImageBundle} to data URIs as
      * defined in RFC 2397 of the IETF.
      */
     postProcessCellStyle: (style: CellStateStyle) => CellStateStyle;

--- a/packages/core/src/view/mixins/CellsMixin.ts
+++ b/packages/core/src/view/mixins/CellsMixin.ts
@@ -51,25 +51,129 @@ import type { CellStateStyle, CellStyle, NumericCellStateStyleKeys } from '../..
 
 declare module '../Graph' {
   interface Graph {
+    /**
+     * Specifies the return value for {@link isCellsResizable}.
+     * @default true
+     */
     cellsResizable: boolean;
+
+    /**
+     * Specifies the return value for {@link isCellsBendable}.
+     * @default true
+     */
     cellsBendable: boolean;
+
+    /**
+     * Specifies the return value for {@link isCellsSelectable}.
+     * @default true
+     */
     cellsSelectable: boolean;
+
+    /**
+     * Specifies the return value for {@link isCellsDisconnectable}.
+     * @default true
+     */
     cellsDisconnectable: boolean;
+
+    /**
+     * Specifies if the graph should automatically update the cell size after an
+     * edit. This is used in {@link isAutoSizeCell}.
+     * @default false
+     */
     autoSizeCells: boolean;
+
+    /**
+     * Specifies if autoSize style should be applied when cells are added.
+     * @default false
+     */
     autoSizeCellsOnAdd: boolean;
+
+    /**
+     * Specifies the return value for {@link isCellLocked}.
+     * @default false
+     */
     cellsLocked: boolean;
+
+    /**
+     * Specifies the return value for {@link isCellCloneable}.
+     * @default true
+     */
     cellsCloneable: boolean;
+
+    /**
+     * Specifies the return value for {@link isCellDeletable}.
+     * @default true
+     */
     cellsDeletable: boolean;
+
+    /**
+     * Specifies the return value for {@link isCellMovable}.
+     * @default true
+     */
     cellsMovable: boolean;
+
+    /**
+     * Specifies if a parent should contain the child bounds after a resize of
+     * the child. This has precedence over {@link constrainChildren}.
+     * @default true
+     */
     extendParents: boolean;
+
+    /**
+     * Specifies if parents should be extended according to the {@link extendParents}
+     * switch if cells are added.
+     * @default true
+     */
     extendParentsOnAdd: boolean;
+
+    /**
+     * Specifies if parents should be extended according to the {@link extendParents}
+     * switch if cells are added.
+     * @default false (for backwards compatibility)
+     */
     extendParentsOnMove: boolean;
 
+    /**
+     * Returns the bounding box for the given array of {@link Cell}. The bounding box for
+     * each cell and its descendants is computed using {@link view.getBoundingBox}.
+     *
+     * @param cells Array of {@link Cell} whose bounding box should be returned.
+     */
     getBoundingBox: (cells: Cell[]) => Rectangle | null;
+
+    /**
+     * Removes all cached information for the given cell and its descendants.
+     * This is called when a cell was removed from the model.
+     *
+     * @param cell {@link Cell} that was removed from the model.
+     */
     removeStateForCell: (cell: Cell) => void;
+
+    /**
+     * Returns the style for the given cell from the cell state, if one exists,
+     * or using {@link getCellStyle}.
+     *
+     * @param cell {@link Cell} whose style should be returned as an array.
+     * @param ignoreState Optional boolean that specifies if the cell state should be ignored.
+     */
     getCurrentCellStyle: (cell: Cell, ignoreState?: boolean) => CellStateStyle;
+
+    /**
+     * Returns the style for the given cell from the cell state, if one exists,
+     * or using {@link getCellStyle}.
+     *
+     * @param cell {@link Cell} whose style should be returned as an array.
+     * @param ignoreState Optional boolean that specifies if the cell state should be ignored.
+     */
     getCellStyle: (cell: Cell) => CellStateStyle;
+
+    /**
+     * Tries to resolve the value for the image style in the image bundles and
+     * turns short data URIs as defined in mxImageBundle to data URIs as
+     * defined in RFC 2397 of the IETF.
+     */
     postProcessCellStyle: (style: CellStateStyle) => CellStateStyle;
+
     /**
      * Sets the style of the specified cells. If no cells are given, then the selection cells are changed.
      *
@@ -77,49 +181,141 @@ declare module '../Graph' {
      * For more details, see {@link GraphDataModel.setStyle}.
      *
      * @param style String representing the new style of the cells.
-     * @param cells Optional array of {@link Cell} to set the style for. Default is the
-     * selection cells.
+     * @param cells Optional array of {@link Cell} to set the style for. Default is the selection cells.
      */
     setCellStyle: (style: CellStyle, cells?: Cell[]) => void;
+
+    /**
+     * Toggles the boolean value for the given key in the style of the given cell
+     * and returns the new value as 0 or 1. If no cell is specified then the
+     * selection cell is used.
+     *
+     * @param key String representing the key for the boolean value to be toggled.
+     * @param defaultValue Optional boolean default value if no value is defined. Default is `false`.
+     * @param cell Optional {@link Cell} whose style should be modified. Default is the selection cell.
+     */
     toggleCellStyle: (
       key: keyof CellStateStyle,
       defaultValue: boolean,
       cell: Cell
     ) => boolean | null;
+
+    /**
+     * Toggles the boolean value for the given key in the style of the given cells
+     * and returns the new value as 0 or 1. If no cells are specified, then the
+     * selection cells are used. For example, this can be used to toggle
+     * {@link 'rounded'} or any other style with a boolean value.
+     *
+     * @param key String representing the key for the boolean value to be toggled.
+     * @param defaultValue Optional boolean default value if no value is defined.
+     * Default is `false`.
+     * @param cells Optional array of {@link Cell} whose styles should be modified. Default is the selection cells.
+     */
     toggleCellStyles: (
       key: keyof CellStateStyle,
       defaultValue: boolean,
       cells: Cell[]
     ) => boolean | null;
+
+    /**
+     * Sets the key to value in the styles of the given cells. This will modify
+     * the existing cell styles in-place and override any existing assignment
+     * for the given key. If no cells are specified, then the selection cells
+     * are changed. If no value is specified, then the respective key is
+     * removed from the styles.
+     *
+     * @param key String representing the key to be assigned.
+     * @param value String representing the new value for the key.
+     * @param cells Optional array of {@link Cell} to change the style for. Default is the selection cells.
+     */
     setCellStyles: (
       key: keyof CellStateStyle,
       value: CellStateStyle[keyof CellStateStyle],
       cells?: Cell[]
     ) => void;
+
+    /**
+     * Toggles the given bit for the given key in the styles of the specified cells.
+     *
+     * @param key String representing the key to toggle the flag in.
+     * @param flag Integer that represents the bit to be toggled.
+     * @param cells Optional array of {@link Cell} to change the style for. Default is the selection cells.
+     */
     toggleCellStyleFlags: (
       key: NumericCellStateStyleKeys,
       flag: number,
       cells?: Cell[] | null
     ) => void;
+
+    /**
+     * Sets or toggles the given bit for the given key in the styles of the specified cells.
+     *
+     * @param key String representing the key to toggle the flag in.
+     * @param flag Integer that represents the bit to be toggled.
+     * @param value Boolean value to be used or null if the value should be toggled.
+     * @param cells Optional array of {@link Cell} to change the style for. Default is the selection cells.
+     */
     setCellStyleFlags: (
       key: NumericCellStateStyleKeys,
       flag: number,
       value?: boolean | null,
       cells?: Cell[] | null
     ) => void;
+
+    /**
+     * Aligns the given cells vertically or horizontally according to the given
+     * alignment using the optional parameter as the coordinate.
+     *
+     * @param align Specifies the alignment. Possible values are all entries of the {@link ALIGN} enum.
+     * @param cells Array of {@link Cell} to be aligned.
+     * @param param Optional coordinate for the alignment.
+     */
     alignCells: (align: string, cells?: Cell[], param?: number | null) => void;
+
+    /**
+     * Returns the clone for the given cell. Uses {@link cloneCells}.
+     *
+     * @param cell {@link Cell} to be cloned.
+     * @param allowInvalidEdges Optional boolean that specifies if invalid edges should be cloned. Default is `true`.
+     * @param mapping Optional mapping for existing clones.
+     * @param keepPosition Optional boolean indicating if the position of the cells should be updated to reflect the lost parent cell. Default is `false`.
+     */
     cloneCell: (
       cell: Cell,
       allowInvalidEdges?: boolean,
       mapping?: any,
       keepPosition?: boolean
     ) => Cell;
+
+    /**
+     * Returns the clones for the given cells. The clones are created recursively
+     * using {@link cloneCells}. If the terminal of an edge is not in the
+     * given array, then the respective end is assigned a terminal point and the
+     * terminal is removed.
+     *
+     * @param cells Array of {@link Cell} to be cloned.
+     * @param allowInvalidEdges Optional boolean that specifies if invalid edges should be cloned. Default is `true`.
+     * @param mapping Optional mapping for existing clones.
+     * @param keepPosition Optional boolean indicating if the position of the cells should be updated to reflect the lost parent cell. Default is `false`.
+     */
     cloneCells: (
       cells: Cell[],
       allowInvalidEdges?: boolean,
       mapping?: any,
       keepPosition?: boolean
     ) => Cell[];
+
+    /**
+     * Adds the cell to the parent and connects it to the given source and
+     * target terminals. This is a shortcut method. Returns the cell that was
+     * added.
+     *
+     * @param cell {@link mxCell} to be inserted into the given parent.
+     * @param parent {@link mxCell} that represents the new parent. If no parent is given then the default parent is used.
+     * @param index Optional index to insert the cells at. Default is 'to append'.
+     * @param source Optional {@link Cell} that represents the source terminal.
+     * @param target Optional {@link Cell} that represents the target terminal.
+     */
     addCell: (
       cell: Cell,
       parent: Cell | null,
@@ -127,6 +323,20 @@ declare module '../Graph' {
       source?: Cell | null,
       target?: Cell | null
     ) => Cell;
+
+    /**
+     * Adds the cells to the parent at the given index, connecting each cell to
+     * the optional source and target terminal. The change is carried out using
+     * {@link cellsAdded}. This method fires {@link Event#ADD_CELLS} while the
+     * transaction is in progress. Returns the cells that were added.
+     *
+     * @param cells Array of {@link Cell}s to be inserted.
+     * @param parent {@link Cell} that represents the new parent. If no parent is given then the default parent is used.
+     * @param index Optional index to insert the cells at. Default is to append.
+     * @param source Optional source {@link Cell} for all inserted cells.
+     * @param target Optional target {@link Cell} for all inserted cells.
+     * @param absolute Optional boolean indicating of cells should be kept at their absolute position. Default is `false`.
+     */
     addCells: (
       cells: Cell[],
       parent: Cell | null,
@@ -135,6 +345,11 @@ declare module '../Graph' {
       target: Cell | null,
       absolute?: boolean
     ) => Cell[];
+
+    /**
+     * Adds the specified cells to the given parent. This method fires
+     * {@link Event#CELLS_ADDED} while the transaction is in progress.
+     */
     cellsAdded: (
       cells: Cell[],
       parent: Cell,
@@ -145,27 +360,210 @@ declare module '../Graph' {
       constrain?: boolean,
       extend?: boolean
     ) => void;
+
+    /**
+     * Resizes the specified cell to just fit around its label and/or children.
+     *
+     * @param cell {@link mxCell} to be resized.
+     * @param recurse Optional boolean which specifies if all descendants should be auto-sized. Default is `true`.
+     */
     autoSizeCell: (cell: Cell, recurse?: boolean) => void;
+
+    /**
+     * Removes the given cells from the graph including all connected edges if
+     * includeEdges is true. The change is carried out using {@link cellsRemoved}.
+     * This method fires {@link InternalEvent.REMOVE_CELLS} while the transaction is in
+     * progress. The removed cells are returned as an array.
+     *
+     * @param cells Array of {@link Cell} to remove. If null is specified then the selection cells which are deletable are used.
+     * @param includeEdges Optional boolean which specifies if all connected edges should be removed as well. Default is `true`.
+     */
     removeCells: (cells?: Cell[] | null, includeEdges?: boolean | null) => Cell[];
+
+    /**
+     * Removes the given cells from the model. This method fires
+     * {@link InternalEvent.CELLS_REMOVED} while the transaction is in progress.
+     *
+     * @param cells Array of {@link Cell} to remove.
+     */
     cellsRemoved: (cells: Cell[]) => void;
+
+    /**
+     * Sets the visible state of the specified cells and all connected edges
+     * if includeEdges is true. The change is carried out using {@link cellsToggled}.
+     * This method fires {@link InternalEvent.TOGGLE_CELLS} while the transaction is in
+     * progress. Returns the cells whose visible state was changed.
+     *
+     * @param show Boolean that specifies the visible state to be assigned.
+     * @param cells Array of {@link Cell} whose visible state should be changed. If `null` is specified then the selection cells are used.
+     * @param includeEdges Optional boolean indicating if the visible state of all connected edges should be changed as well. Default is `true`.
+     */
     toggleCells: (show: boolean, cells: Cell[], includeEdges: boolean) => Cell[];
+
+    /**
+     * Sets the visible state of the specified cells.
+     *
+     * @param cells Array of {@link Cell} whose visible state should be changed.
+     * @param show Boolean that specifies the visible state to be assigned.
+     */
     cellsToggled: (cells: Cell[], show: boolean) => void;
+
+    /**
+     * Updates the size of the given cell in the model using {@link cellSizeUpdated}.
+     * This method fires {@link InternalEvent.UPDATE_CELL_SIZE} while the transaction is in
+     * progress. Returns the cell whose size was updated.
+     *
+     * @param cell {@link Cell} whose size should be updated.
+     * @param ignoreChildren if `true`, ignore the children of the cell when computing the size of the cell. Default is `false`.
+     */
     updateCellSize: (cell: Cell, ignoreChildren?: boolean) => Cell;
+
+    /**
+     * Updates the size of the given cell in the model using {@link getPreferredSizeForCell} to get the new size.
+     *
+     * @param cell {@link Cell} for which the size should be changed.
+     * @param ignoreChildren if `true`, ignore the children of the cell when computing the size of the cell. Default is `false`.
+     */
     cellSizeUpdated: (cell: Cell, ignoreChildren: boolean) => void;
+
+    /**
+     * Returns the preferred width and height of the given {@link Cell} as an
+     * {@link Rectangle}. To implement a minimum width, add a new style e.g.
+     * minWidth in the vertex and override this method as follows.
+     *
+     * ```javascript
+     * var graphGetPreferredSizeForCell = graph.getPreferredSizeForCell;
+     * graph.getPreferredSizeForCell(cell)
+     * {
+     *   var result = graphGetPreferredSizeForCell.apply(this, arguments);
+     *   var style = this.getCellStyle(cell);
+     *
+     *   if (style.minWidth > 0)
+     *   {
+     *     result.width = Math.max(style.minWidth, result.width);
+     *   }
+     *
+     *   return result;
+     * };
+     * ```
+     *
+     * @param cell {@link mxCell} for which the preferred size should be returned.
+     * @param textWidth Optional maximum text width for word wrapping.
+     */
     getPreferredSizeForCell: (cell: Cell, textWidth?: number | null) => Rectangle | null;
+
+    /**
+     * Sets the bounds of the given cell using {@link resizeCells}. Returns the
+     * cell which was passed to the function.
+     *
+     * @param cell {@link Cell} whose bounds should be changed.
+     * @param bounds {@link Rectangle} that represents the new bounds.
+     * @param recurse Optional boolean that specifies if the children should be resized. Default is `false`.
+     */
     resizeCell: (cell: Cell, bounds: Rectangle, recurse?: boolean) => Cell;
+
+    /**
+     * Sets the bounds of the given cells and fires a {@link InternalEvent.RESIZE_CELLS}
+     * event while the transaction is in progress. Returns the cells which
+     * have been passed to the function.
+     *
+     * @param cells Array of {@link Cell} whose bounds should be changed.
+     * @param bounds Array of {@link Rectangle}s that represent the new bounds.
+     * @param recurse Optional boolean that specifies if the children should be resized. Default is {@link isRecursiveResize}.
+     */
     resizeCells: (cells: Cell[], bounds: Rectangle[], recurse: boolean) => Cell[];
+
+    /**
+     * Sets the bounds of the given cells and fires a {@link InternalEvent.CELLS_RESIZED}
+     * event. If {@link extendParents} is true, then the parent is extended if a
+     * child size is changed so that it overlaps with the parent.
+     *
+     * The following example shows how to control group resizes to make sure
+     * that all child cells stay within the group.
+     *
+     * ```javascript
+     * graph.addListener(mxEvent.CELLS_RESIZED, function(sender, evt)
+     * {
+     *   var cells = evt.getProperty('cells');
+     *
+     *   if (cells != null)
+     *   {
+     *     for (var i = 0; i < cells.length; i++)
+     *     {
+     *       if (graph.getDataModel().getChildCount(cells[i]) > 0)
+     *       {
+     *         var geo = cells[i].getGeometry();
+     *
+     *         if (geo != null)
+     *         {
+     *           var children = graph.getChildCells(cells[i], true, true);
+     *           var bounds = graph.getBoundingBoxFromGeometry(children, true);
+     *
+     *           geo = geo.clone();
+     *           geo.width = Math.max(geo.width, bounds.width);
+     *           geo.height = Math.max(geo.height, bounds.height);
+     *
+     *           graph.getDataModel().setGeometry(cells[i], geo);
+     *         }
+     *       }
+     *     }
+     *   }
+     * });
+     * ```
+     *
+     * @param cells Array of {@link Cell} whose bounds should be changed.
+     * @param bounds Array of {@link Rectangle}s that represent the new bounds.
+     * @param recurse Optional boolean that specifies if the children should be resized. Default is `false`.
+     */
     cellsResized: (cells: Cell[], bounds: Rectangle[], recurse: boolean) => void;
+
+    /**
+     * Resizes the parents recursively so that they contain the complete area of the resized child cell.
+     *
+     * @param cell {@link Cell} whose bounds should be changed.
+     * @param bounds {@link Rectangle}s that represent the new bounds.
+     * @param ignoreRelative Boolean that indicates if relative cells should be ignored. Default is `false`.
+     * @param recurse Optional boolean that specifies if the children should be resized. Default is `false`.
+     */
     cellResized: (
       cell: Cell,
       bounds: Rectangle,
       ignoreRelative: boolean,
       recurse: boolean
     ) => Geometry | null;
+
+    /**
+     * Resizes the child cells of the given cell for the given new geometry with respect to the current geometry of the cell.
+     *
+     * @param cell {@link Cell} that has been resized.
+     * @param newGeo {@link Geometry} that represents the new bounds.
+     */
     resizeChildCells: (cell: Cell, newGeo: Geometry) => void;
+
+    /**
+     * Constrains the children of the given cell using {@link constrainChild}.
+     *
+     * @param cell {@link Cell} that has been resized.
+     */
     constrainChildCells: (cell: Cell) => void;
+
+    /**
+     * Scales the points, position and size of the given cell according to the given vertical and horizontal scaling factors.
+     *
+     * @param cell {@link Cell} whose geometry should be scaled.
+     * @param dx Horizontal scaling factor.
+     * @param dy Vertical scaling factor.
+     * @param recurse Boolean indicating if the child cells should be scaled. Default is `false`.
+     */
     scaleCell: (cell: Cell, dx: number, dy: number, recurse: boolean) => void;
+
+    /**
+     * Resizes the parents recursively so that they contain the complete area of the resized child cell.
+     *
+     * @param cell {@link Cell} that has been resized.
+     */
     extendParent: (cell: Cell) => void;
+
     /**
      * Clones and inserts the given cells into the graph using the move method and returns the inserted cells. This shortcut
      * is used if cells are inserted via data transfer.
@@ -173,7 +571,7 @@ declare module '../Graph' {
      * @param cells Array of {@link Cell} to be imported.
      * @param dx Integer that specifies the x-coordinate of the vector. Default is `0`.
      * @param dy Integer that specifies the y-coordinate of the vector. Default is `0`.
-     * @param target {@link mxCell} that represents the new parent of the cells.
+     * @param target {@link Cell} that represents the new parent of the cells.
      * @param evt {@link MouseEvent} that triggered the invocation.
      * @param mapping Optional mapping for existing clones.
      * @returns the cells that were imported.
@@ -216,6 +614,12 @@ declare module '../Graph' {
       evt?: MouseEvent | null,
       mapping?: any
     ) => Cell[];
+
+    /**
+     * Moves the specified cells by the given vector, disconnecting the cells using disconnectGraph is disconnect is true.
+     *
+     * This method fires {@link InternalEvent.CELLS_MOVED} while the transaction is in progress.
+     */
     cellsMoved: (
       cells: Cell[],
       dx: number,
@@ -224,10 +628,55 @@ declare module '../Graph' {
       constrain: boolean,
       extend?: boolean | null
     ) => void;
+
+    /**
+     * Translates the geometry of the given cell and stores the new, translated geometry in the model as an atomic change.
+     */
     translateCell: (cell: Cell, dx: number, dy: number) => void;
+
+    /**
+     * Returns the {@link Rectangle} inside which a cell is to be kept.
+     *
+     * @param cell {@link Cell} for which the area should be returned.
+     */
     getCellContainmentArea: (cell: Cell) => Rectangle | null;
+
+    /**
+     * Keeps the given cell inside the bounds returned by {@link getCellContainmentArea} for its parent,
+     * according to the rules defined by {@link getOverlap} and {@link isConstrainChild}.
+     *
+     * This modifies the cell's geometry in-place and does not clone it.
+     *
+     * @param cell {@link Cell} which should be constrained.
+     * @param sizeFirst Specifies if the size should be changed first. Default is `true`.
+     */
     constrainChild: (cell: Cell, sizeFirst?: boolean) => void;
+
+    /**
+     * Returns the visible child vertices or edges in the given parent.
+     *
+     * If vertices and edges is `false`, then all children are returned.
+     *
+     * @param parent {@link mxCell} whose children should be returned.
+     * @param vertices Optional boolean that specifies if child vertices should be returned. Default is `false`.
+     * @param edges Optional boolean that specifies if child edges should be returned. Default is `false`.
+     */
     getChildCells: (parent?: Cell | null, vertices?: boolean, edges?: boolean) => Cell[];
+
+    /**
+     * Returns the bottom-most cell that intersects the given point (x, y) in the cell hierarchy starting at the given parent.
+     *
+     * This will also return swimlanes if the given location intersects the content area of the swimlane.
+     * If this is not desired, then the {@link hitsSwimlaneContent} may be used if the returned cell is a swimlane
+     * to determine if the location is inside the content area or on the actual title of the swimlane.
+     *
+     * @param x X-coordinate of the location to be checked.
+     * @param y Y-coordinate of the location to be checked.
+     * @param parent {@link mxCell} that should be used as the root of the recursion. Default is current root of the view or the root of the model.
+     * @param vertices Optional boolean indicating if vertices should be returned. Default is `true`.
+     * @param edges Optional boolean indicating if edges should be returned. Default is `true`.
+     * @param ignoreFn Optional function that returns true if cell should be ignored. The function is passed the cell state and the x and y parameter. Default is `null`.
+     */
     getCellAt: (
       x: number,
       y: number,
@@ -236,6 +685,23 @@ declare module '../Graph' {
       edges?: boolean | null,
       ignoreFn?: Function | null
     ) => Cell | null;
+
+    /**
+     * Returns the child vertices and edges of the given parent that are contained in the given rectangle.
+     *
+     * The result is added to the optional result array, which is returned.
+     * If no result array is specified then a new array is created and returned.
+     *
+     * @param x X-coordinate of the rectangle.
+     * @param y Y-coordinate of the rectangle.
+     * @param width Width of the rectangle.
+     * @param height Height of the rectangle.
+     * @param parent {@link mxCell} that should be used as the root of the recursion. Default is current root of the view or the root of the model.
+     * @param result Optional array to store the result in. Default is an empty Array.
+     * @param intersection Default is `null`.
+     * @param ignoreFn Default is `null`.
+     * @param includeDescendants Default is `false`.
+     */
     getCells: (
       x: number,
       y: number,
@@ -247,6 +713,17 @@ declare module '../Graph' {
       ignoreFn?: Function | null,
       includeDescendants?: boolean
     ) => Cell[];
+
+    /**
+     * Returns the children of the given parent that are contained in the half-pane from the given point (x0, y0) rightwards or downwards
+     * depending on rightHalfpane and bottomHalfpane.
+     *
+     * @param x0 X-coordinate of the origin.
+     * @param y0 Y-coordinate of the origin.
+     * @param parent Optional {@link Cell} whose children should be checked. Default is <defaultParent>.
+     * @param rightHalfpane Boolean indicating if the cells in the right halfpane from the origin should be returned. Default is `false`.
+     * @param bottomHalfpane Boolean indicating if the cells in the bottom halfpane from the origin should be returned. Default is `false`.
+     */
     getCellsBeyond: (
       x0: number,
       y0: number,
@@ -254,53 +731,368 @@ declare module '../Graph' {
       rightHalfpane: boolean,
       bottomHalfpane: boolean
     ) => Cell[];
+
+    /**
+     * Returns the bottom-most cell that intersects the given point (x, y) in the cell hierarchy that starts at the given parent.
+     *
+     * @param state {@link CellState} that represents the cell state.
+     * @param x X-coordinate of the location to be checked.
+     * @param y Y-coordinate of the location to be checked.
+     */
     intersects: (state: CellState, x: number, y: number) => boolean;
+
+    /**
+     * Returns whether the specified parent is a valid ancestor of the specified cell,
+     * either direct or indirectly based on whether ancestor recursion is enabled.
+     *
+     * @param cell {@link Cell} the possible child cell
+     * @param parent {@link Cell} the possible parent cell
+     * @param recurse boolean whether to recurse the child ancestors. Default is `false`.
+     */
     isValidAncestor: (cell: Cell, parent: Cell, recurse: boolean) => boolean;
+
+    /**
+     * Returns `true` if the given cell may not be moved, sized, bended, disconnected, edited or selected.
+     *
+     * This implementation returns `true` for all vertices with a relative geometry if {@link locked} is `false`.
+     *
+     * @param cell {@link Cell} whose locked state should be returned.
+     */
     isCellLocked: (cell: Cell) => boolean;
+
     isCellsLocked: () => boolean;
+
+    /**
+     * Sets if any cell may be moved, sized, bended, disconnected, edited or selected.
+     *
+     * @param value Boolean that defines the new value for {@link cellsLocked}.
+     */
     setCellsLocked: (value: boolean) => void;
+
+    /**
+     * Returns the cells which may be exported in the given array of cells.
+     */
     getCloneableCells: (cells: Cell[]) => Cell[];
+
+    /**
+     * Returns true if the given cell is cloneable.
+     *
+     * This implementation returns {@link isCellsCloneable} for all cells unless a cell style specifies {@link CellStateStyle.cloneable} to be `false`.
+     *
+     * @param cell Optional {@link Cell} whose cloneable state should be returned.
+     */
     isCellCloneable: (cell: Cell) => boolean;
+
+    /**
+     * Returns {@link cellsCloneable}, that is, if the graph allows cloning of cells by using control-drag.
+     */
     isCellsCloneable: () => boolean;
+
+    /**
+     * Specifies if the graph should allow cloning of cells by holding down the control key while cells are being moved.
+     *
+     * This implementation updates {@link cellsCloneable}.
+     *
+     * @param value Boolean indicating if the graph should be cloneable.
+     */
     setCellsCloneable: (value: boolean) => void;
+
+    /**
+     * Returns the cells which may be exported in the given array of cells.
+     */
     getExportableCells: (cells: Cell[]) => Cell[];
+
+    /**
+     * Returns true if the given cell may be exported to the clipboard.
+     *
+     * This implementation returns {@link exportEnabled} for all cells.
+     *
+     * @param cell {@link Cell} that represents the cell to be exported.
+     */
     canExportCell: (cell: Cell | null) => boolean;
+
+    /**
+     * Returns the cells which may be imported in the given array of cells.
+     */
     getImportableCells: (cells: Cell[]) => Cell[];
+
+    /**
+     * Returns true if the given cell may be imported from the clipboard.
+     *
+     * This implementation returns {@link importEnabled} for all cells.
+     *
+     * @param cell {@link Cell} that represents the cell to be imported.
+     */
     canImportCell: (cell: Cell | null) => boolean;
+
+    /**
+     * Returns true if the given cell is selectable.
+     *
+     * This implementation returns {@link cellsSelectable}.
+     *
+     * To add a new style for making cells (un)selectable, use the following code.
+     *
+     * ```javascript
+     * isCellSelectable(cell)
+     * {
+     *   var style = this.getCurrentCellStyle(cell);
+     *
+     *   return this.isCellsSelectable() && !this.isCellLocked(cell) && style.selectable != 0;
+     * };
+     * ```
+     *
+     * You can then use the new style as shown in this example.
+     *
+     * ```javascript
+     * graph.insertVertex(parent, null, 'Hello,', 20, 20, 80, 30, 'selectable=0');
+     * ```
+     *
+     * @param cell {@link Cell} whose selectable state should be returned.
+     */
     isCellSelectable: (cell: Cell) => boolean;
+
+    /**
+     * Returns {@link cellsSelectable}.
+     */
     isCellsSelectable: () => boolean;
+
+    /**
+     * Sets {@link cellsSelectable}.
+     */
     setCellsSelectable: (value: boolean) => void;
+
+    /**
+     * Returns the cells which may be exported in the given array of cells.
+     */
     getDeletableCells: (cells: Cell[]) => Cell[];
+
+    /**
+     * Returns `true` if the given cell is deletable.
+     *
+     * @param cell {@link Cell} whose deletable state should be returned.
+     * @returns {@link cellsDeletable} for all given cells if a cells style does not specify {@link CellStateStyle.deletable} to be `false`.
+     */
     isCellDeletable: (cell: Cell) => boolean;
+
+    /**
+     * Returns {@link cellsDeletable}.
+     */
     isCellsDeletable: () => boolean;
+
+    /**
+     * Sets {@link cellsDeletable}.
+     *
+     * @param value Boolean indicating if the graph should allow deletion of cells.
+     */
     setCellsDeletable: (value: boolean) => void;
+
+    /**
+     * Returns `true` if the given cell is rotatable.
+     *
+     * This returns `true` for the given cell if its style does not specify {@link CellStateStyle.rotatable} to be `false`.
+     *
+     * @param cell {@link Cell} whose rotatable state should be returned.
+     */
     isCellRotatable: (cell: Cell) => boolean;
+
+    /**
+     * Returns the cells which are movable in the given array of cells.
+     */
     getMovableCells: (cells: Cell[]) => Cell[];
+
+    /**
+     * Returns `true` if the given cell is movable.
+     *
+     * This returns {@link cellsMovable} for all given cells if {@link isCellLocked} does not return `true` for the given cell,
+     * and its style does not specify {@link CellStateStyle.movable} to be `false`.
+     *
+     * @param cell {@link Cell} whose movable state should be returned.
+     */
     isCellMovable: (cell: Cell) => boolean;
+
+    /**
+     * Returns {@link cellsMovable}.
+     */
     isCellsMovable: () => boolean;
+
+    /**
+     * Specifies if the graph should allow moving of cells.
+     *
+     * This implementation updates {@link cellsMovable}.
+     *
+     * @param value Boolean indicating if the graph should allow moving of cells.
+     */
     setCellsMovable: (value: boolean) => void;
+
+    /**
+     * Returns true if the given cell is resizable.
+     *
+     * This returns {@link cellsResizable} for all given cells if {@link isCellLocked} does not return `true` for the given cell
+     * and its style does not specify {@link 'resizable'} to be `false`.
+     *
+     * @param cell {@link Cell} whose resizable state should be returned.
+     */
     isCellResizable: (cell: Cell) => boolean;
+
+    /**
+     * Returns {@link cellsResizable}.
+     */
     isCellsResizable: () => boolean;
+
+    /**
+     * Specifies if the graph should allow resizing of cells. This implementation updates {@link cellsResizable}.
+     *
+     * @param value Boolean indicating if the graph should allow resizing of cells.
+     */
     setCellsResizable: (value: boolean) => void;
+
+    /**
+     * Returns true if the given cell is bendable.
+     *
+     * This returns {@link cellsBendable} for all given cells if {@link cellsLocked} does not return `true` for the given cell
+     * and its style does not specify {@link CellStateStyle.bendable} to be `false`.
+     *
+     * @param cell {@link Cell} whose bendable state should be returned.
+     */
     isCellBendable: (cell: Cell) => boolean;
+
+    /**
+     * Returns {@link cellsBendable}.
+     */
     isCellsBendable: () => boolean;
+
+    /**
+     * Specifies if the graph should allow bending of edges.
+     *
+     * This implementation updates {@link cellsBendable}.
+     *
+     * @param value Boolean indicating if the graph should allow bending of edges.
+     */
     setCellsBendable: (value: boolean) => void;
+
+    /**
+     * Returns true if the size of the given cell should automatically be updated after a change of the label.
+     *
+     * This implementation returns {@link autoSizeCells} or checks if the cell style does specify {@link CellStateStyle.autoSize} to be `true`.
+     *
+     * @param cell {@link Cell} that should be resized.
+     */
     isAutoSizeCell: (cell: Cell) => boolean;
+
+    /**
+     * Returns {@link autoSizeCells}.
+     */
     isAutoSizeCells: () => boolean;
+
+    /**
+     * Specifies if cell sizes should be automatically updated after a label change.
+     *
+     * This implementation sets {@link autoSizeCells} to the given parameter.
+     *
+     * To update the size of cells when the cells are added, set {@link autoSizeCellsOnAdd} to `true`.
+     *
+     * @param value Boolean indicating if cells should be resized automatically.
+     */
     setAutoSizeCells: (value: boolean) => void;
+
+    /**
+     * Returns true if the parent of the given cell should be extended if the child has been resized so that it overlaps the parent.
+     *
+     * This implementation returns {@link isExtendParents} if the cell is not an edge.
+     *
+     * @param cell {@link Cell} that has been resized.
+     */
     isExtendParent: (cell: Cell) => boolean;
+
+    /**
+     * Returns {@link extendParents}.
+     */
     isExtendParents: () => boolean;
+
+    /**
+     * Sets {@link extendParents}.
+     *
+     * @param value New boolean value for {@link extendParents}.
+     */
     setExtendParents: (value: boolean) => void;
+
+    /**
+     * Returns {@link extendParentsOnAdd}.
+     */
     isExtendParentsOnAdd: (cell: Cell) => boolean;
+
+    /**
+     * Sets {@link extendParentsOnAdd}.
+     *
+     * @param value New boolean value for {@link extendParentsOnAdd}.
+     */
     setExtendParentsOnAdd: (value: boolean) => void;
+
+    /**
+     * Returns {@link extendParentsOnMove}.
+     */
     isExtendParentsOnMove: () => boolean;
+
+    /**
+     * Sets {@link extendParentsOnMove}.
+     *
+     * @param value New boolean value for {@link extendParentsOnAdd}.
+     */
     setExtendParentsOnMove: (value: boolean) => void;
+
+    /**
+     * Returns the cursor value to be used for the CSS of the shape for the given cell.
+     *
+     * This implementation returns `null`.
+     *
+     * @param cell {@link Cell} whose cursor should be returned.
+     */
     getCursorForCell: (cell: Cell) => string | null;
+
+    /**
+     * Returns the scaled, translated bounds for the given cell. See {@link GraphView.getBounds} for arrays.
+     *
+     * @param cell {@link Cell} whose bounds should be returned.
+     * @param includeEdges Optional boolean that specifies if the bounds of the connected edges should be included. Default is `false`.
+     * @param includeDescendants Optional boolean that specifies if the bounds of all descendants should be included. Default is `false`.
+     */
     getCellBounds: (
       cell: Cell,
       includeEdges?: boolean,
       includeDescendants?: boolean
     ) => Rectangle | null;
+
+    /**
+     * Returns the bounding box for the geometries of the vertices in the
+     * given array of cells. This can be used to find the graph bounds during
+     * a layout operation (ie. before the last endUpdate) as follows:
+     *
+     * ```javascript
+     * var cells = graph.getChildCells(graph.getDefaultParent(), true, true);
+     * var bounds = graph.getBoundingBoxFromGeometry(cells, true);
+     * ```
+     *
+     * This can then be used to move cells to the origin:
+     *
+     * ```javascript
+     * if (bounds.x < 0 || bounds.y < 0)
+     * {
+     *   graph.moveCells(cells, -Math.min(bounds.x, 0), -Math.min(bounds.y, 0))
+     * }
+     * ```
+     *
+     * Or to translate the graph view:
+     *
+     * ```javascript
+     * if (bounds.x < 0 || bounds.y < 0)
+     * {
+     *   getView().setTranslate(-Math.min(bounds.x, 0), -Math.min(bounds.y, 0));
+     * }
+     * ```
+     *
+     * @param cells Array of {@link Cell} whose bounds should be returned.
+     * @param includeEdges Specifies if edge bounds should be included by computing the bounding box for all points in geometry. Default is `false`.
+     */
     getBoundingBoxFromGeometry: (
       cells: Cell[],
       includeEdges?: boolean
@@ -458,94 +1250,32 @@ type PartialType = PartialGraph & PartialCells;
 
 // @ts-expect-error The properties of PartialGraph are defined elsewhere.
 export const CellsMixin: PartialType = {
-  /**
-   * Specifies the return value for {@link isCellsResizable}.
-   * @default true
-   */
   cellsResizable: true,
 
-  /**
-   * Specifies the return value for {@link isCellsBendable}.
-   * @default true
-   */
   cellsBendable: true,
 
-  /**
-   * Specifies the return value for {@link isCellsSelectable}.
-   * @default true
-   */
   cellsSelectable: true,
 
-  /**
-   * Specifies the return value for {@link isCellsDisconnectable}.
-   * @default true
-   */
   cellsDisconnectable: true,
 
-  /**
-   * Specifies if the graph should automatically update the cell size after an
-   * edit. This is used in {@link isAutoSizeCell}.
-   * @default false
-   */
   autoSizeCells: false,
 
-  /**
-   * Specifies if autoSize style should be applied when cells are added.
-   * @default false
-   */
   autoSizeCellsOnAdd: false,
 
-  /**
-   * Specifies the return value for {@link isCellLocked}.
-   * @default false
-   */
   cellsLocked: false,
 
-  /**
-   * Specifies the return value for {@link isCellCloneable}.
-   * @default true
-   */
   cellsCloneable: true,
 
-  /**
-   * Specifies the return value for {@link isCellDeletable}.
-   * @default true
-   */
   cellsDeletable: true,
 
-  /**
-   * Specifies the return value for {@link isCellMovable}.
-   * @default true
-   */
   cellsMovable: true,
 
-  /**
-   * Specifies if a parent should contain the child bounds after a resize of
-   * the child. This has precedence over {@link constrainChildren}.
-   * @default true
-   */
   extendParents: true,
 
-  /**
-   * Specifies if parents should be extended according to the {@link extendParents}
-   * switch if cells are added.
-   * @default true
-   */
   extendParentsOnAdd: true,
 
-  /**
-   * Specifies if parents should be extended according to the {@link extendParents}
-   * switch if cells are added.
-   * @default false (for backwards compatibility)
-   */
   extendParentsOnMove: false,
 
-  /**
-   * Returns the bounding box for the given array of {@link Cell}. The bounding box for
-   * each cell and its descendants is computed using {@link view.getBoundingBox}.
-   *
-   * @param cells Array of {@link Cell} whose bounding box should be returned.
-   */
   getBoundingBox(cells) {
     let result = null;
 
@@ -567,14 +1297,6 @@ export const CellsMixin: PartialType = {
     return result;
   },
 
-  /**
-   * Removes all cached information for the given cell and its descendants.
-   * This is called when a cell was removed from the model.
-   *
-   * Paramters:
-   *
-   * @param cell {@link mxCell} that was removed from the model.
-   */
   removeStateForCell(cell) {
     for (const child of cell.getChildren()) {
       this.removeStateForCell(child);
@@ -588,28 +1310,11 @@ export const CellsMixin: PartialType = {
    * Group: Cell styles
    *****************************************************************************/
 
-  /**
-   * Returns the style for the given cell from the cell state, if one exists,
-   * or using {@link getCellStyle}.
-   *
-   * @param cell {@link mxCell} whose style should be returned as an array.
-   * @param ignoreState Optional boolean that specifies if the cell state should be ignored.
-   */
   getCurrentCellStyle(cell, ignoreState = false) {
     const state = ignoreState ? null : this.getView().getState(cell);
     return state ? state.style : this.getCellStyle(cell);
   },
 
-  /**
-   * Returns an array of key, value pairs representing the cell style for the
-   * given cell. If no string is defined in the model that specifies the
-   * style, then the default style for the cell is returned or an empty object,
-   * if no style can be found. Note: You should try and get the cell state
-   * for the given cell and use the cached style in the state before using
-   * this method.
-   *
-   * @param cell {@link mxCell} whose style should be returned as an array.
-   */
   getCellStyle(cell) {
     const cellStyle = cell.getStyle();
     const stylesheet = this.getStylesheet();
@@ -627,11 +1332,6 @@ export const CellsMixin: PartialType = {
     return style;
   },
 
-  /**
-   * Tries to resolve the value for the image style in the image bundles and
-   * turns short data URIs as defined in mxImageBundle to data URIs as
-   * defined in RFC 2397 of the IETF.
-   */
   postProcessCellStyle(style) {
     if (!style.image) {
       return style;
@@ -675,38 +1375,11 @@ export const CellsMixin: PartialType = {
     });
   },
 
-  /**
-   * Toggles the boolean value for the given key in the style of the given cell
-   * and returns the new value as 0 or 1. If no cell is specified then the
-   * selection cell is used.
-   *
-   * Parameter:
-   *
-   * @param key String representing the key for the boolean value to be toggled.
-   * @param defaultValue Optional boolean default value if no value is defined.
-   * Default is `false`.
-   * @param cell Optional {@link Cell} whose style should be modified. Default is
-   * the selection cell.
-   */
   toggleCellStyle(key, defaultValue = false, cell?) {
     cell = cell ?? this.getSelectionCell();
     return this.toggleCellStyles(key, defaultValue, [cell]);
   },
 
-  /**
-   * Toggles the boolean value for the given key in the style of the given cells
-   * and returns the new value as 0 or 1. If no cells are specified, then the
-   * selection cells are used. For example, this can be used to toggle
-   * {@link 'rounded'} or any other style with a boolean value.
-   *
-   * Parameter:
-   *
-   * @param key String representing the key for the boolean value to be toggled.
-   * @param defaultValue Optional boolean default value if no value is defined.
-   * Default is `false`.
-   * @param cells Optional array of {@link Cell} whose styles should be modified.
-   * Default is the selection cells.
-   */
   toggleCellStyles(key, defaultValue = false, cells?) {
     let value = false;
 
@@ -721,49 +1394,18 @@ export const CellsMixin: PartialType = {
     return value;
   },
 
-  /**
-   * Sets the key to value in the styles of the given cells. This will modify
-   * the existing cell styles in-place and override any existing assignment
-   * for the given key. If no cells are specified, then the selection cells
-   * are changed. If no value is specified, then the respective key is
-   * removed from the styles.
-   *
-   * @param key String representing the key to be assigned.
-   * @param value String representing the new value for the key.
-   * @param cells Optional array of {@link Cell} to change the style for. Default is
-   * the selection cells.
-   */
   setCellStyles(key, value, cells) {
     cells = cells ?? this.getSelectionCells();
 
     setCellStyles(this.getDataModel(), cells, key, value);
   },
 
-  /**
-   * Toggles the given bit for the given key in the styles of the specified
-   * cells.
-   *
-   * @param key String representing the key to toggle the flag in.
-   * @param flag Integer that represents the bit to be toggled.
-   * @param cells Optional array of {@link Cell} to change the style for. Default is
-   * the selection cells.
-   */
   toggleCellStyleFlags(key, flag, cells) {
     cells = cells ?? this.getSelectionCells();
 
     this.setCellStyleFlags(key, flag, null, cells);
   },
 
-  /**
-   * Sets or toggles the given bit for the given key in the styles of the
-   * specified cells.
-   *
-   * @param key String representing the key to toggle the flag in.
-   * @param flag Integer that represents the bit to be toggled.
-   * @param value Boolean value to be used or null if the value should be toggled.
-   * @param cells Optional array of {@link Cell} to change the style for. Default is
-   * the selection cells.
-   */
   setCellStyleFlags(key, flag, value = null, cells) {
     cells = cells ?? this.getSelectionCells();
 
@@ -782,15 +1424,6 @@ export const CellsMixin: PartialType = {
    * Group: Cell alignment and orientation
    *****************************************************************************/
 
-  /**
-   * Aligns the given cells vertically or horizontally according to the given
-   * alignment using the optional parameter as the coordinate.
-   *
-   * @param align Specifies the alignment. Possible values are all constants in
-   * mxConstants with an ALIGN prefix.
-   * @param cells Array of {@link Cell} to be aligned.
-   * @param param Optional coordinate for the alignment.
-   */
   alignCells(align, cells, param = null) {
     cells = cells ?? this.getSelectionCells();
 
@@ -877,33 +1510,10 @@ export const CellsMixin: PartialType = {
    * Group: Cell cloning, insertion and removal
    *****************************************************************************/
 
-  /**
-   * Returns the clone for the given cell. Uses {@link cloneCells}.
-   *
-   * @param cell {@link Cell} to be cloned.
-   * @param allowInvalidEdges Optional boolean that specifies if invalid edges
-   * should be cloned. Default is `true`.
-   * @param mapping Optional mapping for existing clones.
-   * @param keepPosition Optional boolean indicating if the position of the cells should
-   * be updated to reflect the lost parent cell. Default is `false`.
-   */
   cloneCell(cell, allowInvalidEdges = false, mapping = {}, keepPosition = false) {
     return this.cloneCells([cell], allowInvalidEdges, mapping, keepPosition)[0];
   },
 
-  /**
-   * Returns the clones for the given cells. The clones are created recursively
-   * using {@link cloneCells}. If the terminal of an edge is not in the
-   * given array, then the respective end is assigned a terminal point and the
-   * terminal is removed.
-   *
-   * @param cells Array of {@link Cell} to be cloned.
-   * @param allowInvalidEdges Optional boolean that specifies if invalid edges
-   * should be cloned. Default is `true`.
-   * @param mapping Optional mapping for existing clones.
-   * @param keepPosition Optional boolean indicating if the position of the cells should
-   * be updated to reflect the lost parent cell. Default is `false`.
-   */
   cloneCells(cells, allowInvalidEdges = true, mapping = {}, keepPosition = false) {
     let clones: Cell[];
 
@@ -1004,37 +1614,10 @@ export const CellsMixin: PartialType = {
     return clones;
   },
 
-  /**
-   * Adds the cell to the parent and connects it to the given source and
-   * target terminals. This is a shortcut method. Returns the cell that was
-   * added.
-   *
-   * @param cell {@link mxCell} to be inserted into the given parent.
-   * @param parent {@link mxCell} that represents the new parent. If no parent is
-   * given then the default parent is used.
-   * @param index Optional index to insert the cells at. Default is 'to append'.
-   * @param source Optional {@link Cell} that represents the source terminal.
-   * @param target Optional {@link Cell} that represents the target terminal.
-   */
   addCell(cell, parent = null, index = null, source = null, target = null) {
     return this.addCells([cell], parent, index, source, target)[0];
   },
 
-  /**
-   * Adds the cells to the parent at the given index, connecting each cell to
-   * the optional source and target terminal. The change is carried out using
-   * <cellsAdded>. This method fires {@link Event#ADD_CELLS} while the
-   * transaction is in progress. Returns the cells that were added.
-   *
-   * @param cells Array of {@link Cells} to be inserted.
-   * @param parent <Cell> that represents the new parent. If no parent is
-   * given then the default parent is used.
-   * @param index Optional index to insert the cells at. Default is to append.
-   * @param source Optional source <Cell> for all inserted cells.
-   * @param target Optional target <Cell> for all inserted cells.
-   * @param absolute Optional boolean indicating of cells should be kept at
-   * their absolute position. Default is false.
-   */
   addCells(
     cells,
     parent = null,
@@ -1056,10 +1639,6 @@ export const CellsMixin: PartialType = {
     return cells;
   },
 
-  /**
-   * Adds the specified cells to the given parent. This method fires
-   * {@link Event#CELLS_ADDED} while the transaction is in progress.
-   */
   cellsAdded(
     cells,
     parent,
@@ -1158,13 +1737,6 @@ export const CellsMixin: PartialType = {
     });
   },
 
-  /**
-   * Resizes the specified cell to just fit around the its label and/or children
-   *
-   * @param cell {@link mxCell} to be resized.
-   * @param recurse Optional boolean which specifies if all descendants should be
-   * autosized. Default is `true`.
-   */
   autoSizeCell(cell, recurse = true) {
     if (recurse) {
       for (const child of cell.getChildren()) {
@@ -1177,17 +1749,6 @@ export const CellsMixin: PartialType = {
     }
   },
 
-  /**
-   * Removes the given cells from the graph including all connected edges if
-   * includeEdges is true. The change is carried out using {@link cellsRemoved}.
-   * This method fires {@link InternalEvent.REMOVE_CELLS} while the transaction is in
-   * progress. The removed cells are returned as an array.
-   *
-   * @param cells Array of {@link Cell} to remove. If null is specified then the
-   * selection cells which are deletable are used.
-   * @param includeEdges Optional boolean which specifies if all connected edges
-   * should be removed as well. Default is `true`.
-   */
   removeCells(cells = null, includeEdges = true) {
     if (!cells) {
       cells = this.getDeletableCells(this.getSelectionCells());
@@ -1228,12 +1789,6 @@ export const CellsMixin: PartialType = {
     return cells ?? [];
   },
 
-  /**
-   * Removes the given cells from the model. This method fires
-   * {@link InternalEvent.CELLS_REMOVED} while the transaction is in progress.
-   *
-   * @param cells Array of {@link Cell} to remove.
-   */
   cellsRemoved(cells) {
     if (cells.length > 0) {
       const { scale } = this.getView();
@@ -1329,18 +1884,6 @@ export const CellsMixin: PartialType = {
    * Group: Cell visibility
    *****************************************************************************/
 
-  /**
-   * Sets the visible state of the specified cells and all connected edges
-   * if includeEdges is true. The change is carried out using {@link cellsToggled}.
-   * This method fires {@link InternalEvent.TOGGLE_CELLS} while the transaction is in
-   * progress. Returns the cells whose visible state was changed.
-   *
-   * @param show Boolean that specifies the visible state to be assigned.
-   * @param cells Array of {@link Cell} whose visible state should be changed. If
-   * null is specified then the selection cells are used.
-   * @param includeEdges Optional boolean indicating if the visible state of all
-   * connected edges should be changed as well. Default is `true`.
-   */
   toggleCells(show = false, cells, includeEdges = true) {
     cells = cells ?? this.getSelectionCells();
 
@@ -1358,12 +1901,6 @@ export const CellsMixin: PartialType = {
     return cells;
   },
 
-  /**
-   * Sets the visible state of the specified cells.
-   *
-   * @param cells Array of {@link Cell} whose visible state should be changed.
-   * @param show Boolean that specifies the visible state to be assigned.
-   */
   cellsToggled(cells, show = false) {
     if (cells.length > 0) {
       this.batchUpdate(() => {
@@ -1378,13 +1915,6 @@ export const CellsMixin: PartialType = {
    * Group: Cell sizing
    *****************************************************************************/
 
-  /**
-   * Updates the size of the given cell in the model using {@link cellSizeUpdated}.
-   * This method fires {@link InternalEvent.UPDATE_CELL_SIZE} while the transaction is in
-   * progress. Returns the cell whose size was updated.
-   *
-   * @param cell {@link mxCell} whose size should be updated.
-   */
   updateCellSize(cell, ignoreChildren = false) {
     this.batchUpdate(() => {
       this.cellSizeUpdated(cell, ignoreChildren);
@@ -1395,12 +1925,6 @@ export const CellsMixin: PartialType = {
     return cell;
   },
 
-  /**
-   * Updates the size of the given cell in the model using
-   * {@link getPreferredSizeForCell} to get the new size.
-   *
-   * @param cell {@link mxCell} for which the size should be changed.
-   */
   cellSizeUpdated(cell, ignoreChildren = false) {
     this.batchUpdate(() => {
       const size = this.getPreferredSizeForCell(cell);
@@ -1475,30 +1999,6 @@ export const CellsMixin: PartialType = {
     });
   },
 
-  /**
-   * Returns the preferred width and height of the given {@link Cell} as an
-   * {@link Rectangle}. To implement a minimum width, add a new style eg.
-   * minWidth in the vertex and override this method as follows.
-   *
-   * ```javascript
-   * var graphGetPreferredSizeForCell = graph.getPreferredSizeForCell;
-   * graph.getPreferredSizeForCell(cell)
-   * {
-   *   var result = graphGetPreferredSizeForCell.apply(this, arguments);
-   *   var style = this.getCellStyle(cell);
-   *
-   *   if (style.minWidth > 0)
-   *   {
-   *     result.width = Math.max(style.minWidth, result.width);
-   *   }
-   *
-   *   return result;
-   * };
-   * ```
-   *
-   * @param cell {@link mxCell} for which the preferred size should be returned.
-   * @param textWidth Optional maximum text width for word wrapping.
-   */
   getPreferredSizeForCell(cell, textWidth = null) {
     let result = null;
 
@@ -1582,25 +2082,10 @@ export const CellsMixin: PartialType = {
     return result;
   },
 
-  /**
-   * Sets the bounds of the given cell using {@link resizeCells}. Returns the
-   * cell which was passed to the function.
-   *
-   * @param cell {@link mxCell} whose bounds should be changed.
-   * @param bounds {@link mxRectangle} that represents the new bounds.
-   */
   resizeCell(cell, bounds, recurse = false) {
     return this.resizeCells([cell], [bounds], recurse)[0];
   },
 
-  /**
-   * Sets the bounds of the given cells and fires a {@link InternalEvent.RESIZE_CELLS}
-   * event while the transaction is in progress. Returns the cells which
-   * have been passed to the function.
-   *
-   * @param cells Array of {@link Cell} whose bounds should be changed.
-   * @param bounds Array of {@link mxRectangles} that represent the new bounds.
-   */
   resizeCells(cells, bounds, recurse): Cell[] {
     recurse = recurse ?? this.isRecursiveResize();
 
@@ -1613,48 +2098,6 @@ export const CellsMixin: PartialType = {
     return cells;
   },
 
-  /**
-   * Sets the bounds of the given cells and fires a {@link InternalEvent.CELLS_RESIZED}
-   * event. If {@link extendParents} is true, then the parent is extended if a
-   * child size is changed so that it overlaps with the parent.
-   *
-   * The following example shows how to control group resizes to make sure
-   * that all child cells stay within the group.
-   *
-   * ```javascript
-   * graph.addListener(mxEvent.CELLS_RESIZED, function(sender, evt)
-   * {
-   *   var cells = evt.getProperty('cells');
-   *
-   *   if (cells != null)
-   *   {
-   *     for (var i = 0; i < cells.length; i++)
-   *     {
-   *       if (graph.getDataModel().getChildCount(cells[i]) > 0)
-   *       {
-   *         var geo = cells[i].getGeometry();
-   *
-   *         if (geo != null)
-   *         {
-   *           var children = graph.getChildCells(cells[i], true, true);
-   *           var bounds = graph.getBoundingBoxFromGeometry(children, true);
-   *
-   *           geo = geo.clone();
-   *           geo.width = Math.max(geo.width, bounds.width);
-   *           geo.height = Math.max(geo.height, bounds.height);
-   *
-   *           graph.getDataModel().setGeometry(cells[i], geo);
-   *         }
-   *       }
-   *     }
-   *   }
-   * });
-   * ```
-   *
-   * @param cells Array of {@link Cell} whose bounds should be changed.
-   * @param bounds Array of {@link mxRectangles} that represent the new bounds.
-   * @param recurse Optional boolean that specifies if the children should be resized.
-   */
   cellsResized(cells, bounds, recurse = false) {
     const prev: (Geometry | null)[] = [];
 
@@ -1682,15 +2125,6 @@ export const CellsMixin: PartialType = {
     return prev;
   },
 
-  /**
-   * Resizes the parents recursively so that they contain the complete area
-   * of the resized child cell.
-   *
-   * @param cell {@link mxCell} whose bounds should be changed.
-   * @param bounds {@link mxRectangles} that represent the new bounds.
-   * @param ignoreRelative Boolean that indicates if relative cells should be ignored.
-   * @param recurse Optional boolean that specifies if the children should be resized.
-   */
   cellResized(cell, bounds, ignoreRelative = false, recurse = false) {
     const prev = cell.getGeometry();
 
@@ -1736,13 +2170,6 @@ export const CellsMixin: PartialType = {
     return prev;
   },
 
-  /**
-   * Resizes the child cells of the given cell for the given new geometry with
-   * respect to the current geometry of the cell.
-   *
-   * @param cell {@link mxCell} that has been resized.
-   * @param newGeo {@link mxGeometry} that represents the new bounds.
-   */
   resizeChildCells(cell, newGeo) {
     const geo = cell.getGeometry();
 
@@ -1756,26 +2183,12 @@ export const CellsMixin: PartialType = {
     }
   },
 
-  /**
-   * Constrains the children of the given cell using {@link constrainChild}.
-   *
-   * @param cell {@link mxCell} that has been resized.
-   */
   constrainChildCells(cell) {
     for (const child of cell.getChildren()) {
       this.constrainChild(child);
     }
   },
 
-  /**
-   * Scales the points, position and size of the given cell according to the
-   * given vertical and horizontal scaling factors.
-   *
-   * @param cell {@link mxCell} whose geometry should be scaled.
-   * @param dx Horizontal scaling factor.
-   * @param dy Vertical scaling factor.
-   * @param recurse Boolean indicating if the child cells should be scaled.
-   */
   scaleCell(cell, dx, dy, recurse = false) {
     let geo = cell.getGeometry();
 
@@ -1821,12 +2234,6 @@ export const CellsMixin: PartialType = {
     }
   },
 
-  /**
-   * Resizes the parents recursively so that they contain the complete area
-   * of the resized child cell.
-   *
-   * @param cell {@link mxCell} that has been resized.
-   */
   extendParent(cell) {
     const parent = cell.getParent();
     let p = parent ? parent.getGeometry() : null;
@@ -1979,11 +2386,6 @@ export const CellsMixin: PartialType = {
     return cells;
   },
 
-  /**
-   * Moves the specified cells by the given vector, disconnecting the cells
-   * using disconnectGraph is disconnect is true. This method fires
-   * {@link Event#CELLS_MOVED} while the transaction is in progress.
-   */
   cellsMoved(cells, dx, dy, disconnect = false, constrain = false, extend = false) {
     if (dx !== 0 || dy !== 0) {
       this.batchUpdate(() => {
@@ -2012,10 +2414,6 @@ export const CellsMixin: PartialType = {
     }
   },
 
-  /**
-   * Translates the geometry of the given cell and stores the new,
-   * translated geometry in the model as an atomic change.
-   */
   translateCell(cell, dx, dy) {
     let geometry = cell.getGeometry();
 
@@ -2057,11 +2455,6 @@ export const CellsMixin: PartialType = {
     }
   },
 
-  /**
-   * Returns the {@link Rectangle} inside which a cell is to be kept.
-   *
-   * @param cell {@link mxCell} for which the area should be returned.
-   */
   getCellContainmentArea(cell) {
     if (!cell.isEdge()) {
       const parent = cell.getParent();
@@ -2109,15 +2502,6 @@ export const CellsMixin: PartialType = {
     return null;
   },
 
-  /**
-   * Keeps the given cell inside the bounds returned by
-   * {@link getCellContainmentArea} for its parent, according to the rules defined by
-   * {@link getOverlap} and {@link isConstrainChild}. This modifies the cell's geometry
-   * in-place and does not clone it.
-   *
-   * @param cell {@link mxCell} which should be constrained.
-   * @param sizeFirst Specifies if the size should be changed first. Default is `true`.
-   */
   constrainChild(cell, sizeFirst = true) {
     let geo = cell.getGeometry();
 
@@ -2236,16 +2620,6 @@ export const CellsMixin: PartialType = {
    * Group: Cell retrieval
    *****************************************************************************/
 
-  /**
-   * Returns the visible child vertices or edges in the given parent. If
-   * vertices and edges is false, then all children are returned.
-   *
-   * @param parent {@link mxCell} whose children should be returned.
-   * @param vertices Optional boolean that specifies if child vertices should
-   * be returned. Default is `false`.
-   * @param edges Optional boolean that specifies if child edges should
-   * be returned. Default is `false`.
-   */
   getChildCells(parent, vertices = false, edges = false) {
     parent = parent ?? this.getDefaultParent();
 
@@ -2261,25 +2635,6 @@ export const CellsMixin: PartialType = {
     return result;
   },
 
-  /**
-   * Returns the bottom-most cell that intersects the given point (x, y) in
-   * the cell hierarchy starting at the given parent. This will also return
-   * swimlanes if the given location intersects the content area of the
-   * swimlane. If this is not desired, then the {@link hitsSwimlaneContent} may be
-   * used if the returned cell is a swimlane to determine if the location
-   * is inside the content area or on the actual title of the swimlane.
-   *
-   * @param x X-coordinate of the location to be checked.
-   * @param y Y-coordinate of the location to be checked.
-   * @param parent {@link mxCell} that should be used as the root of the recursion.
-   * Default is current root of the view or the root of the model.
-   * @param vertices Optional boolean indicating if vertices should be returned.
-   * Default is `true`.
-   * @param edges Optional boolean indicating if edges should be returned. Default
-   * is `true`.
-   * @param ignoreFn Optional function that returns true if cell should be ignored.
-   * The function is passed the cell state and the x and y parameter.
-   */
   getCellAt(x, y, parent = null, vertices = true, edges = true, ignoreFn = null) {
     if (!parent) {
       parent = this.getCurrentRoot();
@@ -2318,20 +2673,6 @@ export const CellsMixin: PartialType = {
     return null;
   },
 
-  /**
-   * Returns the child vertices and edges of the given parent that are contained
-   * in the given rectangle. The result is added to the optional result array,
-   * which is returned. If no result array is specified then a new array is
-   * created and returned.
-   *
-   * @param x X-coordinate of the rectangle.
-   * @param y Y-coordinate of the rectangle.
-   * @param width Width of the rectangle.
-   * @param height Height of the rectangle.
-   * @param parent {@link mxCell} that should be used as the root of the recursion.
-   * Default is current root of the view or the root of the model.
-   * @param result Optional array to store the result in.
-   */
   getCells(
     x,
     y,
@@ -2401,20 +2742,6 @@ export const CellsMixin: PartialType = {
     return result;
   },
 
-  /**
-   * Returns the children of the given parent that are contained in the
-   * halfpane from the given point (x0, y0) rightwards or downwards
-   * depending on rightHalfpane and bottomHalfpane.
-   *
-   * @param x0 X-coordinate of the origin.
-   * @param y0 Y-coordinate of the origin.
-   * @param parent Optional <Cell> whose children should be checked. Default is
-   * <defaultParent>.
-   * @param rightHalfpane Boolean indicating if the cells in the right halfpane
-   * from the origin should be returned.
-   * @param bottomHalfpane Boolean indicating if the cells in the bottom halfpane
-   * from the origin should be returned.
-   */
   getCellsBeyond(x0, y0, parent = null, rightHalfpane = false, bottomHalfpane = false) {
     const result = [];
 
@@ -2437,14 +2764,6 @@ export const CellsMixin: PartialType = {
     return result;
   },
 
-  /**
-   * Returns the bottom-most cell that intersects the given point (x, y) in
-   * the cell hierarchy that starts at the given parent.
-   *
-   * @param state {@link CellState} that represents the cell state.
-   * @param x X-coordinate of the location to be checked.
-   * @param y Y-coordinate of the location to be checked.
-   */
   intersects(state, x, y) {
     const pts = state.absolutePoints;
 
@@ -2484,15 +2803,6 @@ export const CellsMixin: PartialType = {
     return false;
   },
 
-  /**
-   * Returns whether or not the specified parent is a valid
-   * ancestor of the specified cell, either direct or indirectly
-   * based on whether ancestor recursion is enabled.
-   *
-   * @param cell {@link mxCell} the possible child cell
-   * @param parent {@link mxCell} the possible parent cell
-   * @param recurse boolean whether or not to recurse the child ancestors
-   */
   isValidAncestor(cell, parent, recurse = false) {
     return recurse ? parent.isAncestor(cell) : cell.getParent() === parent;
   },
@@ -2501,255 +2811,116 @@ export const CellsMixin: PartialType = {
    * Group: Graph behaviour
    *****************************************************************************/
 
-  /**
-   * Returns true if the given cell may not be moved, sized, bended,
-   * disconnected, edited or selected. This implementation returns true for
-   * all vertices with a relative geometry if {@link locked} is false.
-   *
-   * @param cell {@link mxCell} whose locked state should be returned.
-   */
   isCellLocked(cell) {
     const geometry = cell.getGeometry();
 
     return this.isCellsLocked() || (!!geometry && cell.isVertex() && geometry.relative);
   },
 
-  /**
-   * Returns true if the given cell may not be moved, sized, bended,
-   * disconnected, edited or selected. This implementation returns true for
-   * all vertices with a relative geometry if {@link locked} is false.
-   *
-   * @param cell {@link mxCell} whose locked state should be returned.
-   */
   isCellsLocked() {
     return this.cellsLocked;
   },
 
-  /**
-   * Sets if any cell may be moved, sized, bended, disconnected, edited or
-   * selected.
-   *
-   * @param value Boolean that defines the new value for {@link cellsLocked}.
-   */
   setCellsLocked(value) {
     this.cellsLocked = value;
   },
 
-  /**
-   * Returns the cells which may be exported in the given array of cells.
-   */
   getCloneableCells(cells) {
     return this.getDataModel().filterCells(cells, (cell: Cell) => {
       return this.isCellCloneable(cell);
     });
   },
 
-  /**
-   * Returns true if the given cell is cloneable. This implementation returns
-   * {@link isCellsCloneable} for all cells unless a cell style specifies
-   * {@link mxConstants.STYLE_CLONEABLE} to be 0.
-   *
-   * @param cell Optional {@link Cell} whose cloneable state should be returned.
-   */
   isCellCloneable(cell) {
     const style = this.getCurrentCellStyle(cell);
     const cloneable = style.cloneable == null ? true : style.cloneable;
     return this.isCellsCloneable() && cloneable;
   },
 
-  /**
-   * Returns {@link cellsCloneable}, that is, if the graph allows cloning of cells
-   * by using control-drag.
-   */
   isCellsCloneable() {
     return this.cellsCloneable;
   },
 
-  /**
-   * Specifies if the graph should allow cloning of cells by holding down the
-   * control key while cells are being moved. This implementation updates
-   * {@link cellsCloneable}.
-   *
-   * @param value Boolean indicating if the graph should be cloneable.
-   */
   setCellsCloneable(value) {
     this.cellsCloneable = value;
   },
 
-  /**
-   * Returns the cells which may be exported in the given array of cells.
-   */
   getExportableCells(cells) {
     return this.getDataModel().filterCells(cells, (cell: Cell) => {
       return this.canExportCell(cell);
     });
   },
 
-  /**
-   * Returns true if the given cell may be exported to the clipboard. This
-   * implementation returns {@link exportEnabled} for all cells.
-   *
-   * @param cell {@link mxCell} that represents the cell to be exported.
-   */
-  canExportCell(cell = null) {
+  canExportCell(_cell = null) {
     return this.isExportEnabled();
   },
 
-  /**
-   * Returns the cells which may be imported in the given array of cells.
-   */
   getImportableCells(cells) {
     return this.getDataModel().filterCells(cells, (cell: Cell) => {
       return this.canImportCell(cell);
     });
   },
 
-  /**
-   * Returns true if the given cell may be imported from the clipboard.
-   * This implementation returns {@link importEnabled} for all cells.
-   *
-   * @param cell {@link mxCell} that represents the cell to be imported.
-   */
   canImportCell(cell = null) {
     return this.isImportEnabled();
   },
 
-  /**
-   * Returns true if the given cell is selectable. This implementation
-   * returns {@link cellsSelectable}.
-   *
-   * To add a new style for making cells (un)selectable, use the following code.
-   *
-   * ```javascript
-   * isCellSelectable(cell)
-   * {
-   *   var style = this.getCurrentCellStyle(cell);
-   *
-   *   return this.isCellsSelectable() && !this.isCellLocked(cell) && style.selectable != 0;
-   * };
-   * ```
-   *
-   * You can then use the new style as shown in this example.
-   *
-   * ```javascript
-   * graph.insertVertex(parent, null, 'Hello,', 20, 20, 80, 30, 'selectable=0');
-   * ```
-   *
-   * @param cell {@link mxCell} whose selectable state should be returned.
-   */
-  isCellSelectable(cell) {
+  isCellSelectable(_cell) {
     return this.isCellsSelectable();
   },
 
-  /**
-   * Returns {@link cellsSelectable}.
-   */
   isCellsSelectable() {
     return this.cellsSelectable;
   },
 
-  /**
-   * Sets {@link cellsSelectable}.
-   */
   setCellsSelectable(value) {
     this.cellsSelectable = value;
   },
 
-  /**
-   * Returns the cells which may be exported in the given array of cells.
-   */
   getDeletableCells(cells) {
     return this.getDataModel().filterCells(cells, (cell: Cell) => {
       return this.isCellDeletable(cell);
     });
   },
 
-  /**
-   * Returns true if the given cell is moveable. This returns
-   * {@link cellsDeletable} for all given cells if a cells style does not specify
-   * {@link 'deletable'} to be 0.
-   *
-   * @param cell {@link mxCell} whose deletable state should be returned.
-   */
   isCellDeletable(cell) {
     const style = this.getCurrentCellStyle(cell);
     const deletable = style.deletable == null ? true : style.deletable;
     return this.isCellsDeletable() && deletable;
   },
 
-  /**
-   * Returns {@link cellsDeletable}.
-   */
   isCellsDeletable() {
     return this.cellsDeletable;
   },
 
-  /**
-   * Sets {@link cellsDeletable}.
-   *
-   * @param value Boolean indicating if the graph should allow deletion of cells.
-   */
   setCellsDeletable(value) {
     this.cellsDeletable = value;
   },
 
-  /**
-   * Returns true if the given cell is rotatable. This returns true for the given
-   * cell if its style does not specify {@link 'rotatable'} to be 0.
-   *
-   * @param cell {@link mxCell} whose rotatable state should be returned.
-   */
   isCellRotatable(cell) {
     const style = this.getCurrentCellStyle(cell);
     return style.rotatable == null ? true : style.rotatable;
   },
 
-  /**
-   * Returns the cells which are movable in the given array of cells.
-   */
   getMovableCells(cells) {
     return this.getDataModel().filterCells(cells, (cell: Cell) => {
       return this.isCellMovable(cell);
     });
   },
 
-  /**
-   * Returns `true` if the given cell is movable. This returns {@link cellsMovable}
-   * for all given cells if {@link isCellLocked} does not return `true` for the given
-   * cell, and its style does not specify {@link CellStateStyle.movable} to be `false`.
-   *
-   * @param cell {@link mxCell} whose movable state should be returned.
-   */
   isCellMovable(cell) {
     const style = this.getCurrentCellStyle(cell);
     return this.isCellsMovable() && !this.isCellLocked(cell) && (style.movable ?? true);
   },
 
-  /**
-   * Returns {@link cellsMovable}.
-   */
   isCellsMovable() {
     return this.cellsMovable;
   },
 
-  /**
-   * Specifies if the graph should allow moving of cells. This implementation
-   * updates {@link cellsMovable}.
-   *
-   * @param value Boolean indicating if the graph should allow moving of cells.
-   */
   setCellsMovable(value) {
     this.cellsMovable = value;
   },
 
-  /**
-   * Returns true if the given cell is resizable. This returns
-   * {@link cellsResizable} for all given cells if {@link isCellLocked} does not return
-   * true for the given cell and its style does not specify
-   * {@link 'resizable'} to be 0.
-   *
-   * @param cell {@link mxCell} whose resizable state should be returned.
-   */
   isCellResizable(cell) {
     const style = this.getCurrentCellStyle(cell);
     return (
@@ -2757,142 +2928,64 @@ export const CellsMixin: PartialType = {
     );
   },
 
-  /**
-   * Returns {@link cellsResizable}.
-   */
   isCellsResizable() {
     return this.cellsResizable;
   },
 
-  /**
-   * Specifies if the graph should allow resizing of cells. This
-   * implementation updates {@link cellsResizable}.
-   *
-   * @param value Boolean indicating if the graph should allow resizing of
-   * cells.
-   */
   setCellsResizable(value) {
     this.cellsResizable = value;
   },
 
-  /**
-   * Returns true if the given cell is bendable. This returns {@link cellsBendable}
-   * for all given cells if {@link isLocked} does not return true for the given
-   * cell and its style does not specify {@link mxConstants.STYLE_BENDABLE} to be 0.
-   *
-   * @param cell {@link mxCell} whose bendable state should be returned.
-   */
   isCellBendable(cell) {
     const style = this.getCurrentCellStyle(cell);
     return this.isCellsBendable() && !this.isCellLocked(cell) && style.bendable != false;
   },
 
-  /**
-   * Returns {@link cellsBenadable}.
-   */
   isCellsBendable() {
     return this.cellsBendable;
   },
 
-  /**
-   * Specifies if the graph should allow bending of edges. This
-   * implementation updates {@link bendable}.
-   *
-   * @param value Boolean indicating if the graph should allow bending of
-   * edges.
-   */
   setCellsBendable(value) {
     this.cellsBendable = value;
   },
 
-  /**
-   * Returns true if the size of the given cell should automatically be
-   * updated after a change of the label. This implementation returns
-   * {@link autoSizeCells} or checks if the cell style does specify
-   * {@link 'autoSize'} to be 1.
-   *
-   * @param cell {@link mxCell} that should be resized.
-   */
   isAutoSizeCell(cell) {
     const style = this.getCurrentCellStyle(cell);
     return this.isAutoSizeCells() || (style.autoSize ?? false);
   },
 
-  /**
-   * Returns {@link autoSizeCells}.
-   */
   isAutoSizeCells() {
     return this.autoSizeCells;
   },
 
-  /**
-   * Specifies if cell sizes should be automatically updated after a label
-   * change. This implementation sets {@link autoSizeCells} to the given parameter.
-   * To update the size of cells when the cells are added, set
-   * {@link autoSizeCellsOnAdd} to true.
-   *
-   * @param value Boolean indicating if cells should be resized
-   * automatically.
-   */
   setAutoSizeCells(value) {
     this.autoSizeCells = value;
   },
 
-  /**
-   * Returns true if the parent of the given cell should be extended if the
-   * child has been resized so that it overlaps the parent. This
-   * implementation returns {@link isExtendParents} if the cell is not an edge.
-   *
-   * @param cell {@link mxCell} that has been resized.
-   */
   isExtendParent(cell) {
     return !cell.isEdge() && this.isExtendParents();
   },
 
-  /**
-   * Returns {@link extendParents}.
-   */
   isExtendParents() {
     return this.extendParents;
   },
 
-  /**
-   * Sets {@link extendParents}.
-   *
-   * @param value New boolean value for {@link extendParents}.
-   */
   setExtendParents(value) {
     this.extendParents = value;
   },
 
-  /**
-   * Returns {@link extendParentsOnAdd}.
-   */
   isExtendParentsOnAdd(cell) {
     return this.extendParentsOnAdd;
   },
 
-  /**
-   * Sets {@link extendParentsOnAdd}.
-   *
-   * @param value New boolean value for {@link extendParentsOnAdd}.
-   */
   setExtendParentsOnAdd(value) {
     this.extendParentsOnAdd = value;
   },
 
-  /**
-   * Returns {@link extendParentsOnMove}.
-   */
   isExtendParentsOnMove() {
     return this.extendParentsOnMove;
   },
 
-  /**
-   * Sets {@link extendParentsOnMove}.
-   *
-   * @param value New boolean value for {@link extendParentsOnAdd}.
-   */
   setExtendParentsOnMove(value) {
     this.extendParentsOnMove = value;
   },
@@ -2901,13 +2994,7 @@ export const CellsMixin: PartialType = {
    * Group: Graph appearance
    *****************************************************************************/
 
-  /**
-   * Returns the cursor value to be used for the CSS of the shape for the
-   * given cell. This implementation returns null.
-   *
-   * @param cell {@link mxCell} whose cursor should be returned.
-   */
-  getCursorForCell(cell) {
+  getCursorForCell(_cell) {
     return null;
   },
 
@@ -2915,16 +3002,6 @@ export const CellsMixin: PartialType = {
    * Group: Graph display
    *****************************************************************************/
 
-  /**
-   * Returns the scaled, translated bounds for the given cell. See
-   * {@link GraphView.getBounds} for arrays.
-   *
-   * @param cell {@link mxCell} whose bounds should be returned.
-   * @param includeEdges Optional boolean that specifies if the bounds of
-   * the connected edges should be included. Default is `false`.
-   * @param includeDescendants Optional boolean that specifies if the bounds
-   * of all descendants should be included. Default is `false`.
-   */
   getCellBounds(cell, includeEdges = false, includeDescendants = false) {
     let cells = [cell];
 
@@ -2950,38 +3027,6 @@ export const CellsMixin: PartialType = {
     return result;
   },
 
-  /**
-   * Returns the bounding box for the geometries of the vertices in the
-   * given array of cells. This can be used to find the graph bounds during
-   * a layout operation (ie. before the last endUpdate) as follows:
-   *
-   * ```javascript
-   * var cells = graph.getChildCells(graph.getDefaultParent(), true, true);
-   * var bounds = graph.getBoundingBoxFromGeometry(cells, true);
-   * ```
-   *
-   * This can then be used to move cells to the origin:
-   *
-   * ```javascript
-   * if (bounds.x < 0 || bounds.y < 0)
-   * {
-   *   graph.moveCells(cells, -Math.min(bounds.x, 0), -Math.min(bounds.y, 0))
-   * }
-   * ```
-   *
-   * Or to translate the graph view:
-   *
-   * ```javascript
-   * if (bounds.x < 0 || bounds.y < 0)
-   * {
-   *   getView().setTranslate(-Math.min(bounds.x, 0), -Math.min(bounds.y, 0));
-   * }
-   * ```
-   *
-   * @param cells Array of {@link Cell} whose bounds should be returned.
-   * @param includeEdges Specifies if edge bounds should be included by computing
-   * the bounding box for all points in geometry. Default is `false`.
-   */
   getBoundingBoxFromGeometry(cells, includeEdges = false) {
     let result = null;
     let tmp: Rectangle | null = null;

--- a/packages/core/src/view/mixins/CellsMixin.ts
+++ b/packages/core/src/view/mixins/CellsMixin.ts
@@ -219,11 +219,11 @@ declare module '../Graph' {
     ) => boolean | null;
 
     /**
-     * Sets the key to value in the styles of the given cells. This will modify
-     * the existing cell styles in-place and override any existing assignment
-     * for the given key. If no cells are specified, then the selection cells
-     * are changed. If no value is specified, then the respective key is
-     * removed from the styles.
+     * Sets the key to value in the styles of the given cells. This will modify the existing cell styles in-place and override any existing assignment for the given key.
+     *
+     * If no cells are specified, then the selection cells are changed.
+     *
+     * If no value is specified, then the respective key is removed from the styles.
      *
      * @param key String representing the key to be assigned.
      * @param value String representing the new value for the key.

--- a/packages/core/src/view/mixins/CellsMixin.ts
+++ b/packages/core/src/view/mixins/CellsMixin.ts
@@ -159,11 +159,12 @@ declare module '../Graph' {
     getCurrentCellStyle: (cell: Cell, ignoreState?: boolean) => CellStateStyle;
 
     /**
-     * Returns the style for the given cell from the cell state, if one exists,
-     * or using {@link getCellStyle}.
+     * Returns the computed style of the Cell using the edge or vertex default style regarding of the type of the cell.
+     * The actual computation is done by {@link Stylesheet.getCellStyle}.
+     *
+     * **Note**: You should try and get the cell state for the given cell and use the cached style in the state before using this method.
      *
      * @param cell {@link Cell} whose style should be returned as an array.
-     * @param ignoreState Optional boolean that specifies if the cell state should be ignored.
      */
     getCellStyle: (cell: Cell) => CellStateStyle;
 


### PR DESCRIPTION
This makes the JSDoc available for consumers.
It was previously set on the implementation which is hidden, so it was useless.

## Notes

Covers #442 