### PR TITLE
refactor: remove unused methods in shapes

### DIFF
--- a/packages/core/src/view/geometry/Shape.ts
+++ b/packages/core/src/view/geometry/Shape.ts
@@ -318,28 +318,13 @@ class Shape {
   }
 
   /**
-   * Creates and returns the DOM node(s) for the shape in
-   * the given container. This implementation invokes
-   * <createSvg>, <createHtml> or <createVml> depending
-   * on the <dialect> and style settings.
-   *
-   * @param container DOM node that will contain the shape.
+   * Creates and returns the DOM node for the shape.
+   * This implementation assumes that `maxGraph` produces SVG elements.
    */
   create() {
     return document.createElementNS('http://www.w3.org/2000/svg', 'g');
   }
 
-  /**
-   * Reconfigures this shape. This will update the colors etc in
-   * addition to the bounds or points.
-   */
-  reconfigure() {
-    this.redraw();
-  }
-
-  /**
-   * Creates and returns the SVG node(s) to represent this shape.
-   */
   redraw() {
     this.updateBoundsFromPoints();
 

--- a/packages/core/src/view/geometry/node/ImageShape.ts
+++ b/packages/core/src/view/geometry/node/ImageShape.ts
@@ -95,17 +95,6 @@ class ImageShape extends RectangleShape {
   }
 
   /**
-   * Creates and returns the HTML DOM node(s) to represent
-   * this shape. This implementation falls back to <createVml>
-   * so that the HTML creation is optional.
-   */
-  createHtml() {
-    const node = document.createElement('div');
-    node.style.position = 'absolute';
-    return node;
-  }
-
-  /**
    * Disables inherited roundable support.
    */
   isRoundable(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {


### PR DESCRIPTION
Remove `Shape.reconfigure`
This method was also unused in `mxGraph`.

Remove `ImageShape.createHtml`
It was previously called by `Shape.create` in mxGraph when the dom element creation depends on the dialect value.
When maxGraph removed the support for former Vml and Html canvas, `Shape.create` was updated to inline the dom node creation for SVG only.
The `ImageShape.createHtml` should have been removed at that time.
