### PR TITLE
fix: correctly call methods in TemporaryCellStates and PrintPreview

### DIFF
--- a/packages/core/src/view/other/PrintPreview.ts
+++ b/packages/core/src/view/other/PrintPreview.ts
@@ -968,7 +968,6 @@ class PrintPreview {
       view.overlayPane = overlayPane;
       view.translate = translate;
       if (temp) {
-        console.info('@@PrintPreview temp is set --> destroy');
         temp.destroy();
       }
       view.setEventsEnabled(eventsEnabled);

--- a/packages/core/src/view/other/PrintPreview.ts
+++ b/packages/core/src/view/other/PrintPreview.ts
@@ -27,6 +27,7 @@ import { addLinkToHead, write } from '../../util/domUtils';
 import { Graph } from '../Graph';
 import CellState from '../cell/CellState';
 import Cell from '../cell/Cell';
+import { GlobalConfig } from '../../util/config';
 
 /**
  * @class PrintPreview
@@ -904,7 +905,7 @@ class PrintPreview {
           }
         }
 
-        redraw.apply(this, [state, force, rendering]); // CHECK ME!!!
+        redraw.apply(this.graph.cellRenderer, [state, force, rendering]);
       };
     }
 
@@ -917,6 +918,8 @@ class PrintPreview {
       temp = new TemporaryCellStates(view, scale, cells, null, (state: CellState) => {
         return this.getLinkForCellState(state);
       });
+    } catch (e: unknown) {
+      GlobalConfig.logger.error('PrintPreview unable to generate the preview', e);
     } finally {
       // Removes everything but the SVG node
       let tmp = <HTMLElement>div.firstChild;
@@ -965,6 +968,7 @@ class PrintPreview {
       view.overlayPane = overlayPane;
       view.translate = translate;
       if (temp) {
+        console.info('@@PrintPreview temp is set --> destroy');
         temp.destroy();
       }
       view.setEventsEnabled(eventsEnabled);


### PR DESCRIPTION
In the `PageBreaks` story, the print page failed to display the graph.
This issue was mainly caused by maxGraph core calling functions on incorrect instances.

This problem originated during the migration from mxGraph, especially when switching from regular functions to arrow functions (changing the value of `this`).

Additionally, in `TemporaryCellStates`, the correct method `oldDoRedrawShape` is now called instead of `oldValidateCellState`.
The addition of types helped in identifying this issue.

Finally, `PrintPreview` now logs errors to the global logger, allowing easier troubleshooting in the future.
The previous error was hidden, and enabling logs made it possible to trace the source of the problem.

### Notes

Closes #535

This fix is inspired by https://github.com/maxGraph/maxGraph/pull/88/commits/4ddbdf55bac99c4cdc7e03ff3722026742782eaa which partially fixed the problem.