### PR TITLE
refactor(typescript): use generic when calling Graph.getPlugin

### DIFF
--- a/packages/core/src/view/GraphView.ts
+++ b/packages/core/src/view/GraphView.ts
@@ -43,7 +43,7 @@ import { getClientX, getClientY, getSource, isConsumed } from '../util/EventUtil
 import { clone } from '../util/cloneUtils';
 import type { Graph } from './Graph';
 import StyleRegistry from './style/StyleRegistry';
-import TooltipHandler from './handler/TooltipHandler';
+import type TooltipHandler from './handler/TooltipHandler';
 import type { EdgeStyleFunction, MouseEventListener } from '../types';
 
 /**
@@ -2167,7 +2167,7 @@ export class GraphView extends EventSource {
     });
 
     this.moveHandler = (evt: MouseEvent) => {
-      const tooltipHandler = graph.getPlugin('TooltipHandler') as TooltipHandler;
+      const tooltipHandler = graph.getPlugin<TooltipHandler>('TooltipHandler');
 
       // Hides the tooltip if mouse is outside container
       if (tooltipHandler && tooltipHandler.isHideOnHover()) {

--- a/packages/core/src/view/mixins/ConnectionsMixin.ts
+++ b/packages/core/src/view/mixins/ConnectionsMixin.ts
@@ -23,7 +23,7 @@ import EventObject from '../event/EventObject';
 import InternalEvent from '../event/InternalEvent';
 import Dictionary from '../../util/Dictionary';
 import type { Graph } from '../Graph';
-import ConnectionHandler from '../handler/ConnectionHandler';
+import type ConnectionHandler from '../handler/ConnectionHandler';
 
 type PartialGraph = Pick<Graph, 'getView' | 'getDataModel' | 'isPortsEnabled'>;
 type PartialConnections = Pick<
@@ -511,12 +511,12 @@ export const ConnectionsMixin: PartialType = {
   },
 
   setConnectable(connectable) {
-    const connectionHandler = this.getPlugin('ConnectionHandler') as ConnectionHandler;
+    const connectionHandler = this.getPlugin<ConnectionHandler>('ConnectionHandler');
     connectionHandler?.setEnabled(connectable);
   },
 
   isConnectable() {
-    const connectionHandler = this.getPlugin('ConnectionHandler') as ConnectionHandler;
+    const connectionHandler = this.getPlugin<ConnectionHandler>('ConnectionHandler');
     return connectionHandler?.isEnabled() ?? false;
   },
 };

--- a/packages/core/src/view/mixins/EditingMixin.ts
+++ b/packages/core/src/view/mixins/EditingMixin.ts
@@ -74,9 +74,7 @@ export const EditingMixin: PartialType = {
           new EventObject(InternalEvent.START_EDITING, { cell, event: evt })
         );
 
-        const cellEditorHandler = this.getPlugin(
-          'CellEditorHandler'
-        ) as CellEditorHandler;
+        const cellEditorHandler = this.getPlugin<CellEditorHandler>('CellEditorHandler');
         cellEditorHandler?.startEditing(cell, evt);
 
         this.fireEvent(
@@ -91,7 +89,7 @@ export const EditingMixin: PartialType = {
   },
 
   stopEditing(cancel = false) {
-    const cellEditorHandler = this.getPlugin('CellEditorHandler') as CellEditorHandler;
+    const cellEditorHandler = this.getPlugin<CellEditorHandler>('CellEditorHandler');
     cellEditorHandler?.stopEditing(cancel);
     this.fireEvent(new EventObject(InternalEvent.EDITING_STOPPED, { cancel }));
   },
@@ -127,7 +125,7 @@ export const EditingMixin: PartialType = {
    *****************************************************************************/
 
   isEditing(cell = null) {
-    const cellEditorHandler = this.getPlugin('CellEditorHandler') as CellEditorHandler;
+    const cellEditorHandler = this.getPlugin<CellEditorHandler>('CellEditorHandler');
     const editingCell = cellEditorHandler?.getEditingCell();
     return !cell ? !!editingCell : cell === editingCell;
   },

--- a/packages/core/src/view/mixins/EventsMixin.ts
+++ b/packages/core/src/view/mixins/EventsMixin.ts
@@ -34,15 +34,15 @@ import {
 } from '../../util/EventUtils';
 import CellState from '../cell/CellState';
 import Cell from '../cell/Cell';
-import PanningHandler from '../handler/PanningHandler';
-import ConnectionHandler from '../handler/ConnectionHandler';
+import type PanningHandler from '../handler/PanningHandler';
+import type ConnectionHandler from '../handler/ConnectionHandler';
 import Point from '../geometry/Point';
 import { convertPoint } from '../../util/styleUtils';
 import { NONE } from '../../util/Constants';
 import Client from '../../Client';
-import CellEditorHandler from '../handler/CellEditorHandler';
+import type CellEditorHandler from '../handler/CellEditorHandler';
 import type { Graph } from '../Graph';
-import TooltipHandler from '../handler/TooltipHandler';
+import type TooltipHandler from '../handler/TooltipHandler';
 
 type PartialGraph = Pick<
   Graph,
@@ -338,8 +338,8 @@ export const EventsMixin: PartialType = {
       cell: me.getCell(),
     });
 
