### PR TITLE
docs(JSDoc): introduce a category for "Vertex Shapes"

### DIFF
--- a/packages/core/src/view/geometry/ActorShape.ts
+++ b/packages/core/src/view/geometry/ActorShape.ts
@@ -23,26 +23,24 @@ import { ColorValue } from '../../types';
 import { NONE } from '../../util/Constants';
 
 /**
- * Extends {@link Shape} to implement an actor shape. If a custom shape with one
- * filled area is needed, then this shape's {@link redrawPath} method should be overridden.
+ * Extends {@link Shape} to implement an actor shape.
+ * This shape is registered by default under {@link SHAPE.ACTOR} in {@link CellRenderer}.
  *
- * This shape is registered under {@link Constants.SHAPE_ACTOR} in {@link cellRenderer}.
+ * If a custom shape with one filled area is needed, then this shape's {@link redrawPath} method should be overridden
+ * like in the following example:
  *
- * ```javascript
- * function SampleShape() { }
- *
- * SampleShape.prototype = new mxActor();
- * SampleShape.prototype.constructor = vsAseShape;
- *
- * mxCellRenderer.registerShape('sample', SampleShape);
- * SampleShape.prototype.redrawPath = function(path, x, y, w, h)
- * {
- *   path.moveTo(0, 0);
- *   path.lineTo(w, h);
- *   // ...
- *   path.close();
+ * ```typescript
+ * class SampleShape extends ActorShape {
+ *   redrawPath(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
+ *     path.moveTo(0, 0);
+ *     path.lineTo(w, h);
+ *     // ...
+ *     path.close();
+ *   }
  * }
  * ```
+ *
+ * @category Vertex Shapes
  */
 class ActorShape extends Shape {
   constructor(

--- a/packages/core/src/view/geometry/node/CloudShape.ts
+++ b/packages/core/src/view/geometry/node/CloudShape.ts
@@ -22,8 +22,9 @@ import Rectangle from '../Rectangle';
 
 /**
  * Extends {@link ActorShape} to implement a cloud shape.
+ * This shape is registered by default under {@link SHAPE.CLOUD} in {@link CellRenderer}.
  *
- * This shape is registered under {@link mxConstants.SHAPE_CLOUD} in {@link cellRenderer}.
+ * @category Vertex Shapes
  */
 class CloudShape extends ActorShape {
   constructor(bounds: Rectangle, fill: string, stroke: string, strokeWidth = 1) {

--- a/packages/core/src/view/geometry/node/CylinderShape.ts
+++ b/packages/core/src/view/geometry/node/CylinderShape.ts
@@ -22,10 +22,12 @@ import Rectangle from '../Rectangle';
 import { NONE } from '../../../util/Constants';
 
 /**
- * Extends {@link Shape} to implement an cylinder shape. If a custom shape with one filled area and an overlay path is
- * needed, then this shape's {@link redrawPath} should be overridden.
+ * Extends {@link Shape} to implement a cylinder shape.
+ * This shape is registered by default under {@link SHAPE.CYLINDER} in {@link CellRenderer}.
  *
- * This shape is registered under {@link mxConstants.SHAPE_CYLINDER} in {@link cellRenderer}.
+ * If a custom shape with one filled area and an overlay path is needed, then this shape's {@link redrawPath} should be overridden.
+ *
+ * @category Vertex Shapes
  */
 class CylinderShape extends Shape {
   constructor(bounds: Rectangle, fill: string, stroke: string, strokeWidth = 1) {

--- a/packages/core/src/view/geometry/node/DoubleEllipseShape.ts
+++ b/packages/core/src/view/geometry/node/DoubleEllipseShape.ts
@@ -22,30 +22,33 @@ import AbstractCanvas2D from '../../../view/canvas/AbstractCanvas2D';
 
 /**
  * Extends {@link Shape} to implement a double ellipse shape.
+ * This shape is registered by default under {@link SHAPE.DOUBLE_ELLIPSE} in {@link CellRenderer}.
  *
- * This shape is registered under {@link mxConstants.SHAPE_DOUBLE_ELLIPSE} in {@link cellRenderer}.
+ * If a custom shape is needed to only fill the inner ellipse, then this shape's {@link paintVertexShape} method should be overridden
+ * like in the following example:
  *
- * Use the following override to only fill the inner ellipse in this shape:
- * ```javascript
- * mxDoubleEllipse.prototype.paintVertexShape = function(c, x, y, w, h)
- * {
- *   c.ellipse(x, y, w, h);
- *   c.stroke();
- *
- *   var inset = mxUtils.getValue(this.style, 'margin', Math.min(3 + this.strokewidth, Math.min(w / 5, h / 5)));
- *   x += inset;
- *   y += inset;
- *   w -= 2 * inset;
- *   h -= 2 * inset;
- *
- *   if (w > 0 && h > 0)
- *   {
+ * ```typescript
+ * class SampleShape extends DoubleEllipseShape {
+ *   paintVertexShape(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
  *     c.ellipse(x, y, w, h);
- *   }
+ *     c.stroke();
  *
- *   c.fillAndStroke();
- * };
+ *     const inset = this.style.margin ?? Math.min(3 + this.strokewidth, Math.min(w / 5, h / 5));
+ *     x += inset;
+ *     y += inset;
+ *     w -= 2 * inset;
+ *     h -= 2 * inset;
+ *
+ *     if (w > 0 && h > 0) {
+ *       c.ellipse(x, y, w, h);
+ *     }
+ *
+ *     c.fillAndStroke();
+ *   }
+ * }
  * ```
+ *
+ * @category Vertex Shapes
  */
 class DoubleEllipseShape extends Shape {
   constructor(bounds: Rectangle, fill: string, stroke: string, strokeWidth = 1) {

--- a/packages/core/src/view/geometry/node/EllipseShape.ts
+++ b/packages/core/src/view/geometry/node/EllipseShape.ts
@@ -21,8 +21,10 @@ import AbstractCanvas2D from '../../../view/canvas/AbstractCanvas2D';
 import Rectangle from '../Rectangle';
 
 /**
- * Extends mxShape to implement an ellipse shape.
- * This shape is registered under mxConstants.SHAPE_ELLIPSE in mxCellRenderer.
+ * Extends {@link Shape} to implement an ellipse shape.
+ * This shape is registered by default under {@link SHAPE.ELLIPSE} in {@link CellRenderer}.
+ *
+ * @category Vertex Shapes
  */
 class EllipseShape extends Shape {
   constructor(bounds: Rectangle, fill: string, stroke: string, strokeWidth = 1) {

--- a/packages/core/src/view/geometry/node/HexagonShape.ts
+++ b/packages/core/src/view/geometry/node/HexagonShape.ts
@@ -23,8 +23,8 @@ import AbstractCanvas2D from '../../canvas/AbstractCanvas2D';
 
 /**
  * Implementation of the hexagon shape.
- * @class HexagonShape
- * @extends {ActorShape}
+ *
+ * @category Vertex Shapes
  */
 class HexagonShape extends ActorShape {
   constructor() {
@@ -33,11 +33,6 @@ class HexagonShape extends ActorShape {
 
   /**
    * Draws the path for this shape.
-   * @param {mxAbstractCanvas2D} c
-   * @param {number} x
-   * @param {number} y
-   * @param {number} w
-   * @param {number} h
    */
   redrawPath(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
     const arcSize = (this.style?.arcSize ?? LINE_ARCSIZE) / 2;

--- a/packages/core/src/view/geometry/node/ImageShape.ts
+++ b/packages/core/src/view/geometry/node/ImageShape.ts
@@ -26,7 +26,9 @@ import { ColorValue } from '../../../types';
 
 /**
  * Extends {@link RectangleShape} to implement an image shape.
- * This shape is registered under {@link Constants.SHAPE.SHAPE_IMAGE} in {@link CellRenderer}.
+ * This shape is registered by default under {@link SHAPE.IMAGE} in {@link CellRenderer}.
+ *
+ * @category Vertex Shapes
  */
 class ImageShape extends RectangleShape {
   constructor(

--- a/packages/core/src/view/geometry/node/LabelShape.ts
+++ b/packages/core/src/view/geometry/node/LabelShape.ts
@@ -23,22 +23,20 @@ import { ColorValue } from '../../../types';
 import AbstractCanvas2D from '../../canvas/AbstractCanvas2D';
 
 /**
- * Extends {@link Shape} to implement an image shape with a label.
- * This shape is registered under {@link Constants#SHAPE_LABEL} in
- * {@link CellRenderer}.
+ * Extends {@link RectangleShape} to implement an image shape with a label.
+ * This shape is registered by default under {@link SHAPE.LABEL} in {@link CellRenderer}.
  *
- * Constructor: mxLabel
- *
- * Constructs a new label shape.
- *
- * @param bounds {@link Rectangle} that defines the bounds. This is stored in
- * {@link Shape#bounds}.
- * @param fill String that defines the fill color. This is stored in <fill>.
- * @param stroke String that defines the stroke color. This is stored in <stroke>.
- * @param strokewidth Optional integer that defines the stroke width. Default is
- * 1. This is stored in <strokewidth>.
+ * @category Vertex Shapes
  */
 class LabelShape extends RectangleShape {
+  /**
+   * Constructs a new label shape.
+   *
+   * @param bounds {@link Rectangle} that defines the bounds. This is stored in {@link bounds}.
+   * @param fill String that defines the fill color. This is stored in {@link fill}.
+   * @param stroke String that defines the stroke color. This is stored in {@link stroke}.
+   * @param strokeWidth Optional integer that defines the stroke width. Default is 1. This is stored in {@link strokeWidth}.
+   */
   constructor(
     bounds: Rectangle,
     fill: ColorValue,

--- a/packages/core/src/view/geometry/node/RectangleShape.ts
+++ b/packages/core/src/view/geometry/node/RectangleShape.ts
@@ -24,9 +24,9 @@ import { ColorValue } from '../../../types';
 
 /**
  * Extends {@link Shape} to implement a rectangle shape.
- * This shape is registered under {@link mxConstants.SHAPE_RECTANGLE} in {@link cellRenderer}.
- * @class RectangleShape
- * @extends {Shape}
+ * This shape is registered by default under {@link SHAPE.RECTANGLE} in {@link CellRenderer}.
+ *
+ * @category Vertex Shapes
  */
 class RectangleShape extends Shape {
   constructor(bounds: Rectangle, fill: ColorValue, stroke: ColorValue, strokeWidth = 1) {

--- a/packages/core/src/view/geometry/node/RhombusShape.ts
+++ b/packages/core/src/view/geometry/node/RhombusShape.ts
@@ -24,9 +24,9 @@ import AbstractCanvas2D from '../../canvas/AbstractCanvas2D';
 
 /**
  * Extends {@link Shape} to implement a rhombus (aka diamond) shape.
- * This shape is registered under {@link mxConstants.SHAPE_RHOMBUS} in {@link cellRenderer}.
- * @class RhombusShape
- * @extends {Shape}
+ * This shape is registered by default under {@link SHAPE.RHOMBUS} in {@link CellRenderer}.
+ *
+ * @category Vertex Shapes
  */
 class RhombusShape extends Shape {
   constructor(bounds: Rectangle, fill: string, stroke: string, strokewidth = 1) {

--- a/packages/core/src/view/geometry/node/SwimlaneShape.ts
+++ b/packages/core/src/view/geometry/node/SwimlaneShape.ts
@@ -29,17 +29,17 @@ import AbstractCanvas2D from '../../canvas/AbstractCanvas2D';
 
 /**
  * Extends {@link Shape} to implement a swimlane shape.
- * This shape is registered under {@link mxConstants.SHAPE_SWIMLANE} in {@link mxCellRenderer}.
- * Use the {@link mxConstants.STYLE_STYLE_STARTSIZE} to define the size of the title
- * region, `'swimLaneFillColor'` for the content area fill,
- * `'separatorColor'` to draw an additional vertical separator and
- * {@link mxConstants.STYLE_SWIMLANE_LINE} to hide the line between the title region and
- * the content area.
- * The {@link 'horizontal'} affects the orientation of this shape,
- * not only its label.
+ * This shape is registered by default under {@link SHAPE.SWIMLANE} in {@link CellRenderer}.
  *
- * @class SwimlaneShape
- * @extends {Shape}
+ * Use:
+ * - {@link CellStateStyle.startSize} to define the size of the title region,
+ * - {@link CellStateStyle.swimlaneFillColor} for the content area fill,
+ * - {@link CellStateStyle.separatorColor} to draw an additional vertical separator,
+ * - {@link CellStateStyle.swimlaneLine} to hide the line between the title region and the content area
+ *
+ * {@link CellStateStyle.horizontal} affects the orientation of this shape, not only its label.
+ *
+ * @category Vertex Shapes
  */
 class SwimlaneShape extends Shape {
   constructor(bounds: Rectangle, fill: ColorValue, stroke: ColorValue, strokeWidth = 1) {

--- a/packages/core/src/view/geometry/node/TextShape.ts
+++ b/packages/core/src/view/geometry/node/TextShape.ts
@@ -50,14 +50,14 @@ import {
 import SvgCanvas2D from '../../canvas/SvgCanvas2D';
 
 /**
- * Extends mxShape to implement a text shape.
- * To change vertical text from bottom to top to top to bottom,
- * the following code can be used:
+ * Extends {@link Shape} to implement a text shape.
+ *
+ * To change vertical text from "bottom to top" to "top to bottom", the following code can be used:
  * ```javascript
- * mxText.prototype.verticalTextRotation = 90;
+ * TextShape.prototype.verticalTextRotation = 90;
  * ```
- * @class TextShape
- * @extends {Shape}
+ *
+ * @category Vertex Shapes
  */
 class TextShape extends Shape {
   constructor(

--- a/packages/core/src/view/geometry/node/TriangleShape.ts
+++ b/packages/core/src/view/geometry/node/TriangleShape.ts
@@ -23,8 +23,8 @@ import AbstractCanvas2D from '../../canvas/AbstractCanvas2D';
 
 /**
  * Implementation of the triangle shape.
- * @class TriangleShape
- * @extends {ActorShape}
+ *
+ * @category Vertex Shapes
  */
 class TriangleShape extends ActorShape {
   constructor() {

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -17,7 +17,7 @@
     "readme": "none",
     "excludeExternals": true,
     "excludePrivate": true,
-    "categoryOrder": ["Configuration", "Edge Shapes", "Logging", "*"],
+    "categoryOrder": ["Configuration", "Logging", "Edge Shapes", "Vertex Shapes","*"],
     "categorizeByGroup": false,
     "navigation": {
       "includeCategories": false, // not enough categories to warrant this


### PR DESCRIPTION
Better group related elements in HTML API documentation.