### PR TITLE
docs(JSDoc): introduce a category for "Serialization with Codecs"

### DIFF
--- a/packages/core/src/serialization/Codec.ts
+++ b/packages/core/src/serialization/Codec.ts
@@ -125,7 +125,7 @@ const createXmlDocument = () => {
  * };
  * ```
  *
- * @class Codec
+ * @category Serialization with Codecs
  */
 class Codec {
   constructor(document: XMLDocument = createXmlDocument()) {

--- a/packages/core/src/serialization/CodecRegistry.ts
+++ b/packages/core/src/serialization/CodecRegistry.ts
@@ -44,6 +44,8 @@ import ObjectCodec from './ObjectCodec';
  *
  * {@link ObjectCodec.decode} may be used to either create a new instance of an object or to configure an existing instance,
  * in which case the into argument points to the existing object. In this case, we say the codec "configures" the object.
+ *
+ * @category Serialization with Codecs
  */
 class CodecRegistry {
   static codecs: { [key: string]: ObjectCodec | undefined } = {};

--- a/packages/core/src/serialization/ModelXmlSerializer.ts
+++ b/packages/core/src/serialization/ModelXmlSerializer.ts
@@ -27,6 +27,7 @@ import type GraphDataModel from '../view/GraphDataModel';
  * @alpha
  * @experimental
  * @since 0.6.0
+ * @category Serialization with Codecs
  */
 export type ModelExportOptions = {
   /**
@@ -44,6 +45,7 @@ export type ModelExportOptions = {
  * @alpha
  * @experimental
  * @since 0.6.0
+ * @category Serialization with Codecs
  */
 // Include 'XML' in the class name as there were past discussions about supporting other format like JSON for example
 // See https://github.com/maxGraph/maxGraph/discussions/60 for more details.

--- a/packages/core/src/serialization/ObjectCodec.ts
+++ b/packages/core/src/serialization/ObjectCodec.ts
@@ -195,6 +195,8 @@ import type Codec from './Codec';
  * functions on the resulting object.
  *
  * Expressions are only evaluated if {@link allowEval} is true.
+ *
+ * @category Serialization with Codecs
  */
 class ObjectCodec {
   private name?: string;

--- a/packages/core/src/serialization/codecs/CellCodec.ts
+++ b/packages/core/src/serialization/codecs/CellCodec.ts
@@ -49,6 +49,8 @@ import { removeWhitespace } from '../../util/StringUtils';
  * CodecRegistry.getCodec(Cell).template = new CustomCell();
  * CodecRegistry.addAlias('CustomCell', 'Cell');
  * ```
