### PR TITLE
docs: provide more information about global configuration

### DIFF
--- a/packages/core/src/view/plugins/index.ts
+++ b/packages/core/src/view/plugins/index.ts
@@ -29,6 +29,7 @@ import PanningHandler from '../handler/PanningHandler';
  * The function returns a new array each time it is called.
  *
  * @category Plugin
+ * @since 0.13.0
  */
 export const getDefaultPlugins = (): GraphPluginConstructor[] => [
   CellEditorHandler,

--- a/packages/website/docs/usage/global-configuration.md
+++ b/packages/website/docs/usage/global-configuration.md
@@ -13,10 +13,11 @@ This guide explains how to configure `maxGraph` globally. This global configurat
 The following objects can be used to configure `maxGraph` globally:
 
   - `Client`: this is the historical entry point for global configuration, coming from the `mxGraph` library.
-  - `StencilShapeConfig`: introduced in version _0.11.0_. This object is used to configure stencil shapes globally.
-  - `GlobalConfig`: introduced in version _0.11.0_.
+  - `GlobalConfig` (since 0.11.0): for shared resources (logger).
+  - `StencilShapeConfig` (since 0.11.0): for stencil shapes.
+  - `VertexHandlerConfig` (since 0.12.0): for `VertexHandler`.
 
-Notice that the new global configuration elements introduced in version _0.11.0_ are experimental and are subject to change in future versions. 
+Notice that the new global configuration elements introduced as version _0.11.0_ are experimental and are subject to change in future versions.
 
 ## Styles
 

--- a/packages/website/docs/usage/migrate-from-mxgraph.md
+++ b/packages/website/docs/usage/migrate-from-mxgraph.md
@@ -413,7 +413,7 @@ Others were removed:
 
 - Codec renaming and output: https://github.com/maxGraph/maxGraph/pull/70
 - `mxDictionary`&lt;T&gt; to `Dictionary`&lt;K, V&gt;
-
+- `mxVertexHandler.rotationEnabled` has been removed. Use `VertexHandlerConfig.rotationEnabled` instead (since `0.12.0`).
 
 ### Event handling
 


### PR DESCRIPTION
`VertexHandlerConfig` was missing.
In addition, update the JSDoc of `getDefaultPlugins` to mention the version in which it was introduced.