### PR TITLE
feat: declare the package as side effects free

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,7 @@
   "private": false,
   "version": "0.11.0",
   "type": "module",
-  "sideEffects": true,
+  "sideEffects": ["**/*.css"],
   "description": "maxGraph is a fully client side JavaScript diagramming library that uses SVG and HTML for rendering.",
   "keywords": [
     "browser",


### PR DESCRIPTION
`maxGraph` code no longer contains side effects, so it can be declared as such in the `package.json` file. This allows bundlers to perform more efficient tree-shaking, reducing maxGraph's footprint in applications.

Declare CSS files in side effects
This ensures that when using the webpack css-loader plugin and importing a CSS file from `maxGraph`, this CSS file is not dropped during tree-shaking.


## Notes

closes #442

For webpack css-loader: see https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free

### Bundle size decrease in examples

Here are a few figures concerning the reduction in bundle size in the examples available in this repository.

As a reminder:
- ts-example:
  - TypeScript application built with `Vite`
  - includes custom shapes
  - sizes shown are for the _maxGraph_ chunk only which doesn't include the rest of the application
- js-example:
  - JavaScript application built with `webpack`
  - includes model codecs
  - bundles the _maxGraph_ common.css file (4.33kB unminified) within the js bundle
  - sizes shown are for the entire application


**Bundle size decrease**

ts-example:
- 0.11.0: 444.89 kB
- before merge of #471 444.89 kB
- after merge of #471 555.66 kB
- e1898798 555.24 kB
- declaration sideEffects false: 444.46 kB 
<!-- intermediate value while developing
- declaration sideEffects false: 444.5 kB 
-->

js-example: 
- 0.11.0: 512.6kB
- after merge of no side effects of mixin 512.24kB
- before merge of #471 the example already loads model Codecs as it explicitly uses ModelSerializer 512.6kB
- after merge of #471 512.6kB
- e1898798 512.6kB
- declaration sideEffects false (without including the maxGraph CSS file): 452.22 kB 
- declaration sideEffects false: 458.7 kB (with GH Actions)


### Impact of #471 in `ts-example`

This PR change the implementation of the Editor which now uses `ModelXmlSerializer`.
So, it imports all model Codecs.
Apparently, this has had a negative impact on the way Rollup (which is used to bundle Vite applications) decides to perform tree-shaking.
In https://github.com/maxGraph/maxGraph/releases/tag/v0.6.0, the maxGraph chunk in ts-example decreased from 568.58 kB in version 0.5.0 to 468.01 kB, which was due to the removal of the codecs registration by default.
With #471, everything acts as if this improvement was cancelled.