### PR TITLE
docs: declare register functions in the "Configuration" category

### DIFF
--- a/packages/core/src/serialization/register.ts
+++ b/packages/core/src/serialization/register.ts
@@ -77,6 +77,7 @@ let isModelCodecsRegistered = false;
  * @param force if `true` register the codecs even if they were already registered. If false, only register them
  *              if they have never been registered before.
  * @since 0.10.0
+ * @category Configuration
  */
 export const registerModelCodecs = (force = false) => {
   if (!isModelCodecsRegistered || force) {
@@ -113,6 +114,7 @@ let isCoreCodecsRegistered = false;
  * @param force if `true` register the codecs even if they were already registered. If false, only register them
  *              if they have never been registered before.
  * @since 0.6.0
+ * @category Configuration
  */
 export const registerCoreCodecs = (force = false) => {
   if (!isCoreCodecsRegistered || force) {
@@ -136,6 +138,7 @@ let isEditorCodecsRegistered = false;
  * @param force if `true` register the codecs even if they were already registered. If false, only register them
  *              if they have never been registered before.
  * @since 0.6.0
+ * @category Configuration
  */
 export const registerEditorCodecs = (force = false) => {
   if (!isEditorCodecsRegistered || force) {
@@ -154,6 +157,7 @@ export const registerEditorCodecs = (force = false) => {
  * @param force if `true` register the codecs even if they were already registered. If false, only register them
  *              if they have never been registered before.
  * @since 0.6.0
+ * @category Configuration
  */
 export const registerAllCodecs = (force = false) => {
   registerCoreCodecs(force);

--- a/packages/core/src/view/cell/register-shapes.ts
+++ b/packages/core/src/view/cell/register-shapes.ts
@@ -38,6 +38,8 @@ let isDefaultElementsRegistered = false;
 
 /**
  * Add default shapes into `CellRenderer` shapes.
+ *
+ * @category Configuration
  */
 export function registerDefaultShapes() {
   if (!isDefaultElementsRegistered) {

--- a/packages/core/src/view/geometry/edge/MarkerShape.ts
+++ b/packages/core/src/view/geometry/edge/MarkerShape.ts
@@ -252,6 +252,9 @@ function diamond(
 }
 
 let isDefaultMarkersRegistered = false;
+/**
+ * @category Configuration
+ */
 export const registerDefaultEdgeMarkers = (): void => {
   if (!isDefaultMarkersRegistered) {
     MarkerShape.addMarker('classic', createArrow(2));

--- a/packages/core/src/view/style/register.ts
+++ b/packages/core/src/view/style/register.ts
@@ -23,6 +23,8 @@ let isDefaultsRegistered = false;
 
 /**
  * Register style elements for "EdgeStyle" and "Perimeters".
+ *
+ * @category Configuration
  */
 export const registerDefaultStyleElements = (): void => {
   if (!isDefaultsRegistered) {


### PR DESCRIPTION
Better classify such functions in the HTML documentation produced by `typedoc`.
