### PR TITLE
refactor: improve the types in signature of Cell.getClonedStyle

### DIFF
--- a/packages/core/src/view/cell/Cell.ts
+++ b/packages/core/src/view/cell/Cell.ts
@@ -255,7 +255,7 @@ export class Cell implements IdentityObject {
    *
    * See {@link GraphDataModel.setStyle} for more details.
    */
-  getClonedStyle() {
+  getClonedStyle(): CellStyle {
     return clone(this.getStyle());
   }
 


### PR DESCRIPTION
Make the method return `CellStyle` instead of `any`.
