### PR TITLE
fix(PrintPreview): Execute writeHead even if css is null

### DIFF
--- a/packages/core/src/view/other/PrintPreview.ts
+++ b/packages/core/src/view/other/PrintPreview.ts
@@ -422,9 +422,7 @@ class PrintPreview {
         doc.writeln('<html>');
 
         doc.writeln('<head>');
-
         this.writeHead(doc, css);
-
         doc.writeln('</head>');
         doc.writeln('<body class="mxPage">');
       }
@@ -646,8 +644,8 @@ class PrintPreview {
     // position (absolute) needs to be updated in IE (see below)
     doc.writeln(
       '  table.mxPageSelector { position: fixed; right: 10px; top: 10px;' +
-      'font-family: Arial; font-size:10pt; border: solid 1px darkgray;' +
-      'background: white; border-collapse:collapse; }'
+        'font-family: Arial; font-size:10pt; border: solid 1px darkgray;' +
+        'background: white; border-collapse:collapse; }'
     );
     doc.writeln('  table.mxPageSelector td { border: solid 1px gray; padding:4px; }');
     doc.writeln('  body.mxPage { background: gray; }');

--- a/packages/core/src/view/other/PrintPreview.ts
+++ b/packages/core/src/view/other/PrintPreview.ts
@@ -422,9 +422,9 @@ class PrintPreview {
         doc.writeln('<html>');
 
         doc.writeln('<head>');
-        if (css) {
-          this.writeHead(doc, css);
-        }
+
+        this.writeHead(doc, css);
+
         doc.writeln('</head>');
         doc.writeln('<body class="mxPage">');
       }
@@ -625,7 +625,7 @@ class PrintPreview {
    * Writes the HEAD section into the given document, without the opening
    * and closing HEAD tags.
    */
-  writeHead(doc: Document, css: string): void {
+  writeHead(doc: Document, css: string | null): void {
     if (this.title != null) {
       doc.writeln(`<title>${this.title}</title>`);
     }
@@ -646,8 +646,8 @@ class PrintPreview {
     // position (absolute) needs to be updated in IE (see below)
     doc.writeln(
       '  table.mxPageSelector { position: fixed; right: 10px; top: 10px;' +
-        'font-family: Arial; font-size:10pt; border: solid 1px darkgray;' +
-        'background: white; border-collapse:collapse; }'
+      'font-family: Arial; font-size:10pt; border: solid 1px darkgray;' +
+      'background: white; border-collapse:collapse; }'
     );
     doc.writeln('  table.mxPageSelector td { border: solid 1px gray; padding:4px; }');
     doc.writeln('  body.mxPage { background: gray; }');


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a Pull Request to maxGraph! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.

All contributions to this project are done under the terms of the Apache 2.0 license as stated in the LICENSE file located at the root of this repository.


Note: core contributors are not required to use this template.
-->

## PR Checklist

- [x] Addresses an existing open issue: This PR fixes some part of #535, but doesn't close.
- [x] You have discussed this issue with the maintainers of `maxGraph`, and you are assigned to the issue.
- [x] The scope of the PR is small enough to review in a single session. PR targeting several issues should be split into separate PRs. Don't create large PR like https://github.com/maxGraph/maxGraph/pull/88.
- [x] I have added tests to prove my fix is effective or my feature works. This can be done in the form of automatic tests in `packages/core/_tests_` or a new or altered Storybook story in `packages/html/stories` (an existing story may also demonstrate the change).
- [x] I have provided screenshot/videos to demonstrate the change. If no releavant, explain why.
- [x] ~I have added or edited necessary documentation, or~ no docs changes are needed.
- [x] The PR title follows the ["Conventional Commits"](https://www.conventionalcommits.org/en/v1.0.0/) guidelines.

<!--
The PR title must look like `<type>[optional scope]: <lower case description>`

*type* can be (see existing Pull Request for more elements):
- chore
- docs
- feat
- fix
- refactor
  ...

If defined, the _optional scope_ must be put in parentheses.

Note: The title is used as proposal for the maintainer merging the Pull Request.
-->


## Overview



This PR fixes some [parts](https://github.com/maxGraph/maxGraph/issues/535#issuecomment-2388482258) of #535 .
- fix background color and tab title are not set.

In mxgraph, argument `css` to `writeHead` was allowed to be null. Please see line 45570 in mxClient.js. I fixed signature of `PrintPreview.writeHead` and removed null check before calling `writeHead` in `PrintPreview.open`.
![スクリーンショット 2024-10-02 215432](https://github.com/user-attachments/assets/1bda1113-4faa-41f6-96d4-dc3c8af0148c)
This is a image of the tab opened after clicking 'Print' button in page break story.
![スクリーンショット 2024-10-02 214129](https://github.com/user-attachments/assets/4010e2d4-0486-4cca-bc31-cc03954faadd)
 

## Notes

Vertices and edges are not shown. This PR doesn't close 535.


