### PR TITLE
docs: improve setup instructions for js-example

### DIFF
--- a/packages/js-example/README.md
+++ b/packages/js-example/README.md
@@ -5,14 +5,22 @@ Demonstrate how to import/decode an XML model using `Codecs`.
 ## Setup
 
 Initialize all packages
-> From the repository root, run `npm install`.
+From the repository root, run:
+```bash
+npm install
+cd packages/core/
+npm pack
+cd ../../packages/example
+# For more details see 'Run' below
+npm run dev
+```
 
-Build [@maxgraph/core](../../README.md#development).
+For more build information see: [@maxgraph/core](../../README.md#development).
 
 
 ## Run
 
-Run `npm run dev` and go to http://localhost:8080/
+Run `npm run dev` from this directory and go to http://localhost:8080/
 
 If you want to bundle the application, run `npm run build` and then run `npm run preview` to access to a preview of the
 bundle application.

--- a/packages/js-example/README.md
+++ b/packages/js-example/README.md
@@ -4,13 +4,12 @@ Demonstrate how to import/decode an XML model using `Codecs`.
 
 ## Setup
 
-Initialize all packages
 From the repository root, run:
 ```bash
 npm install
 cd packages/core/
-npm pack
-cd ../../packages/example
+npm run build
+cd ../../packages/js-example/
 # For more details see 'Run' below
 npm run dev
 ```
@@ -22,5 +21,4 @@ For more build information see: [@maxgraph/core](../../README.md#development).
 
 Run `npm run dev` from this directory and go to http://localhost:8080/
 
-If you want to bundle the application, run `npm run build` and then run `npm run preview` to access to a preview of the
-bundle application.
+If you want to bundle the application, run `npm run build` and then run `npm run preview` to access to a preview of the bundle application.


### PR DESCRIPTION
## Minor documentation editing

_Please excuse my laziness in not filling out the below_

To see the changes rendered: https://github.com/hbmartin/maxGraph/tree/main/packages/js-example



