### PR TITLE
chore(package): store application resources in the `lib` folder

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 **/dist/**
+**/lib/**
 **/node_modules/**
 packages/core/build/**
 packages/core/coverage/**

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.iml
 .vscode/
 dist
+lib/
 *.tgz
 
 # dependencies

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,13 +13,13 @@
     "graph",
     "svg"
   ],
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "module": "lib/index.js",
+  "types": "lib/index.d.ts",
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
       }
     },
     "./css/*": "./css/*",
@@ -28,7 +28,7 @@
   },
   "files": [
     "css",
-    "dist",
+    "lib",
     "images"
   ],
   "homepage": "https://github.com/maxGraph/maxGraph",
@@ -40,7 +40,7 @@
     "url": "https://github.com/maxGraph/maxGraph/issues"
   },
   "scripts": {
-    "clean": "rimraf dist",
+    "clean": "rimraf lib",
     "dev": "tsc --watch",
     "build": "tsc --version && tsc",
     "docs:api": "typedoc src/index.ts",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -6,7 +6,7 @@
     "declarationMap": false,
     "emitDeclarationOnly": false,
     "isolatedModules": true,
-    "outDir": "./dist",
+    "outDir": "./lib",
     "strict": true,
     "skipLibCheck": false,
     "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
Previously in they were stored in the `dist` folder, which is commonly used to store bundles.
`lib` is generally use to store the generated javascript code, so the npm package now follows this convention.