+ *
+ * @category Serialization with Codecs
  */
 export class CellCodec extends ObjectCodec {
   constructor() {

--- a/packages/core/src/serialization/codecs/ChildChangeCodec.ts
+++ b/packages/core/src/serialization/codecs/ChildChangeCodec.ts
@@ -34,6 +34,8 @@ import { NODETYPE } from '../../util/Constants';
  * Reference Fields:
  *
  * - parent
+ *
+ * @category Serialization with Codecs
  */
 export class ChildChangeCodec extends ObjectCodec {
   constructor() {

--- a/packages/core/src/serialization/codecs/GenericChangeCodec.ts
+++ b/packages/core/src/serialization/codecs/GenericChangeCodec.ts
@@ -33,6 +33,8 @@ import type Codec from '../Codec';
  * Reference Fields:
  *
  * - cell
+ *
+ * @category Serialization with Codecs
  */
 export class GenericChangeCodec extends ObjectCodec {
   /**

--- a/packages/core/src/serialization/codecs/GraphCodec.ts
+++ b/packages/core/src/serialization/codecs/GraphCodec.ts
@@ -33,6 +33,8 @@ import { Graph } from '../../view/Graph';
  * - cellRenderer
  * - editor
  * - selection
+ *
+ * @category Serialization with Codecs
  */
 export class GraphCodec extends ObjectCodec {
   constructor() {

--- a/packages/core/src/serialization/codecs/GraphViewCodec.ts
+++ b/packages/core/src/serialization/codecs/GraphViewCodec.ts
@@ -27,6 +27,8 @@ import Point from '../../view/geometry/Point';
  *
  * This codec only writes views into an XML format that can be used to create an image for the graph, that is,
  * it contains absolute coordinates with computed perimeters, edge styles and cell styles.
+ *
+ * @category Serialization with Codecs
  */
 export class GraphViewCodec extends ObjectCodec {
   constructor() {

--- a/packages/core/src/serialization/codecs/ModelCodec.ts
+++ b/packages/core/src/serialization/codecs/ModelCodec.ts
@@ -23,6 +23,8 @@ import type Codec from '../Codec';
  * Codec for {@link GraphDataModel}s.
  *
  * This class is created and registered dynamically at load time and used implicitly via {@link Codec} and the {@link CodecRegistry}.
+ *
+ * @category Serialization with Codecs
  */
 export class ModelCodec extends ObjectCodec {
   constructor() {

--- a/packages/core/src/serialization/codecs/RootChangeCodec.ts
+++ b/packages/core/src/serialization/codecs/RootChangeCodec.ts
@@ -29,6 +29,8 @@ import { NODETYPE } from '../../util/Constants';
  * - model
  * - previous
  * - root
+ *
+ * @category Serialization with Codecs
  */
 export class RootChangeCodec extends ObjectCodec {
   constructor() {

--- a/packages/core/src/serialization/codecs/StylesheetCodec.ts
+++ b/packages/core/src/serialization/codecs/StylesheetCodec.ts
@@ -28,6 +28,8 @@ import { getTextContent } from '../../util/domUtils';
  * Codec for {@link Stylesheet}s.
  *
  * This class is created and registered dynamically at load time and used implicitly via {@link Codec} and the {@link CodecRegistry}.
+ *
+ * @category Serialization with Codecs
  */
 export class StylesheetCodec extends ObjectCodec {
   constructor() {

--- a/packages/core/src/serialization/codecs/TerminalChangeCodec.ts
+++ b/packages/core/src/serialization/codecs/TerminalChangeCodec.ts
@@ -32,6 +32,8 @@ import type Codec from '../Codec';
  *
  * - cell
  * - terminal
+ *
+ * @category Serialization with Codecs
  */
 export class TerminalChangeCodec extends ObjectCodec {
   constructor() {

--- a/packages/core/src/serialization/codecs/editor/EditorCodec.ts
+++ b/packages/core/src/serialization/codecs/editor/EditorCodec.ts
@@ -34,6 +34,8 @@ import { addLinkToHead, getChildNodes } from '../../../util/domUtils';
  * - undoManager
  * - graphContainer
  * - toolbarContainer
+ *
+ * @category Serialization with Codecs
  */
 export class EditorCodec extends ObjectCodec {
   constructor() {

--- a/packages/core/src/serialization/codecs/editor/EditorKeyHandlerCodec.ts
+++ b/packages/core/src/serialization/codecs/editor/EditorKeyHandlerCodec.ts
@@ -24,6 +24,8 @@ import EditorKeyHandler from '../../../editor/EditorKeyHandler';
  * This class is created and registered dynamically at load time and used implicitly via {@link Codec} and the {@link CodecRegistry}.
  *
  * This codec only reads configuration data for existing key handlers, it does not encode or create key handlers.
+ *
+ * @category Serialization with Codecs
  */
 export class EditorKeyHandlerCodec extends ObjectCodec {
   constructor() {

--- a/packages/core/src/serialization/codecs/editor/EditorPopupMenuCodec.ts
+++ b/packages/core/src/serialization/codecs/editor/EditorPopupMenuCodec.ts
@@ -27,6 +27,7 @@ import EditorPopupMenu from '../../../editor/EditorPopupMenu';
  * Note that this codec only passes the configuration node to the popup menu, which uses the config to dynamically create menus.
  *
  * @see {@link EditorPopupMenu.createMenu}.
+ * @category Serialization with Codecs
  */
 export class EditorPopupMenuCodec extends ObjectCodec {
   constructor() {

--- a/packages/core/src/serialization/codecs/editor/EditorToolbarCodec.ts
+++ b/packages/core/src/serialization/codecs/editor/EditorToolbarCodec.ts
@@ -32,6 +32,8 @@ import Translations from '../../../util/Translations';
  * This class is created and registered dynamically at load time and used implicitly via {@link Codec} and the {@link CodecRegistry}.
  *
  * This codec only reads configuration data for existing toolbars handlers, it does not encode or create toolbars.
+ *
+ * @category Serialization with Codecs
  */
 export class EditorToolbarCodec extends ObjectCodec {
   constructor() {

--- a/packages/core/src/serialization/codecs/mxGraph/mxCellCodec.ts
+++ b/packages/core/src/serialization/codecs/mxGraph/mxCellCodec.ts
@@ -19,7 +19,9 @@ import { CellCodec } from '../CellCodec';
 import type Codec from '../../Codec';
 
 /**
- * CellCodec to support the legacy `mxGraph` format.
+ * Add support for the legacy `mxGraph` format of {@link Cell}.
+ *
+ * @category Serialization with Codecs
  */
 export class mxCellCodec extends CellCodec {
   getName(): string {

--- a/packages/core/src/serialization/codecs/mxGraph/mxGeometryCodec.ts
+++ b/packages/core/src/serialization/codecs/mxGraph/mxGeometryCodec.ts
@@ -19,6 +19,11 @@ import ObjectCodec from '../../ObjectCodec';
 import Geometry from '../../../view/geometry/Geometry';
 import Point from '../../../view/geometry/Point';
 
+/**
+ * Add support for the legacy `mxGraph` format of {@link Geometry}.
+ *
+ * @category Serialization with Codecs
+ */
 export class mxGeometryCodec extends ObjectCodec {
   getName(): string {
     return 'mxGeometry';

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -17,7 +17,7 @@
     "readme": "none",
     "excludeExternals": true,
     "excludePrivate": true,
-    "categoryOrder": ["Configuration", "Logging", "Edge Shapes", "Vertex Shapes","*"],
+    "categoryOrder": ["Configuration", "Logging", "Edge Shapes", "Vertex Shapes", "Serialization with Codecs", "*"],
     "categorizeByGroup": false,
     "navigation": {
       "includeCategories": false, // not enough categories to warrant this


### PR DESCRIPTION
Better group related elements in HTML API documentation.