### PR TITLE
docs(JSDoc): introduce a category for "Perimeter"

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1131,6 +1131,8 @@ export type IdentityFunction = {
  * @param orthogonal Boolean that specifies if the orthogonal projection onto the perimeter should be returned.
  *                   If this is `false`, then the intersection of the perimeter and the line between the next and the center point is returned.
  * @returns the resulting {@link Point} projected to the perimeter.
+ *
+ * @category Perimeter
  */
 export type PerimeterFunction = (
   bounds: Rectangle,
@@ -1141,6 +1143,8 @@ export type PerimeterFunction = (
 
 /**
  * Names used to register the perimeter provided out-of-the-box by maxGraph with {@link StyleRegistry.putValue}.
+ *
+ * @category Perimeter
  */
 export type PerimeterValue =
   | 'ellipsePerimeter'

--- a/packages/core/src/view/style/Perimeter.ts
+++ b/packages/core/src/view/style/Perimeter.ts
@@ -75,6 +75,8 @@ import { TrianglePerimeter as TrianglePerimeterFunction } from './perimeter/Tria
  * Note that the object can be used directly when programmatically setting
  * the value, but the key in the {@link StyleRegistry} should be used when
  * setting the value via a key, value pair in a cell style.
+ *
+ * @category Perimeter
  */
 const Perimeter = {
   /**

--- a/packages/core/src/view/style/perimeter/EllipsePerimeter.ts
+++ b/packages/core/src/view/style/perimeter/EllipsePerimeter.ts
@@ -21,6 +21,9 @@ import type CellState from '../../cell/CellState';
 import Point from '../../geometry/Point';
 import type { PerimeterFunction } from '../../../types';
 
+/**
+ * @category Perimeter
+ */
 export const EllipsePerimeter: PerimeterFunction = (
   bounds: Rectangle,
   _vertex: CellState,

--- a/packages/core/src/view/style/perimeter/HexagonPerimeter.ts
+++ b/packages/core/src/view/style/perimeter/HexagonPerimeter.ts
@@ -23,6 +23,9 @@ import type { PerimeterFunction } from '../../../types';
 import { DIRECTION } from '../../../util/Constants';
 import { intersection } from '../../../util/mathUtils';
 
+/**
+ * @category Perimeter
+ */
 export const HexagonPerimeter: PerimeterFunction = (
   bounds: Rectangle,
   vertex: CellState,

--- a/packages/core/src/view/style/perimeter/RectanglePerimeter.ts
+++ b/packages/core/src/view/style/perimeter/RectanglePerimeter.ts
@@ -23,6 +23,8 @@ import type { PerimeterFunction } from '../../../types';
 
 /**
  * Describes a rectangular perimeter for the given bounds.
+ *
+ * @category Perimeter
  */
 export const RectanglePerimeter: PerimeterFunction = (
   bounds: Rectangle,

--- a/packages/core/src/view/style/perimeter/RhombusPerimeter.ts
+++ b/packages/core/src/view/style/perimeter/RhombusPerimeter.ts
@@ -22,6 +22,9 @@ import Point from '../../geometry/Point';
 import type { PerimeterFunction } from '../../../types';
 import { intersection } from '../../../util/mathUtils';
 
+/**
+ * @category Perimeter
+ */
 export const RhombusPerimeter: PerimeterFunction = (
   bounds: Rectangle,
   _vertex: CellState,

--- a/packages/core/src/view/style/perimeter/TrianglePerimeter.ts
+++ b/packages/core/src/view/style/perimeter/TrianglePerimeter.ts
@@ -23,6 +23,9 @@ import type { PerimeterFunction } from '../../../types';
 import { DIRECTION } from '../../../util/Constants';
 import { intersection } from '../../../util/mathUtils';
 
+/**
+ * @category Perimeter
+ */
 export const TrianglePerimeter: PerimeterFunction = (
   bounds: Rectangle,
   vertex: CellState,

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -17,7 +17,7 @@
     "readme": "none",
     "excludeExternals": true,
     "excludePrivate": true,
-    "categoryOrder": ["Configuration", "Logging", "Edge Shapes", "Vertex Shapes", "Serialization with Codecs", "*"],
+    "categoryOrder": ["Configuration", "Logging", "Edge Shapes", "Vertex Shapes", "Perimeter", "Serialization with Codecs", "*"],
     "categorizeByGroup": false,
     "navigation": {
       "includeCategories": false, // not enough categories to warrant this


### PR DESCRIPTION
Better group related elements in HTML API documentation.