### PR TITLE
feat: accept `Element` parameter in `ModelXmlSerializer.import`

### DIFF
--- a/packages/core/__tests__/editor/Editor.test.ts
+++ b/packages/core/__tests__/editor/Editor.test.ts
@@ -1,0 +1,100 @@
+/*
+Copyright 2024-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, expect, test } from '@jest/globals';
+import { Editor, Geometry } from '../../src';
+import { ModelChecker } from '../serialization/utils';
+import { parseXml } from '../../src/util/xmlUtils';
+
+describe('writeGraphModel', () => {
+  test('empty model', () => {
+    const editor = new Editor(null!);
+
+    const xml = editor.writeGraphModel();
+    expect(xml).toBe(
+      '<GraphDataModel><root><Cell id="0"><Object as="style"/></Cell><Cell id="1" parent="0"><Object as="style"/></Cell></root></GraphDataModel>'
+    );
+  });
+
+  test('non empty model, write with default linefeed', () => {
+    const editor = new Editor(null!);
+    editor.graph.insertVertex({
+      id: 'v1',
+      value: 'vertex 1\nwith linefeed',
+      position: [10, 20],
+      size: [30, 30],
+    });
+
+    const xml = editor.writeGraphModel();
+    expect(xml).toBe(
+      '<GraphDataModel><root><Cell id="0"><Object as="style"/></Cell><Cell id="1" parent="0"><Object as="style"/></Cell><Cell id="v1" value="vertex 1&#xA;with linefeed" vertex="1" parent="1"><Geometry _x="10" _y="20" _width="30" _height="30" as="geometry"/><Object as="style"/></Cell></root></GraphDataModel>'
+    );
+  });
+
+  test('non empty model, write with custom linefeed', () => {
+    const editor = new Editor(null!);
+    editor.graph.insertVertex({
+      id: 'v1',
+      value: 'vertex 1\nwith linefeed\nand others\nagain',
+      position: [0, 0],
+      size: [20, 30],
+    });
+
+    // The linefeed parameter should be removed from the method signature
+    // In maxGraph, the getXml function ignores the linefeed as it always uses XmlSerializer
+    // In mxGraph, it was only taken into account in Internet Explorer which used a custom serialization code
+    // The test here has been written prior switching the writeGraphModel implementation from direct Codec usage to ModelXmlSerializer
+    const xml = editor.writeGraphModel('LF');
+    expect(xml).toBe(
+      '<GraphDataModel><root><Cell id="0"><Object as="style"/></Cell><Cell id="1" parent="0"><Object as="style"/></Cell><Cell id="v1" value="vertex 1&#xA;with linefeed&#xA;and others&#xA;again" vertex="1" parent="1"><Geometry _width="20" _height="30" as="geometry"/><Object as="style"/></Cell></root></GraphDataModel>'
+    );
+  });
+});
+
+test('readGraphModel', () => {
+  const editor = new Editor(null!);
+
+  const xmlDocument = parseXml(
+    `<GraphDataModel>
+  <root>
+    <Cell id="0">
+      <Object as="style" />
+    </Cell>
+    <Cell id="1" parent="0">
+      <Object as="style" />
+    </Cell>
+    <Cell id="v1" value="vertex 1" vertex="1" parent="1">
+      <Geometry _x="100" _y="100" _width="100" _height="80" as="geometry" />
+      <Object fillColor="green" strokeWidth="4" as="style" />
+    </Cell>
+  </root>
+</GraphDataModel>`
+  );
+
+  editor.readGraphModel(xmlDocument.documentElement);
+  const model = editor.graph.model;
+
+  const modelChecker = new ModelChecker(model);
+  modelChecker.checkRootCells();
+
+  modelChecker.expectIsVertex(model.getCell('v1'), 'vertex 1', {
+    geometry: new Geometry(100, 100, 100, 80),
+    style: {
+      fillColor: 'green',
+      strokeWidth: 4,
+    },
+  });
+});

--- a/packages/core/__tests__/serialization/serialization.xml.mxGraph.test.ts
+++ b/packages/core/__tests__/serialization/serialization.xml.mxGraph.test.ts
@@ -16,13 +16,7 @@ limitations under the License.
 
 import { describe, test } from '@jest/globals';
 import { ModelChecker } from './utils';
-import {
-  CodecRegistry,
-  Geometry,
-  GraphDataModel,
-  ModelXmlSerializer,
-  Point,
-} from '../../src';
+import { Geometry, GraphDataModel, ModelXmlSerializer, Point } from '../../src';
 
 describe('import mxGraph model', () => {
   test('Model with geometry', () => {

--- a/packages/core/__tests__/serialization/serialization.xml.test.ts
+++ b/packages/core/__tests__/serialization/serialization.xml.test.ts
@@ -177,7 +177,7 @@ describe('export', () => {
     expect(
       new ModelXmlSerializer(new GraphDataModel()).export({ pretty: false })
     ).toEqual(
-      `<GraphDataModel><root><Cell id="0"><Object as="style" /></Cell><Cell id="1" parent="0"><Object as="style" /></Cell></root></GraphDataModel>`
+      `<GraphDataModel><root><Cell id="0"><Object as="style"/></Cell><Cell id="1" parent="0"><Object as="style"/></Cell></root></GraphDataModel>`
     );
   });
 

--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -28,6 +28,7 @@ import StackLayout from '../view/layout/StackLayout';
 import EventObject from '../view/event/EventObject';
 import { getOffset } from '../util/styleUtils';
 import Codec from '../serialization/Codec';
+import { ModelXmlSerializer } from '../serialization/ModelXmlSerializer';
 import MaxWindow, { error } from '../gui/MaxWindow';
 import MaxForm from '../gui/MaxForm';
 import Outline from '../view/other/Outline';
@@ -1891,13 +1892,11 @@ export class Editor extends EventSource {
   }
 
   /**
-   * Reads the specified XML node into the existing graph model and resets
-   * the command history and modified state.
-   * @param node
+   * Reads the specified XML node into the existing graph model and resets the command history and modified state.
+   * @param node the XML node to be read into the graph model.
    */
