### PR TITLE
fix(type): declare Graph.toggleCellStyles optional parameters

### DIFF
--- a/packages/core/src/view/mixins/CellsMixin.ts
+++ b/packages/core/src/view/mixins/CellsMixin.ts
@@ -214,8 +214,8 @@ declare module '../Graph' {
      */
     toggleCellStyles: (
       key: keyof CellStateStyle,
-      defaultValue: boolean,
-      cells: Cell[]
+      defaultValue?: boolean,
+      cells?: Cell[]
     ) => boolean | null;
 
     /**


### PR DESCRIPTION
The last 2 parameters weren't declared as optional whereas the implementation already managed the default values.