-    const panningHandler = this.getPlugin('PanningHandler') as PanningHandler;
-    const connectionHandler = this.getPlugin('ConnectionHandler') as ConnectionHandler;
+    const panningHandler = this.getPlugin<PanningHandler>('PanningHandler');
+    const connectionHandler = this.getPlugin<ConnectionHandler>('ConnectionHandler');
 
     // LATER: Check if event should be consumed if me is consumed
     this.fireEvent(mxe);
@@ -576,7 +576,7 @@ export const EventsMixin: PartialType = {
     sender = sender ?? (this as Graph);
 
     if (this.isEventSourceIgnored(evtName, me)) {
-      const tooltipHandler = this.getPlugin('TooltipHandler') as TooltipHandler;
+      const tooltipHandler = this.getPlugin<TooltipHandler>('TooltipHandler');
       if (tooltipHandler) {
         tooltipHandler.hide();
       }
@@ -758,7 +758,7 @@ export const EventsMixin: PartialType = {
           Math.abs(this.initialTouchY - me.getGraphY()) < this.tolerance;
       }
 
-      const cellEditorHandler = this.getPlugin('CellEditorHandler') as CellEditorHandler;
+      const cellEditorHandler = this.getPlugin<CellEditorHandler>('CellEditorHandler');
 
       // Stops editing for all events other than from cellEditorHandler
       if (

--- a/packages/core/src/view/mixins/PanningMixin.ts
+++ b/packages/core/src/view/mixins/PanningMixin.ts
@@ -17,11 +17,11 @@ limitations under the License.
 import { hasScrollbars } from '../../util/styleUtils';
 import EventObject from '../event/EventObject';
 import InternalEvent from '../event/InternalEvent';
-import PanningHandler from '../handler/PanningHandler';
+import type PanningHandler from '../handler/PanningHandler';
 import { Graph } from '../Graph';
 import Rectangle from '../geometry/Rectangle';
 import Point from '../geometry/Point';
-import SelectionCellsHandler from '../handler/SelectionCellsHandler';
+import type SelectionCellsHandler from '../handler/SelectionCellsHandler';
 
 type PartialGraph = Pick<Graph, 'getContainer' | 'getView' | 'getPlugin' | 'fireEvent'>;
 type PartialPanning = Pick<
@@ -292,9 +292,9 @@ export const PanningMixin: PartialType = {
       if (isChanged) {
         this.getView().refresh();
 
-        const selectionCellsHandler = this.getPlugin(
+        const selectionCellsHandler = this.getPlugin<SelectionCellsHandler>(
           'SelectionCellsHandler'
-        ) as SelectionCellsHandler;
+        );
 
         // Repaints selection marker (ticket 18)
         if (selectionCellsHandler) {
@@ -307,7 +307,7 @@ export const PanningMixin: PartialType = {
   },
 
   setPanning(enabled) {
-    const panningHandler = this.getPlugin('PanningHandler') as PanningHandler;
+    const panningHandler = this.getPlugin<PanningHandler>('PanningHandler');
     panningHandler && (panningHandler.panningEnabled = enabled);
   },
 };

--- a/packages/core/src/view/mixins/PanningMixin.type.ts
+++ b/packages/core/src/view/mixins/PanningMixin.type.ts
@@ -109,6 +109,8 @@ declare module '../Graph' {
     /**
      * Specifies if panning should be enabled. This implementation updates {@link PanningHandler.panningEnabled}.
      *
+     **IMPORTANT**: only has an effect if the {@link PanningHandler} plugin is available.
+     *
      * @param enabled Boolean indicating if panning should be enabled.
      */
     setPanning: (enabled: boolean) => void;

--- a/packages/core/src/view/mixins/TooltipMixin.ts
+++ b/packages/core/src/view/mixins/TooltipMixin.ts
@@ -53,9 +53,9 @@ export const TooltipMixin: PartialType = {
     }
 
     if (!tip) {
-      const selectionCellsHandler = this.getPlugin(
+      const selectionCellsHandler = this.getPlugin<SelectionCellsHandler>(
         'SelectionCellsHandler'
-      ) as SelectionCellsHandler;
+      );
 
       const handler = selectionCellsHandler?.getHandler(state.cell);
 
@@ -89,7 +89,7 @@ export const TooltipMixin: PartialType = {
   },
 
   setTooltips(enabled: boolean) {
-    const tooltipHandler = this.getPlugin('TooltipHandler') as TooltipHandler;
+    const tooltipHandler = this.getPlugin<TooltipHandler>('TooltipHandler');
     tooltipHandler?.setEnabled(enabled);
   },
 };

--- a/packages/core/src/view/mixins/TooltipMixin.type.ts
+++ b/packages/core/src/view/mixins/TooltipMixin.type.ts
@@ -57,7 +57,7 @@ declare module '../Graph' {
      *
      * Replaces all tooltips with the string Hello, World!
      *
-     * @param cell {@link mxCell} whose tooltip should be returned.
+     * @param cell {@link Cell} whose tooltip should be returned.
      */
     getTooltipForCell: (cell: Cell) => HTMLElement | string;
 
@@ -65,6 +65,8 @@ declare module '../Graph' {
      * Specifies if tooltips should be enabled.
      *
      * This implementation updates {@link TooltipHandler.enabled}.
+     *
+     * **IMPORTANT**: only has an effect if the {@link TooltipHandler} plugin is available.
      *
      * @param enabled Boolean indicating if tooltips should be enabled.
      */


### PR DESCRIPTION
The code has not been fully migrated in commit 08fb37e7.