-  readGraphModel(node: any): void {
-    const dec = new Codec(node.ownerDocument);
-    dec.decode(node, this.graph.getDataModel());
+  readGraphModel(node: Element): void {
+    new ModelXmlSerializer(this.graph.getDataModel()).import(node);
     this.resetHistory();
   }
 
@@ -1974,24 +1973,14 @@ export class Editor extends EventSource {
   }
 
   /**
-   * Hook to create the string representation of the diagram. The default
-   * implementation uses an {@link Codec} to encode the graph model as
-   * follows:
+   * Hook to create the string representation of the diagram.
    *
-   * @example
-   * ```javascript
-   * var enc = new Codec();
-   * var node = enc.encode(this.graph.getDataModel());
-   * return mxUtils.getXml(node, this.linefeed);
-   * ```
+   * The default implementation uses {@link ModelXmlSerializer} to encode the graph model.
    *
    * @param linefeed Optional character to be used as the linefeed. Default is {@link linefeed}.
    */
-  writeGraphModel(linefeed: string): string {
-    linefeed = linefeed != null ? linefeed : this.linefeed;
-    const enc = new Codec();
-    const node = <Element>enc.encode(this.graph.getDataModel());
-    return getXml(node, linefeed);
+  writeGraphModel(linefeed?: string): string {
+    return new ModelXmlSerializer(this.graph.getDataModel()).export({ pretty: false });
   }
 
   /**

--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -57,6 +57,8 @@ import { show } from '../util/printUtils';
 import PanningHandler from '../view/handler/PanningHandler';
 import { cloneCell } from '../util/cellArrayUtils';
 
+// TODO disabled side effects, so editor resources are not loaded by default
+// This should be done in a different way
 /**
  * Installs the required language resources at class
  * loading time.
@@ -208,9 +210,9 @@ if (mxLoadResources) {
  *
  * ```javascript
  * <Task label="Task" description="">
- *   <mxCell vertex="true">
- *     <mxGeometry as="geometry" width="72" height="32"/>
- *   </mxCell>
+ *   <Cell vertex="true">
+ *     <Geometry as="geometry" width="72" height="32"/>
+ *   </Cell>
  * </Task>
  * ```
  *
@@ -258,7 +260,7 @@ if (mxLoadResources) {
  * New entries can be added to the toolbar by inserting an add-node into the
  * above configuration. Existing entries may be removed and changed by
  * modifying or removing the respective entries in the configuration.
- * The configuration is read by the {@link DefaultPopupMenuCodec}, the format of the
+ * The configuration is read by the {@link EditorPopupMenuCodec}, the format of the
  * configuration is explained in {@link EditorPopupMenu.decode}.
  *
  * The toolbar is defined in the EditorToolbar section. Items can be added
@@ -272,8 +274,7 @@ if (mxLoadResources) {
  *     ...
  * ```
  *
- * The format of the configuration is described in
- * {@link DefaultToolbarCodec.decode}.
+ * The format of the configuration is described in {@link EditorToolbarCodec.decode}.
  *
  * Ids:
  *
@@ -282,12 +283,12 @@ if (mxLoadResources) {
  * time. For example, if the Task node from above has an id attribute, then
  * the {@link Cell.id} of the corresponding cell will have this value. If there
  * is no Id collision in the model, then the cell may be retrieved using this
- * Id with the {@link mxGraphModel.getCell} function. If there is a collision, a new
- * Id will be created for the cell using {@link mxGraphModel.createId}. At encoding
+ * Id with the {@link GraphDataModel.getCell} function. If there is a collision, a new
+ * Id will be created for the cell using {@link GraphDataModel.createId}. At encoding
  * time, this new Id will replace the value previously stored under the id
  * attribute in the Task node.
  *
- * See {@link EditorCodec}, {@link DefaultToolbarCodec} and {@link DefaultPopupMenuCodec}
+ * See {@link EditorCodec}, {@link EditorToolbarCodec} and {@link EditorPopupMenuCodec}
  * for information about configuring the editor and user interface.
  *
  * Programmatically inserting cells:

--- a/packages/core/src/editor/EditorKeyHandler.ts
+++ b/packages/core/src/editor/EditorKeyHandler.ts
@@ -22,7 +22,7 @@ import KeyHandler from '../view/handler/KeyHandler';
 import Editor from './Editor';
 
 /**
- * Binds keycodes to actionnames in an editor.  This aggregates an internal {@link handler} and extends the implementation of {@link KeyHandler.escape} to not only cancel the editing, but also hide the properties dialog and fire an <Editor.escape> event via {@link editor}.  An instance of this class is created by {@link Editor} and stored in {@link Editor.keyHandler}.
+ * Binds keycodes to action names in an editor.  This aggregates an internal {@link handler} and extends the implementation of {@link KeyHandler.escape} to not only cancel the editing, but also hide the properties dialog and fire an <Editor.escape> event via {@link editor}.  An instance of this class is created by {@link Editor} and stored in {@link Editor.keyHandler}.
  *
  * @Example
  * Bind the delete key to the delete action in an existing editor.

--- a/packages/core/src/serialization/ModelXmlSerializer.ts
+++ b/packages/core/src/serialization/ModelXmlSerializer.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { registerModelCodecs } from './register';
-import { getPrettyXml, parseXml } from '../util/xmlUtils';
+import { getPrettyXml, getXml, parseXml } from '../util/xmlUtils';
 import Codec from './Codec';
 import type GraphDataModel from '../view/GraphDataModel';
 
@@ -52,16 +52,14 @@ export class ModelXmlSerializer {
     this.registerCodecs();
   }
 
-  import(xml: string): void {
-    const doc = parseXml(xml);
+  import(input: string | Element): void {
+    const doc = typeof input === 'string' ? parseXml(input) : input.ownerDocument;
     new Codec(doc).decode(doc.documentElement, this.dataModel);
   }
 
   export(options?: ModelExportOptions): string {
     const encodedNode = new Codec().encode(this.dataModel);
-    return options?.pretty ?? true
-      ? getPrettyXml(encodedNode)
-      : getPrettyXml(encodedNode, '', '', '');
+    return options?.pretty ?? true ? getPrettyXml(encodedNode) : getXml(encodedNode!);
   }
 
   /**

--- a/packages/core/src/util/StringUtils.ts
+++ b/packages/core/src/util/StringUtils.ts
@@ -132,8 +132,8 @@ export const removeWhitespace = (node: HTMLElement, before: boolean) => {
  * Replaces characters (less than, greater than, newlines and quotes) with
  * their HTML entities in the given string and returns the result.
  *
- * @param {string} s String that contains the characters to be converted.
- * @param {boolean} newline If newlines should be replaced. Default is true.
+ * @param s String that contains the characters to be converted.
+ * @param newline If newlines should be replaced. Default is `true`.
  */
 export const htmlEntities = (s: string, newline = true): string => {
   s = String(s || '');

--- a/packages/core/src/util/xmlUtils.ts
+++ b/packages/core/src/util/xmlUtils.ts
@@ -102,20 +102,18 @@ export const getViewXml = (
 };
 
 /**
- * Returns the XML content of the specified node. For Internet Explorer,
- * all \r\n\t[\t]* are removed from the XML string and the remaining \r\n
- * are replaced by \n. All \n are then replaced with linefeed, or &#xa; if
- * no linefeed is defined.
+ * Returns the XML content of the specified node.
+ *
+ * All `\n` are then replaced with the linefeed parameter value.
  *
  * @param node DOM node to return the XML for.
- * @param linefeed Optional string that linefeeds are converted into. Default is `\&#xa;`.
+ * @param linefeed Optional string that linefeed are converted into. Default is `&#xa;`.
  */
 export const getXml = (node: Element, linefeed = '&#xa;'): string => {
   const xmlSerializer = new XMLSerializer();
   let xml = xmlSerializer.serializeToString(node);
 
-  // Replaces linefeeds with HTML Entities.
-  linefeed = linefeed || '&#xa;';
+  // Replaces linefeed with HTML Entities.
   xml = xml.replace(/\n/g, linefeed);
   return xml;
 };


### PR DESCRIPTION
`Editor.writeGraphModel` can now use `ModelXmlSerializer`, eliminating the need to manually register model codecs. `Editor.readGraphModel` also uses `ModelXmlSerializer` for the same reason.

`ModelXmlSerializer.import` now produces a more compact xml when `pretty` is `false` (no extra spaces).


### Notes

⚠️ This increases the size of the maxGraph chunk in the ts-example from **444.89 kB** to **555.66 kB**. Editor seems imported, so `ModelXmlSerializer` is now imported with all model codecs which increases the size of the chunk.
This should be fixed by #442 

The size of the index.js file in the js-example doesn't change: this example directly uses `ModelXmlSerializer`, so the model codecs were already imported.
