### PR TITLE
feat(typescript): let use generic when calling `Graph.getPlugin`

### DIFF
--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -1438,7 +1438,7 @@ export class Editor extends EventSource {
     this.installInsertHandler(graph);
 
     // Redirects the function for creating the popupmenu items
-    const popupMenuHandler = <PopupMenuHandler>graph.getPlugin('PopupMenuHandler');
+    const popupMenuHandler = graph.getPlugin<PopupMenuHandler>('PopupMenuHandler');
     if (popupMenuHandler) {
       popupMenuHandler.factoryMethod = (menu: any, cell: Cell | null, evt: any): void => {
         return this.createPopupMenu(menu, cell, evt);
@@ -1446,7 +1446,7 @@ export class Editor extends EventSource {
     }
 
     // Redirects the function for creating new connections in the diagram
-    const connectionHandler = <ConnectionHandler>graph.getPlugin('ConnectionHandler');
+    const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler');
     if (connectionHandler) {
       connectionHandler.factoryMethod = (
         source: Cell | null,
@@ -2428,20 +2428,14 @@ export class Editor extends EventSource {
   }
 
   /**
-   * Puts the graph into the specified mode. The following modenames are
-   * supported:
-   *
-   * select - Selects using the left mouse button, new connections are disabled.
-   * connect - Selects using the left mouse button or creates new connections if mouse over cell hotspot.
-   * See {@link mxConnectionHandler}.
-   * pan - Pans using the left mouse button, new connections are disabled.
-   * @param modename
+   * Puts the graph into the specified mode. The following mode names are supported:
+   * - select - Selects using the left mouse button, new connections are disabled.
+   * - connect - Selects using the left mouse button or creates new connections if mouse over cell hotspot. See {@link ConnectionHandler}.
+   * - pan - Pans using the left mouse button, new connections are disabled.
    */
   setMode(modename: any): void {
-    const panningHandler: PanningHandler = <PanningHandler>(
-      this.graph.getPlugin('PanningHandler')
-    );
-
+    const panningHandler: PanningHandler =
+      this.graph.getPlugin<PanningHandler>('PanningHandler');
     if (modename === 'select') {
       panningHandler && (panningHandler.useLeftButtonForPanning = false);
       this.graph.setConnectable(false);

--- a/packages/core/src/view/Graph.ts
+++ b/packages/core/src/view/Graph.ts
@@ -720,7 +720,7 @@ class Graph extends EventSource {
    * specified.
    */
   scrollPointToVisible(x: number, y: number, extend = false, border = 20) {
-    const panningHandler = this.getPlugin('PanningHandler') as PanningHandler;
+    const panningHandler = this.getPlugin<PanningHandler>('PanningHandler');
 
     if (
       !this.isTimerAutoScroll() &&

--- a/packages/core/src/view/Graph.ts
+++ b/packages/core/src/view/Graph.ts
@@ -536,7 +536,7 @@ class Graph extends EventSource {
   }
 
   getContainer = () => this.container;
-  getPlugin = (id: string) => this.plugins[id] as unknown;
+  getPlugin = <T extends GraphPlugin>(id: string): T => this.plugins[id] as T;
   getCellRenderer = () => this.cellRenderer;
   getDialect = () => this.dialect;
   isPageVisible = () => this.pageVisible;

--- a/packages/core/src/view/GraphView.ts
+++ b/packages/core/src/view/GraphView.ts
@@ -680,7 +680,7 @@ export class GraphView extends EventSource {
               graph.fireMouseEvent(InternalEvent.MOUSE_DOWN, new InternalMouseEvent(evt));
             },
             (evt: MouseEvent) => {
-              const tooltipHandler = graph.getPlugin('TooltipHandler') as TooltipHandler;
+              const tooltipHandler = graph.getPlugin<TooltipHandler>('TooltipHandler');
 
               // Hides the tooltip if mouse is outside container
               if (tooltipHandler && tooltipHandler.isHideOnHover()) {
@@ -2155,7 +2155,7 @@ export class GraphView extends EventSource {
     // in Firefox and Chrome
     graph.addMouseListener({
       mouseDown: (sender: any, me: InternalMouseEvent) => {
-        const popupMenuHandler = graph.getPlugin('PopupMenuHandler') as PopupMenuHandler;
+        const popupMenuHandler = graph.getPlugin<PopupMenuHandler>('PopupMenuHandler');
         popupMenuHandler?.hideMenu();
       },
       mouseMove: () => {

--- a/packages/core/src/view/cell/CellRenderer.ts
+++ b/packages/core/src/view/cell/CellRenderer.ts
@@ -1382,9 +1382,9 @@ class CellRenderer {
         this.installListeners(state);
 
         // Forces a refresh of the handler if one exists
-        const selectionCellsHandler = graph.getPlugin(
+        const selectionCellsHandler = graph.getPlugin<SelectionCellsHandler>(
           'SelectionCellsHandler'
-        ) as SelectionCellsHandler;
+        );
         selectionCellsHandler?.updateHandler(state);
       }
     } else if (
@@ -1396,9 +1396,9 @@ class CellRenderer {
       state.shape.resetStyles();
       this.configureShape(state);
       // LATER: Ignore update for realtime to fix reset of current gesture
-      const selectionCellsHandler = graph.getPlugin(
+      const selectionCellsHandler = graph.getPlugin<SelectionCellsHandler>(
         'SelectionCellsHandler'
-      ) as SelectionCellsHandler;
+      );
       selectionCellsHandler?.updateHandler(state);
       force = true;
     }

--- a/packages/core/src/view/handler/CellEditorHandler.ts
+++ b/packages/core/src/view/handler/CellEditorHandler.ts
@@ -711,7 +711,7 @@ class CellEditorHandler implements GraphPlugin {
       this.init();
     }
 
-    const tooltipHandler = this.graph.getPlugin('TooltipHandler') as TooltipHandler;
+    const tooltipHandler = this.graph.getPlugin<TooltipHandler>('TooltipHandler');
     tooltipHandler?.hideTooltip();
 
     const state = this.graph.getView().getState(cell);

--- a/packages/core/src/view/handler/EdgeHandler.ts
+++ b/packages/core/src/view/handler/EdgeHandler.ts
@@ -311,7 +311,7 @@ class EdgeHandler {
       }
     }
 
-    const selectionHandler = this.graph.getPlugin('SelectionHandler') as SelectionHandler;
+    const selectionHandler = this.graph.getPlugin<SelectionHandler>('SelectionHandler');
 
     // Creates bends for the non-routed absolute points
     // or bends that don't correspond to points

--- a/packages/core/src/view/handler/KeyHandler.ts
+++ b/packages/core/src/view/handler/KeyHandler.ts
@@ -243,9 +243,8 @@ class KeyHandler {
     const source = <Element>getSource(evt);
 
     // Accepts events from the target object or in-place editing inside graph
-    const cellEditorHandler = this.graph?.getPlugin(
-      'CellEditorHandler'
-    ) as CellEditorHandler;
+    const cellEditorHandler =
+      this.graph?.getPlugin<CellEditorHandler>('CellEditorHandler');
     if (
       source === this.target ||
       source.parentNode === this.target ||

--- a/packages/core/src/view/handler/PopupMenuHandler.ts
+++ b/packages/core/src/view/handler/PopupMenuHandler.ts
@@ -101,7 +101,7 @@ class PopupMenuHandler extends MaxPopupMenu implements GraphPlugin {
   init() {
     // Hides the tooltip if the mouse is over the context menu
     InternalEvent.addGestureListeners(this.div, (evt) => {
-      const tooltipHandler = this.graph.getPlugin('TooltipHandler') as TooltipHandler;
+      const tooltipHandler = this.graph.getPlugin<TooltipHandler>('TooltipHandler');
       tooltipHandler?.hide();
     });
   }
@@ -174,7 +174,7 @@ class PopupMenuHandler extends MaxPopupMenu implements GraphPlugin {
       }
 
       // Hides the tooltip if there is one
-      const tooltipHandler = this.graph.getPlugin('TooltipHandler') as TooltipHandler;
+      const tooltipHandler = this.graph.getPlugin<TooltipHandler>('TooltipHandler');
       tooltipHandler?.hide();
 
       // Menu is shifted by 1 pixel so that the mouse up event

--- a/packages/core/src/view/handler/SelectionHandler.ts
+++ b/packages/core/src/view/handler/SelectionHandler.ts
@@ -122,9 +122,9 @@ class SelectionHandler implements GraphPlugin {
             this.updateHint();
 
             if (this.livePreviewUsed) {
-              const selectionCellsHandler = this.graph.getPlugin(
+              const selectionCellsHandler = this.graph.getPlugin<SelectionCellsHandler>(
                 'SelectionCellsHandler'
-              ) as SelectionCellsHandler;
+              );
 
               // Forces update to ignore last visible state
               this.setHandlesVisibleForCells(
@@ -469,16 +469,15 @@ class SelectionHandler implements GraphPlugin {
   isDelayedSelection(cell: Cell, me: InternalMouseEvent) {
     let c: Cell | null = cell;
 
-    const selectionCellsHandler = this.graph.getPlugin(
+    const selectionCellsHandler = this.graph.getPlugin<SelectionCellsHandler>(
       'SelectionCellsHandler'
-    ) as SelectionCellsHandler;
+    );
 
     if (!this.graph.isToggleEvent(me.getEvent()) || !isAltDown(me.getEvent())) {
       while (c) {
         if (selectionCellsHandler?.isHandled(c)) {
-          const cellEditorHandler = this.graph.getPlugin(
-            'CellEditorHandler'
-          ) as CellEditorHandler;
+          const cellEditorHandler =
+            this.graph.getPlugin<CellEditorHandler>('CellEditorHandler');
           return cellEditorHandler?.getEditingCell() !== c;
         }
         c = c.getParent();
@@ -491,7 +490,7 @@ class SelectionHandler implements GraphPlugin {
    * Implements the delayed selection for the given mouse event.
    */
   selectDelayed(me: InternalMouseEvent) {
-    const popupMenuHandler = this.graph.getPlugin('PopupMenuHandler') as PopupMenuHandler;
+    const popupMenuHandler = this.graph.getPlugin<PopupMenuHandler>('PopupMenuHandler');
 
     if (!popupMenuHandler || !popupMenuHandler.isPopupTrigger(me)) {
       let cell = me.getCell();
@@ -1055,9 +1054,9 @@ class SelectionHandler implements GraphPlugin {
   updatePreview(remote = false) {
     if (this.livePreviewUsed && !remote) {
       if (this.cells) {
-        const selectionCellsHandler = this.graph.getPlugin(
+        const selectionCellsHandler = this.graph.getPlugin<SelectionCellsHandler>(
           'SelectionCellsHandler'
-        ) as SelectionCellsHandler;
+        );
 
         this.setHandlesVisibleForCells(
           selectionCellsHandler?.getHandledSelectionCells() ?? [],
@@ -1256,9 +1255,9 @@ class SelectionHandler implements GraphPlugin {
    * Redraws the preview shape for the given states array.
    */
   redrawHandles(states: CellState[][]) {
-    const selectionCellsHandler = this.graph.getPlugin(
+    const selectionCellsHandler = this.graph.getPlugin<SelectionCellsHandler>(
       'SelectionCellsHandler'
-    ) as SelectionCellsHandler;
+    );
 
     for (let i = 0; i < states.length; i += 1) {
       const handler = selectionCellsHandler?.getHandler(states[i][0].cell);
@@ -1371,9 +1370,9 @@ class SelectionHandler implements GraphPlugin {
     if (force || this.handlesVisible !== visible) {
       this.handlesVisible = visible;
 
-      const selectionCellsHandler = this.graph.getPlugin(
+      const selectionCellsHandler = this.graph.getPlugin<SelectionCellsHandler>(
         'SelectionCellsHandler'
-      ) as SelectionCellsHandler;
+      );
 
       for (let i = 0; i < cells.length; i += 1) {
         const handler = selectionCellsHandler?.getHandler(cells[i]);
@@ -1425,9 +1424,8 @@ class SelectionHandler implements GraphPlugin {
           cell.isConnectable() &&
           graph.isEdgeValid(null, this.cell, cell)
         ) {
-          const connectionHandler = graph.getPlugin(
-            'ConnectionHandler'
-          ) as ConnectionHandler;
+          const connectionHandler =
+            graph.getPlugin<ConnectionHandler>('ConnectionHandler');
 
           connectionHandler?.connect(this.cell, cell, me.getEvent());
         } else {
@@ -1479,9 +1477,9 @@ class SelectionHandler implements GraphPlugin {
     if (this.livePreviewUsed) {
       this.resetLivePreview();
 
-      const selectionCellsHandler = this.graph.getPlugin(
+      const selectionCellsHandler = this.graph.getPlugin<SelectionCellsHandler>(
         'SelectionCellsHandler'
-      ) as SelectionCellsHandler;
+      );
 
       this.setHandlesVisibleForCells(
         selectionCellsHandler?.getHandledSelectionCells() ?? [],

--- a/packages/core/src/view/handler/TooltipHandler.ts
+++ b/packages/core/src/view/handler/TooltipHandler.ts
@@ -235,9 +235,8 @@ class TooltipHandler implements GraphPlugin {
         const x = me.getX();
         const y = me.getY();
         const stateSource = me.isSource(state.shape) || me.isSource(state.text);
-        const popupMenuHandler = this.graph.getPlugin(
-          'PopupMenuHandler'
-        ) as PopupMenuHandler;
+        const popupMenuHandler =
+          this.graph.getPlugin<PopupMenuHandler>('PopupMenuHandler');
 
         this.thread = window.setTimeout(() => {
           if (

--- a/packages/core/src/view/handler/VertexHandler.ts
+++ b/packages/core/src/view/handler/VertexHandler.ts
@@ -245,7 +245,7 @@ class VertexHandler {
       this.selectionBorder.setCursor(CURSOR.MOVABLE_VERTEX);
     }
 
-    const selectionHandler = this.graph.getPlugin('SelectionHandler') as SelectionHandler;
+    const selectionHandler = this.graph.getPlugin<SelectionHandler>('SelectionHandler');
 
     // Adds the sizer handles
     if (
@@ -351,7 +351,7 @@ class VertexHandler {
    * Returns `true` if the rotation handle should be showing.
    */
   isRotationHandleVisible() {
-    const selectionHandler = this.graph.getPlugin('SelectionHandler') as SelectionHandler;
+    const selectionHandler = this.graph.getPlugin<SelectionHandler>('SelectionHandler');
     const selectionHandlerCheck = selectionHandler
       ? selectionHandler.maxCells <= 0 ||
         this.graph.getSelectionCount() < selectionHandler.maxCells
@@ -739,9 +739,9 @@ class VertexHandler {
         const edges = this.state.cell.getEdges();
         this.edgeHandlers = [];
 
-        const selectionCellsHandler = this.graph.getPlugin(
+        const selectionCellsHandler = this.graph.getPlugin<SelectionCellsHandler>(
           'SelectionCellsHandler'
-        ) as SelectionCellsHandler;
+        );
 
         for (let i = 0; i < edges.length; i += 1) {
           const handler = selectionCellsHandler?.getHandler(edges[i]);

--- a/packages/core/src/view/other/DragSource.ts
+++ b/packages/core/src/view/other/DragSource.ts
@@ -534,7 +534,7 @@ class DragSource {
 
     // Guide is only needed if preview element is used
     if (this.isGuidesEnabled() && this.previewElement) {
-      const selectionHandler = graph.getPlugin('SelectionHandler') as SelectionHandler;
+      const selectionHandler = graph.getPlugin<SelectionHandler>('SelectionHandler');
       this.currentGuide = new Guide(graph, selectionHandler?.getGuideStates());
     }
 

--- a/packages/html/stories/Codec.stories.ts
+++ b/packages/html/stories/Codec.stories.ts
@@ -111,7 +111,7 @@ const Template = ({ label, ...args }: Record<string, any>) => {
   style.edgeStyle = 'elbowEdgeStyle';
 
   // Enables panning with left mouse button
-  const panningHandler = graph.getPlugin('PanningHandler') as PanningHandler;
+  const panningHandler = graph.getPlugin<PanningHandler>('PanningHandler');
   panningHandler.useLeftButtonForPanning = true;
   panningHandler.ignoreCell = true;
   graph.container.style.cursor = 'move';

--- a/packages/html/stories/ContextIcons.stories.ts
+++ b/packages/html/stories/ContextIcons.stories.ts
@@ -116,8 +116,8 @@ const Template = ({ label, ...args }: Record<string, any>) => {
       img.style.width = '16px';
       img.style.height = '16px';
 
-      const graphHandler = graph.getPlugin('SelectionHandler') as SelectionHandler;
-      const connectionHandler = graph.getPlugin('ConnectionHandler') as ConnectionHandler;
+      const graphHandler = graph.getPlugin<SelectionHandler>('SelectionHandler');
+      const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler');
 
       InternalEvent.addGestureListeners(img, (evt) => {
         graphHandler.start(
@@ -192,7 +192,7 @@ const Template = ({ label, ...args }: Record<string, any>) => {
   const graph = new MyCustomGraph(container);
   graph.setConnectable(true);
 
-  const connectionHandler = graph.getPlugin('ConnectionHandler') as ConnectionHandler;
+  const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler');
   connectionHandler.createTarget = true;
 
   // Uncomment the following if you want the container

--- a/packages/html/stories/DynamicToolbar.stories.ts
+++ b/packages/html/stories/DynamicToolbar.stories.ts
@@ -84,7 +84,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
 
   // Defines an icon for creating new connections in the connection handler.
   // This will automatically disable the highlighting of the source vertex.
-  const connectionHandler = graph.getPlugin('ConnectionHandler') as ConnectionHandler;
+  const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler');
   connectionHandler.connectImage = new ImageBox(
     `${Client.imageBasePath}/connector.gif`,
     16,

--- a/packages/html/stories/FileIO.stories.ts
+++ b/packages/html/stories/FileIO.stories.ts
@@ -70,7 +70,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   graph.setEnabled(false);
   graph.setPanning(true);
   graph.setTooltips(true);
-  (graph.getPlugin('PanningHandler') as PanningHandler).useLeftButtonForPanning = true;
+  graph.getPlugin<PanningHandler>('PanningHandler').useLeftButtonForPanning = true;
 
   // Adds a highlight on the cell under the mouse pointer
   new CellTracker(graph, undefined!);

--- a/packages/html/stories/SwimLanes.stories.ts
+++ b/packages/html/stories/SwimLanes.stories.ts
@@ -81,12 +81,12 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   graph.setResizeContainer(true);
   configureExpandedAndCollapsedImages(graph);
 
-  const graphHandler = graph.getPlugin('SelectionHandler') as SelectionHandler;
+  const graphHandler = graph.getPlugin<SelectionHandler>('SelectionHandler');
   graphHandler.setRemoveCellsFromParent(false);
 
   // Defines an icon for creating new connections in the connection handler.
   // This will automatically disable the highlighting of the source vertex.
-  const connectionHandler = graph.getPlugin('ConnectionHandler') as ConnectionHandler;
+  const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler');
   connectionHandler.connectImage = new ImageBox(
     `${Client.imageBasePath}/connector.gif`,
     16,

--- a/packages/html/stories/Toolbar.stories.ts
+++ b/packages/html/stories/Toolbar.stories.ts
@@ -91,7 +91,7 @@ const Template = ({ label, ...args }: { [p: string]: any }) => {
 
   // Defines an icon for creating new connections in the connection handler.
   // This will automatically disable the highlighting of the source vertex.
-  const connectionHandler = graph.getPlugin('ConnectionHandler') as ConnectionHandler;
+  const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler');
   connectionHandler.connectImage = new ImageBox(
     `${Client.imageBasePath}/connector.gif`,
     16,


### PR DESCRIPTION
The use generic type parameter directly in the `getPlugin` method call eliminates the need for the
type assertion with the "as" keyword.
This makes the code more concise while maintaining the same behavior.
