### PR TITLE
chore(js-example): store CSS out of the JS bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10026,6 +10026,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "devOptional": true
     },
+    "node_modules/fast-uri": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
+      "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==",
+      "dev": true
+    },
     "node_modules/fast-url-parser": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
@@ -27014,6 +27020,7 @@
         "css-loader": "~7.1.2",
         "html-webpack-plugin": "~5.6.0",
         "http-server": "~14.1.1",
+        "mini-css-extract-plugin": "~2.9.0",
         "style-loader": "~4.0.0",
         "webpack": "~5.93.0",
         "webpack-cli": "~5.1.4",
@@ -27364,6 +27371,73 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/streamich"
+      }
+    },
+    "packages/js-example/node_modules/mini-css-extract-plugin": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.0.tgz",
+      "integrity": "sha512-Zs1YsZVfemekSZG+44vBsYTLQORkPMwnlv+aehcxK/NLKC+EGhDB39/YePYYqx/sTk6NnYpuqikhSn7+JIevTA==",
+      "dev": true,
+      "dependencies": {
+        "schema-utils": "^4.0.0",
+        "tapable": "^2.2.1"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      }
+    },
+    "packages/js-example/node_modules/mini-css-extract-plugin/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "packages/js-example/node_modules/mini-css-extract-plugin/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "packages/js-example/node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
+      "integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "packages/js-example/node_modules/open": {

--- a/packages/js-example/package.json
+++ b/packages/js-example/package.json
@@ -11,6 +11,7 @@
     "css-loader": "~7.1.2",
     "http-server": "~14.1.1",
     "html-webpack-plugin": "~5.6.0",
+    "mini-css-extract-plugin": "~2.9.0",
     "style-loader": "~4.0.0",
     "webpack": "~5.93.0",
     "webpack-cli": "~5.1.4",

--- a/packages/js-example/webpack.config.js
+++ b/packages/js-example/webpack.config.js
@@ -2,12 +2,18 @@
 const path = require('path');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+
+// hack to get the webpack mode
+const isDevMode = !process.argv.includes('--mode=production');
 
 module.exports = {
   mode: 'development',
   entry: './src/index.js',
   output: {
+    filename: '[name].[contenthash].js',
     path: path.resolve(__dirname, 'dist'),
+    clean: true,
   },
   devServer: {
     static: './dist',
@@ -16,7 +22,7 @@ module.exports = {
     rules: [
       {
         test: /\.css$/i,
-        use: ['style-loader', 'css-loader'],
+        use: [isDevMode ? 'style-loader' : MiniCssExtractPlugin.loader, 'css-loader'],
       },
       // @maxgraph/core is a dependency of this project but don't declare imports with js extension
       // use this workaround to make webpack happy: https://github.com/webpack/webpack/issues/11467#issuecomment-691873586
@@ -35,5 +41,5 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: 'index.html',
     }),
-  ],
+  ].concat(isDevMode ? [] : [new MiniCssExtractPlugin()]),
 };


### PR DESCRIPTION
This reduces the size of the JS bundle.

In addition:
  - add hash to the JS bundle name (to improve caching)
  - clean output folder (to ease maintenance)

### Resources

- https://webpack.js.org/loaders/style-loader/#recommend
- https://github.com/webpack-contrib/css-loader#recommend / https://github.com/webpack-contrib/css-loader?tab=readme-ov-file#recommend
- https://webpack.js.org/plugins/mini-css-extract-plugin/
- https://webpack.js.org/configuration/mode/

