### PR TITLE
refactor: prefer usage of AbstractCanvas2D type in Shapes

### DIFF
--- a/packages/core/src/view/geometry/ActorShape.ts
+++ b/packages/core/src/view/geometry/ActorShape.ts
@@ -18,7 +18,7 @@ limitations under the License.
 
 import Rectangle from './Rectangle';
 import Shape from './Shape';
-import SvgCanvas2D from '../canvas/SvgCanvas2D';
+import type AbstractCanvas2D from '../canvas/AbstractCanvas2D';
 import { ColorValue } from '../../types';
 import { NONE } from '../../util/Constants';
 
@@ -61,7 +61,7 @@ class ActorShape extends Shape {
   /**
    * Redirects to redrawPath for subclasses to work.
    */
-  paintVertexShape(c: SvgCanvas2D, x: number, y: number, w: number, h: number) {
+  paintVertexShape(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
     c.translate(x, y);
     c.begin();
     this.redrawPath(c, x, y, w, h);
@@ -71,7 +71,7 @@ class ActorShape extends Shape {
   /**
    * Draws the path for this shape.
    */
-  redrawPath(c: SvgCanvas2D, x: number, y: number, w: number, h: number) {
+  redrawPath(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
     const width = w / 3;
     c.moveTo(0, h);
     c.curveTo(0, (3 * h) / 5, 0, (2 * h) / 5, w / 2, (2 * h) / 5);

--- a/packages/core/src/view/geometry/Shape.ts
+++ b/packages/core/src/view/geometry/Shape.ts
@@ -28,7 +28,7 @@ import {
   SHADOW_OFFSET_Y,
 } from '../../util/Constants';
 import Point from './Point';
-import AbstractCanvas2D from '../canvas/AbstractCanvas2D';
+import type AbstractCanvas2D from '../canvas/AbstractCanvas2D';
 import SvgCanvas2D from '../canvas/SvgCanvas2D';
 import InternalEvent from '../event/InternalEvent';
 import Client from '../../Client';
@@ -193,13 +193,14 @@ class Shape {
   boundingBox: Rectangle | null = null;
 
   /**
-   * Holds the {@link Stencil} that defines the shape.
+   * Holds the {@link StencilShape} that defines the shape.
    */
   stencil: StencilShape | null = null;
 
   /**
-   * Event-tolerance for SVG strokes (in px). Default is 8. This is only passed
-   * to the canvas in <createSvgCanvas> if <pointerEvents> is true.
+   * Event-tolerance for SVG strokes (in px).
+   * This is only passed to the canvas in {@link createSvgCanvas} if {@link pointerEvents} is `true`.
+   * @default 8
    */
   svgStrokeTolerance = 8;
 
@@ -512,7 +513,7 @@ class Shape {
   }
 
   /**
-   * Creates and returns an <mxSvgCanvas2D> for rendering this shape.
+   * Creates and returns an {@link SvgCanvas2D} for rendering this shape.
    */
   createSvgCanvas() {
     if (!this.node) return null;

--- a/packages/core/src/view/geometry/node/ImageShape.ts
+++ b/packages/core/src/view/geometry/node/ImageShape.ts
@@ -17,19 +17,16 @@ limitations under the License.
 */
 
 import RectangleShape from './RectangleShape';
-import Rectangle from '../Rectangle';
+import type Rectangle from '../Rectangle';
 import CellState from '../../cell/CellState';
-import AbstractCanvas2D from '../../canvas/SvgCanvas2D';
+import type AbstractCanvas2D from '../../canvas/AbstractCanvas2D';
 import CellOverlay from '../../cell/CellOverlay';
 import { NONE } from '../../../util/Constants';
 import { ColorValue } from '../../../types';
 
 /**
- * Extends {@link mxShape} to implement an image shape.
- * This shape is registered under {@link mxConstants.SHAPE_IMAGE} in {@link cellRenderer}.
- *
- * @class ImageShape
- * @extends {RectangleShape}
+ * Extends {@link RectangleShape} to implement an image shape.
+ * This shape is registered under {@link Constants.SHAPE.SHAPE_IMAGE} in {@link CellRenderer}.
  */
 class ImageShape extends RectangleShape {
   constructor(
@@ -68,19 +65,15 @@ class ImageShape extends RectangleShape {
   }
 
   /**
-   * Overrides {@link mxShape.apply} to replace the fill and stroke colors with the
-   * respective values from {@link 'imageBackground'} and
-   * {@link 'imageBorder'}.
+   * Overrides to replace the fill and stroke colors with the respective values from {@link imageBackground} and {@link imageBorder}.
    *
-   * Applies the style of the given {@link CellState} to the shape. This
-   * implementation assigns the following styles to local fields:
+   * Applies the style of the given {@link CellState} to the shape. This implementation assigns the following styles to local fields:
    *
-   * - {@link 'imageBackground'} => fill
-   * - {@link 'imageBorder'} => stroke
+   * - {@link imageBackground} => fill
+   * - {@link imageBorder} => stroke
    *
    * @param {CellState} state   {@link CellState} of the corresponding cell.
    */
-  // apply(state: CellState): void;
   apply(state: CellState) {
     super.apply(state);
 


### PR DESCRIPTION
Previously, some shapes were using the SvgCanvas2D type. This didn't match the signature of methods in the parent class and reduce the possibility to use other implementations of AbstractCanvas2D.

Also improve JSDoc in various shapes.



## Notes

Detected in #187.

