### PR TITLE
feat!: ease the configuration to rotate the selected vertex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## UNRELEASED
 
 **Breaking Changes**
-- `VertexHandler.rotationEnabled` has been removed as it was not possible to correctly change its value. Use the `VertexHandlerConfig` class to configure the rotation behavior globally or override the new `VertexHandler.isRotationEnabled` method.
+- `VertexHandler.rotationEnabled` has been removed as it was not possible to correctly change its value.
+Use `VertexHandlerConfig.rotationEnabled` to configure the rotation behavior globally or override the `VertexHandler.isRotationEnabled` method.
 
 ## 0.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # `maxGraph` Change Log
 
+## UNRELEASED
+
+**Breaking Changes**
+- `VertexHandler.rotationEnabled` has been removed as it was not possible to correctly change its value. Use the `VertexHandlerConfig` class to configure the rotation behavior globally or override the new `VertexHandler.isRotationEnabled` method.
+
 ## 0.11.0
 
 Release date: `2024-06-09`

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -61,6 +61,7 @@ export { default as RubberBandHandler } from './view/handler/RubberBandHandler';
 export { default as SelectionCellsHandler } from './view/handler/SelectionCellsHandler';
 export { default as TooltipHandler } from './view/handler/TooltipHandler';
 export { default as VertexHandler } from './view/handler/VertexHandler';
+export { VertexHandlerConfig } from './view/handler/config';
 
 export { default as CircleLayout } from './view/layout/CircleLayout';
 export { default as CompactTreeLayout } from './view/layout/CompactTreeLayout';

