### PR TITLE
docs: shorten the title of the "migrate from mxGraph" page

### DIFF
--- a/packages/website/docs/usage/migrate-from-mxgraph.md
+++ b/packages/website/docs/usage/migrate-from-mxgraph.md
@@ -3,7 +3,7 @@ sidebar_position: 10
 description: How-to easily migrate from mxGraph to maxGraph
 ---
 
-# Migrate from mxGraph to maxGraph
+# Migrate from mxGraph
 
 This documentation provides instructions for migrating from `mxGraph` to `maxGraph`.
 It includes information about application setup changes, code changes, styles, event handling and other relevant information.
@@ -152,8 +152,15 @@ In maxGraph@0.11.0, the `allowEval` and `defaultLocalized` properties have been 
 ### `mxUtils` split
 Several functions in `mxUtils` have been moved to their own namespaces in `maxGraph`. Some remain in `utils`.
 
+Here are a few examples of the methods that have been moved.
+
 #### `domUtils`
 - `extractTextWithWhitespace()`: : Update your code to use `domUtils.extractTextWithWhitespace()` instead of `mxUtils.extractTextWithWhitespace()`.
+
+#### `mathUtils`
+- `getBoundingBox()`: Update your code to use `mathUtils.getBoundingBox()` instead of `mxUtils.getBoundingBox()`.
+- `getPortConstraints()`: Update your code to use `mathUtils.getPortConstraints()` instead of `mxUtils.getPortConstraints()`.
+- `getRotatedPoint()`: Update your code to use `mathUtils.getRotatedPoint()` instead of `mxUtils.getRotatedPoint()`.
 
 #### `stringUtils`
 - `trim()`: Update your code to use `stringUtils.trim()` instead of `mxUtils.trim()`.


### PR DESCRIPTION
This fits better in the left navigation menu, and there is no need to mention the target (maxGraph),
as the documentation applies to maxGraph, so it is implicit and clear enough.

Also add information about the methods which moved from mxUtils to mathUtils.

### Screenshots

before | now
---- | ----
![image](https://github.com/user-attachments/assets/c49416d0-79bd-4318-89e2-b8caafd8beae) | ![image](https://github.com/user-attachments/assets/48f4a7ab-5700-4b6a-ac6a-1f82ec23cb82)


