### PR TITLE
docs: declare JSDoc of `GroupingMixin` in type definition

### DIFF
--- a/packages/core/src/view/mixins/GroupingMixin.ts
+++ b/packages/core/src/view/mixins/GroupingMixin.ts
@@ -26,18 +26,90 @@ import { Graph } from '../Graph';
 
 declare module '../Graph' {
   interface Graph {
+    /**
+     * Adds the cells into the given group.
+     * The change is carried out using {@link cellsAdded}, {@link cellsMoved} and {@link cellsResized}.
+     *
+     * This method fires {@link InternalEvent.GROUP_CELLS} while the transaction is in progress.
+     *
+     * @param group {@link Cell} that represents the target group. If `null` is specified then a new group is created using {@link createGroupCell}.
+     * @param border Optional integer that specifies the border between the child area and the group bounds. Default is `0`.
+     * @param cells Optional array of {@link Cell} to be grouped. If `null` is specified then the selection cells are used.
+     * @returns the new group. A group is only created if there is at least one entry in the given array of cells.
+     */
     groupCells: (group: Cell, border: number, cells?: Cell[] | null) => Cell;
+
+    /**
+     * Returns the cells with the same parent as the first cell in the given array.
+     */
     getCellsForGroup: (cells: Cell[]) => Cell[];
+
+    /**
+     * Returns the bounds to be used for the given group and children.
+     */
     getBoundsForGroup: (
       group: Cell,
       children: Cell[],
       border: number | null
     ) => Rectangle | null;
+
+    /**
+     * Hook for creating the group cell to hold the given array of {@link Cell} if no group cell was given to the {@link group} function.
+     *
+     * The following code can be used to set the style of new group cells.
+     *
+     * ```javascript
+     * const graphCreateGroupCell = graph.createGroupCell;
+     * graph.createGroupCell = function(cells) {
+     *   const group = graphCreateGroupCell.apply(this, arguments);
+     *   group.setStyle('group');
+     *
+     *   return group;
+     * };
+     */
     createGroupCell: (cells: Cell[]) => Cell;
+
+    /**
+     * Ungroups the given cells by moving the children to their parents parent and removing the empty groups.
+     *
+     * @param cells Array of cells to be ungrouped. If `null` is specified then the selection cells are used.
+     * @returns the children that have been removed from the groups.
+     */
     ungroupCells: (cells?: Cell[] | null) => Cell[];
+
+    /**
+     * Returns the selection cells that can be ungrouped.
+     */
     getCellsForUngroup: () => Cell[];
+
+    /**
+     * Hook to remove the groups after {@link ungroupCells}.
+     *
+     * @param cells Array of {@link Cell} that were ungrouped.
+     */
     removeCellsAfterUngroup: (cells: Cell[]) => void;
+
+    /**
+     * Removes the specified cells from their parents and adds them to the default parent.
+     *
+     * @param cells Array of {@link Cell} to be removed from their parents.
+     * @returns the cells that were removed from their parents.
+     */
     removeCellsFromParent: (cells?: Cell[] | null) => Cell[];
+
+    /**
+     * Updates the bounds of the given groups to include all children and returns the passed-in cells.
+     *
+     * Call this with the groups in parent to child order, top-most group first, the cells are processed in reverse order and cells with no children are ignored.
+     *
+     * @param cells The groups whose bounds should be updated. If this is `null`, then the selection cells are used.
+     * @param border Optional border to be added in the group. Default is `0`.
+     * @param moveGroup Optional boolean that allows the group to be moved. Default is `false`.
+     * @param topBorder Optional top border to be added in the group. Default is `0`.
+     * @param rightBorder Optional top border to be added in the group. Default is `0`.
+     * @param bottomBorder Optional top border to be added in the group. Default is `0`.
+     * @param leftBorder Optional top border to be added in the group. Default is `0`.
+     */
     updateGroupBounds: (
       cells: Cell[],
       border?: number,
@@ -47,7 +119,19 @@ declare module '../Graph' {
       bottomBorder?: number,
       leftBorder?: number
     ) => Cell[];
+
+    /**
+     * Uses the given cell as the root of the displayed cell hierarchy. If no cell is specified then the selection cell is used.
+     *
+     * The cell is only used if {@link isValidRoot} returns `true`.
+     *
+     * @param cell Optional {@link Cell} to be used as the new root. Default is the selection cell.
+     */
     enterGroup: (cell: Cell) => void;
+
+    /**
+     * Changes the current root to the next valid root in the displayed cell hierarchy.
+     */
     exitGroup: () => void;
   }
 }
@@ -95,24 +179,6 @@ type PartialType = PartialGraph & PartialGrouping;
 
 // @ts-expect-error The properties of PartialGraph are defined elsewhere.
 const GroupingMixin: PartialType = {
-  /*****************************************************************************
-   * Group: Grouping
-   *****************************************************************************/
-
-  /**
-   * Adds the cells into the given group. The change is carried out using
-   * {@link cellsAdded}, {@link cellsMoved} and {@link cellsResized}. This method fires
-   * {@link InternalEvent.GROUP_CELLS} while the transaction is in progress. Returns the
-   * new group. A group is only created if there is at least one entry in the
-   * given array of cells.
-   *
-   * @param group {@link mxCell} that represents the target group. If `null` is specified
-   * then a new group is created using {@link createGroupCell}.
-   * @param border Optional integer that specifies the border between the child
-   * area and the group bounds. Default is `0`.
-   * @param cells Optional array of {@link Cell} to be grouped. If `null` is specified
-   * then the selection cells are used.
-   */
   groupCells(group, border = 0, cells) {
     if (!cells) cells = sortCells(this.getSelectionCells(), true);
     if (!cells) cells = this.getCellsForGroup(cells);
@@ -158,10 +224,6 @@ const GroupingMixin: PartialType = {
     return group;
   },
 
-  /**
-   * Returns the cells with the same parent as the first cell
-   * in the given array.
-   */
   getCellsForGroup(cells) {
     const result = [];
     if (cells != null && cells.length > 0) {
@@ -178,9 +240,6 @@ const GroupingMixin: PartialType = {
     return result;
   },
 
-  /**
-   * Returns the bounds to be used for the given group and children.
-   */
   getBoundsForGroup(group, children, border) {
     const result = this.getBoundingBoxFromGeometry(children, true);
     if (result != null) {
@@ -204,22 +263,6 @@ const GroupingMixin: PartialType = {
     return result;
   },
 
-  /**
-   * Hook for creating the group cell to hold the given array of {@link Cell} if
-   * no group cell was given to the {@link group} function.
-   *
-   * The following code can be used to set the style of new group cells.
-   *
-   * ```javascript
-   * var graphCreateGroupCell = graph.createGroupCell;
-   * graph.createGroupCell = function(cells)
-   * {
-   *   var group = graphCreateGroupCell.apply(this, arguments);
-   *   group.setStyle('group');
-   *
-   *   return group;
-   * };
-   */
   createGroupCell(cells) {
     const group = new Cell('');
     group.setVertex(true);
@@ -228,14 +271,6 @@ const GroupingMixin: PartialType = {
     return group;
   },
 
-  /**
-   * Ungroups the given cells by moving the children the children to their
-   * parents parent and removing the empty groups. Returns the children that
-   * have been removed from the groups.
-   *
-   * @param cells Array of cells to be ungrouped. If null is specified then the
-   * selection cells are used.
-   */
   ungroupCells(cells) {
     let result: Cell[] = [];
 
@@ -282,9 +317,6 @@ const GroupingMixin: PartialType = {
     return result;
   },
 
-  /**
-   * Returns the selection cells that can be ungrouped.
-   */
   getCellsForUngroup() {
     const cells = this.getSelectionCells();
 
@@ -299,21 +331,10 @@ const GroupingMixin: PartialType = {
     return tmp;
   },
 
-  /**
-   * Hook to remove the groups after {@link ungroupCells}.
-   *
-   * @param cells Array of {@link Cell} that were ungrouped.
-   */
   removeCellsAfterUngroup(cells) {
     this.cellsRemoved(this.addAllEdges(cells));
   },
 
-  /**
-   * Removes the specified cells from their parents and adds them to the
-   * default parent. Returns the cells that were removed from their parents.
-   *
-   * @param cells Array of {@link Cell} to be removed from their parents.
-   */
   removeCellsFromParent(cells) {
     if (cells == null) {
       cells = this.getSelectionCells();
@@ -328,22 +349,6 @@ const GroupingMixin: PartialType = {
     return cells;
   },
 
-  /**
-   * Updates the bounds of the given groups to include all children and returns
-   * the passed-in cells. Call this with the groups in parent to child order,
-   * top-most group first, the cells are processed in reverse order and cells
-   * with no children are ignored.
-   *
-   * @param cells The groups whose bounds should be updated. If this is null, then
-   * the selection cells are used.
-   * @param border Optional border to be added in the group. Default is 0.
-   * @param moveGroup Optional boolean that allows the group to be moved. Default
-   * is false.
-   * @param topBorder Optional top border to be added in the group. Default is 0.
-   * @param rightBorder Optional top border to be added in the group. Default is 0.
-   * @param bottomBorder Optional top border to be added in the group. Default is 0.
-   * @param leftBorder Optional top border to be added in the group. Default is 0.
-   */
   updateGroupBounds(
     cells,
     border = 0,
@@ -413,14 +418,6 @@ const GroupingMixin: PartialType = {
    * Group: Drilldown
    *****************************************************************************/
 
-  /**
-   * Uses the given cell as the root of the displayed cell hierarchy. If no
-   * cell is specified then the selection cell is used. The cell is only used
-   * if {@link isValidRoot} returns true.
-   *
-   * @param cell Optional {@link Cell} to be used as the new root. Default is the
-   * selection cell.
-   */
   enterGroup(cell) {
     cell = cell || this.getSelectionCell();
 
@@ -430,10 +427,6 @@ const GroupingMixin: PartialType = {
     }
   },
 
-  /**
-   * Changes the current root to the next valid root in the displayed cell
-   * hierarchy.
-   */
   exitGroup() {
     const root = this.getDataModel().getRoot();
     const current = this.getCurrentRoot();


### PR DESCRIPTION
This makes the JSDoc available for consumers.
It was previously set on the implementation which is hidden, so it was useless.

## Notes

Covers #442 