--- a/packages/core/src/view/handler/ConnectionHandler.ts
+++ b/packages/core/src/view/handler/ConnectionHandler.ts
@@ -362,14 +362,16 @@ class ConnectionHandler extends EventSource implements GraphPlugin {
   /**
    * Switch to enable moving the preview away from the mousepointer. This is required in browsers
    * where the preview cannot be made transparent to events and if the built-in hit detection on
-   * the HTML elements in the page should be used. Default is the value of <Client.IS_VML>.
+   * the HTML elements in the page should be used.
+   * @default false
    */
   movePreviewAway = false;
 
   /**
    * Specifies if connections to the outline of a highlighted target should be
    * enabled. This will allow to place the connection point along the outline of
-   * the highlighted target. Default is false.
+   * the highlighted target.
+   * @default false
    */
   outlineConnect = false;
 

--- a/packages/core/src/view/handler/EdgeHandler.ts
+++ b/packages/core/src/view/handler/EdgeHandler.ts
@@ -219,16 +219,16 @@ class EdgeHandler {
   /**
    * Specifies if connections to the outline of a highlighted target should be
    * enabled. This will allow to place the connection point along the outline of
-   * the highlighted target. Default is false.
+   * the highlighted target.
+   * @default false
    */
-  // outlineConnect: boolean;
   outlineConnect = false;
 
   /**
    * Specifies if the label handle should be moved if it intersects with another
-   * handle. Uses <checkLabelHandle> for checking and moving. Default is false.
+   * handle. Uses {@link checkLabelHandle} for checking and moving.
+   * @default false
    */
-  // manageLabelHandle: boolean;
   manageLabelHandle = false;
 
   escapeHandler: (sender: Listenable, evt: Event) => void;

--- a/packages/core/src/view/handler/VertexHandler.ts
+++ b/packages/core/src/view/handler/VertexHandler.ts
@@ -110,7 +110,7 @@ class VertexHandler {
   tolerance = 0;
 
   /**
-   * Enable rotation handle
+   * Specifies if a rotation handle should be visible.
    *
    * This implementation returns {@link VertexHandlerConfig.rotationEnabled}.
    * @since 0.12.0

--- a/packages/core/src/view/handler/VertexHandler.ts
+++ b/packages/core/src/view/handler/VertexHandler.ts
@@ -42,13 +42,14 @@ import { Graph } from '../Graph';
 import CellState from '../cell/CellState';
 import Image from '../image/ImageBox';
 import Cell from '../cell/Cell';
-import { CellHandle, Listenable } from '../../types';
+import type { CellHandle, Listenable } from '../../types';
 import Shape from '../geometry/Shape';
 import InternalMouseEvent from '../event/InternalMouseEvent';
 import EdgeHandler from './EdgeHandler';
 import EventSource from '../event/EventSource';
 import SelectionHandler from './SelectionHandler';
 import SelectionCellsHandler from './SelectionCellsHandler';
+import { VertexHandlerConfig } from './config';
 
 /**
  * Event handler for resizing cells.
@@ -109,10 +110,14 @@ class VertexHandler {
   tolerance = 0;
 
   /**
-   * Specifies if a rotation handle should be visible.
-   * @default false
+   * Enable rotation handle
+   *
+   * This implementation returns {@link VertexHandlerConfig.rotationEnabled}.
+   * @since 0.12.0
    */
-  rotationEnabled = false;
+  protected isRotationEnabled(): boolean {
+    return VertexHandlerConfig.rotationEnabled;
+  }
 
   /**
    * Specifies if the parent should be highlighted if a child cell is selected.
@@ -325,7 +330,7 @@ class VertexHandler {
     }
 
     // Handles escape keystrokes
-    this.escapeHandler = (sender: Listenable, evt: Event) => {
+    this.escapeHandler = (_sender: Listenable, _evt: Event) => {
       if (this.livePreview && this.index != null) {
         // Redraws the live preview
         (<Graph>this.state.view.graph).cellRenderer.redraw(this.state, true);
@@ -354,7 +359,7 @@ class VertexHandler {
 
     return (
       this.graph.isEnabled() &&
-      this.rotationEnabled &&
+      this.isRotationEnabled() &&
       this.graph.isCellRotatable(this.state.cell) &&
       selectionHandlerCheck
     );
@@ -375,9 +380,11 @@ class VertexHandler {
   }
 
   /**
-   * Returns an array of custom handles. This implementation returns null.
+   * Returns an array of custom handles.
+   *
+   * This implementation returns an empty array.
    */
-  createCustomHandles() {
+  createCustomHandles(): CellHandle[] {
     return [];
   }
 
@@ -407,7 +414,7 @@ class VertexHandler {
   }
 
   /**
-   * Returns the mxRectangle that defines the bounds of the selection border.
+   * Returns the Rectangle that defines the bounds of the selection border.
    */
   getSelectionBounds(state: CellState) {
     return new Rectangle(
@@ -508,7 +515,7 @@ class VertexHandler {
    *
    * This implementation returns `true` for all given indices.
    */
-  isSizerVisible(index: number) {
+  isSizerVisible(_index: number) {
     return true;
   }
 
@@ -556,7 +563,7 @@ class VertexHandler {
 
   /**
    * Returns the index of the handle for the given event. This returns the index
-   * of the sizer from where the event originated or {@link Event.LABEL_HANDLE}.
+   * of the sizer from where the event originated or {@link InternalEvent.LABEL_HANDLE}.
    */
   getHandleForEvent(me: InternalMouseEvent) {
     // Connection highlight may consume events before they reach sizer handle
@@ -1223,7 +1230,7 @@ class VertexHandler {
         if (index <= InternalEvent.CUSTOM_HANDLE) {
           if (this.customHandles != null) {
             // Creates style before changing cell state
-            const style = (<Graph>this.state.view.graph).getCellStyle(this.state.cell);
+            const style = this.state.view.graph.getCellStyle(this.state.cell);
 
             this.customHandles[InternalEvent.CUSTOM_HANDLE - index].active = false;
             this.customHandles[InternalEvent.CUSTOM_HANDLE - index].execute(me);
@@ -1296,8 +1303,9 @@ class VertexHandler {
 
   /**
    * Hook for subclasses to implement a single click on the rotation handle.
-   * This code is executed as part of the model transaction. This implementation
-   * is empty.
+   * This code is executed as part of the model transaction.
+   *
+   * This implementation is empty.
    */
   rotateClick() {
     return;
@@ -1896,9 +1904,7 @@ class VertexHandler {
 
         // Hides rotation handle during text editing
         this.rotationShape.node.style.visibility =
-          (<Graph>this.state.view.graph).isEditing() || !this.handlesVisible
-            ? 'hidden'
-            : '';
+          this.state.view.graph.isEditing() || !this.handlesVisible ? 'hidden' : '';
       }
     }
 

--- a/packages/core/src/view/handler/config.ts
+++ b/packages/core/src/view/handler/config.ts
@@ -1,0 +1,30 @@
+/*
+Copyright 2024-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Global configuration for {@link VertexHandler}.
+ *
+ * @experimental subject to change or removal. maxGraph's global configuration may be modified in the future without prior notice.
+ * @since 0.12.0
+ * @category Configuration
+ */
+export const VertexHandlerConfig = {
+  /**
+   * Enable rotation handle
+   * @default false
+   */
+  rotationEnabled: false,
+};

--- a/packages/html/.storybook/preview.ts
+++ b/packages/html/.storybook/preview.ts
@@ -1,5 +1,5 @@
 import type { Preview } from '@storybook/html';
-import { GlobalConfig, NoOpLogger } from '@maxgraph/core';
+import { GlobalConfig, NoOpLogger, VertexHandlerConfig } from '@maxgraph/core';
 
 const defaultLogger = new NoOpLogger();
 // if you want to debug using the browser console, use the following configuration
@@ -7,6 +7,12 @@ const defaultLogger = new NoOpLogger();
 // defaultLogger.infoEnabled = true;
 // defaultLogger.debugEnabled = true;
 // defaultLogger.traceEnabled = true;
+
+const resetMaxGraphConfigs = (): void => {
+  GlobalConfig.logger = defaultLogger;
+
+  VertexHandlerConfig.rotationEnabled = false;
+};
 
 const preview: Preview = {
   parameters: {
@@ -19,11 +25,10 @@ const preview: Preview = {
     },
   },
   decorators: [
-    // reset the logger to the default NoOpLogger, as it may have been globally changed in a story (for example, in the Window story)
+    // reset the global configurations, as they may have been globally changed in a story (for example, the Window story updates the logger configuration)
     // inspired by https://github.com/storybookjs/storybook/issues/4997#issuecomment-447301514
     (storyFn) => {
-      GlobalConfig.logger = defaultLogger;
-
+      resetMaxGraphConfigs();
       return storyFn();
     },
   ],

--- a/packages/html/stories/Handles.stories.ts
+++ b/packages/html/stories/Handles.stories.ts
@@ -27,6 +27,10 @@ import {
   RubberBandHandler,
   utils,
   VertexHandle,
+  type AbstractCanvas2D,
+  type CellState,
+  CellStateStyle,
+  VertexHandlerConfig,
 } from '@maxgraph/core';
 
 import {
@@ -38,8 +42,7 @@ import {
   rubberBandValues,
 } from './shared/args.js';
 import { createGraphContainer } from './shared/configure.js';
-// style required by RubberBand
-import '@maxgraph/core/css/common.css';
+import '@maxgraph/core/css/common.css'; // style required by RubberBand
 
 export default {
   title: 'Layouts/Handles',
@@ -54,7 +57,7 @@ export default {
     ...rubberBandValues,
   },
 };
-const Template = ({ label, ...args }) => {
+const Template = ({ label, ...args }: Record<string, string>) => {
   const div = document.createElement('div');
   const container = createGraphContainer(args);
   div.appendChild(container);
@@ -64,7 +67,7 @@ const Template = ({ label, ...args }) => {
 
     defaultPos2 = 60;
 
-    getLabelBounds(rect) {
+    getLabelBounds(rect: Rectangle) {
       const pos1 = utils.getValue(this.style, 'pos1', this.defaultPos1) * this.scale;
       const pos2 = utils.getValue(this.style, 'pos2', this.defaultPos2) * this.scale;
       return new Rectangle(
@@ -75,7 +78,14 @@ const Template = ({ label, ...args }) => {
       );
     }
 
-    redrawPath(path, x, y, w, h, isForeground) {
+    redrawPath(
+      path: AbstractCanvas2D,
+      _x: number,
+      _y: number,
+      w: number,
+      h: number,
+      isForeground = false
+    ) {
       const pos1 = utils.getValue(this.style, 'pos1', this.defaultPos1);
       const pos2 = utils.getValue(this.style, 'pos2', this.defaultPos2);
 
@@ -94,12 +104,19 @@ const Template = ({ label, ...args }) => {
       }
     }
   }
+  // @ts-ignore
   CellRenderer.registerShape('myShape', MyShape);
+
+  // Enable rotation handle
+  VertexHandlerConfig.rotationEnabled = true;
+
+  type CustomCellStateStyle = CellStateStyle & {
+    pos1?: number;
+    pos2?: number;
+  };
 
   class MyCustomVertexHandler extends VertexHandler {
     livePreview = true;
-
-    rotationEnabled = true;
 
     createCustomHandles() {
       if (this.state.style.shape === 'myShape') {
@@ -107,6 +124,8 @@ const Template = ({ label, ...args }) => {
         const firstHandle = new VertexHandle(this.state);
 
         firstHandle.getPosition = function (bounds) {
+          if (!bounds) return new Point(0, 0);
+
           const pos2 = Math.max(
             0,
             Math.min(
@@ -130,6 +149,8 @@ const Template = ({ label, ...args }) => {
         };
 
         firstHandle.setPosition = function (bounds, pt) {
+          if (!bounds) return;
+
           const pos2 = Math.max(
             0,
             Math.min(
@@ -140,12 +161,13 @@ const Template = ({ label, ...args }) => {
             )
           );
 
-          this.state.style.pos1 = Math.round(
+          (this.state.style as CustomCellStateStyle).pos1 = Math.round(
             Math.max(0, Math.min(pos2, pt.y - bounds.y))
           );
         };
 
         firstHandle.execute = function () {
+          // @ts-ignore
           this.copyStyle('pos1');
         };
 
@@ -155,6 +177,8 @@ const Template = ({ label, ...args }) => {
         const secondHandle = new VertexHandle(this.state);
 
         secondHandle.getPosition = function (bounds) {
+          if (!bounds) return new Point(0, 0);
+
           const pos1 = Math.max(
             0,
             Math.min(
@@ -178,6 +202,8 @@ const Template = ({ label, ...args }) => {
         };
 
         secondHandle.setPosition = function (bounds, pt) {
+          if (!bounds) return;
+
           const pos1 = Math.max(
             0,
             Math.min(
@@ -188,12 +214,13 @@ const Template = ({ label, ...args }) => {
             )
           );
 
-          this.state.style.pos2 = Math.round(
+          (this.state.style as CustomCellStateStyle).pos2 = Math.round(
             Math.max(pos1, Math.min(bounds.height, pt.y - bounds.y))
           );
         };
 
         secondHandle.execute = function () {
+          // @ts-ignore
           this.copyStyle('pos2');
         };
 
@@ -202,12 +229,12 @@ const Template = ({ label, ...args }) => {
         return [firstHandle, secondHandle];
       }
 
-      return null;
+      return [];
     }
   }
 
   class MyCustomGraph extends Graph {
-    createVertexHandler(state) {
+    createVertexHandler(state: CellState) {
       return new MyCustomVertexHandler(state);
     }
   }
@@ -231,7 +258,7 @@ const Template = ({ label, ...args }) => {
 
   // Adds cells to the model in a single step
   graph.batchUpdate(() => {
-    const v1 = graph.insertVertex(
+    graph.insertVertex(
       parent,
       null,
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
@@ -239,7 +266,13 @@ const Template = ({ label, ...args }) => {
       20,
       240,
       120,
-      { shape: 'myShape', whiteSpace: 'wrap', overflow: 'hidden', pos1: 30, pos2: 80 }
+      {
+        shape: 'myShape',
+        whiteSpace: 'wrap',
+        overflow: 'hidden',
+        pos1: 30,
+        pos2: 80,
+      } as CustomCellStateStyle
     );
   });
 

--- a/packages/html/stories/Handles.stories.ts
+++ b/packages/html/stories/Handles.stories.ts
@@ -29,7 +29,7 @@ import {
   VertexHandle,
   type AbstractCanvas2D,
   type CellState,
-  CellStateStyle,
+  type CellStateStyle,
   VertexHandlerConfig,
 } from '@maxgraph/core';
 

--- a/packages/html/stories/Stencils.stories.ts
+++ b/packages/html/stories/Stencils.stories.ts
@@ -81,16 +81,20 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   EdgeHandler.prototype.outlineConnect = true;
   CellHighlight.prototype.keepOnTop = true;
 
-  // Enable rotation handle
-  VertexHandler.prototype.rotationEnabled = true;
-
   class CustomVertexHandler extends VertexHandler {
+    // Enable rotation handle
+    // use an alternate way to enable rotation handle as we already override the VertexHandler for other purposes
+    // another way to enable rotation handle is to set `VertexHandlerConfig.rotationEnabled = true`;
+    isRotationEnabled(): boolean {
+      return true;
+    }
+
     // Uses the shape for resize previews
     createSelectionShape(bounds: Rectangle) {
       const stencil = StencilShapeRegistry.getStencil(this.state.style.shape ?? '');
-      let shape = null;
+      let shape: Shape;
 
-      if (stencil != null) {
+      if (stencil) {
         shape = new Shape(stencil);
         shape.apply(this.state);
       } else {
@@ -101,7 +105,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
       shape.outline = true;
       shape.bounds = bounds;
       shape.stroke = constants.HANDLE_STROKECOLOR;
-      shape.strokewidth = this.getSelectionStrokeWidth();
+      shape.strokeWidth = this.getSelectionStrokeWidth();
       shape.isDashed = this.isSelectionDashed();
       shape.isShadow = false;
       return shape;
@@ -173,7 +177,6 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   if (!args.contextMenu) InternalEvent.disableContextMenu(container);
 
   // Creates the graph inside the given container
-  // const graph = new Graph(container);
   const graph = new CustomGraph(container);
   graph.setConnectable(true);
   graph.setTooltips(true);


### PR DESCRIPTION
Previously, it was hard to enable rotation, because the `VertexHandler.rotationEnabled` property value was used in the constructor. The sole solution was to override `VertexHandler.isRotationHandleVisible` to ignore the value of `rotationEnabled`.
In `mxGraph` this was advised to do change the value globally by updating the prototype of the VertexHandler rotationEnabled property
This no longer works in maxGraph (VertexHandler is defined as an ES6 class).

The `rotationEnabled` property has been removed. Instead, the value is now stored in a global configuration state: `VertexHandlerConfig.rotationEnabled` It is also possible to override a new `VertexHandler.isRotationEnabled` to enable the rotation for a single Graph implementation.

Each of the 2 methods is used separately in the `Handles` and `Stencils` stories for demonstration. The Handles story has been migrated to TypeScript to ease the maintenance

In addition, improve JSDoc and type usage in some other handlers

BREAKING CHANGES:
`VertexHandler.rotationEnabled` has been removed as it was not possible to correctly change its value.
Use `VertexHandlerConfig.rotationEnabled` to configure the rotation behavior globally or override the `VertexHandler.isRotationEnabled` method.


## Notes

Closes #267


## New behavior in the updated stories

### Handles

https://github.com/maxGraph/maxGraph/assets/27200110/be63c6ce-0761-4487-8226-2b161807b33e

### Stencils

https://github.com/maxGraph/maxGraph/assets/27200110/95c79b3d-3608-4d23-9cc6-50699a93af17
