### PR TITLE
feat: allow usage of functions in `CellStateStyle.edgeStyle`

### DIFF
--- a/packages/core/__tests__/serialization/serialization.xml.test.ts
+++ b/packages/core/__tests__/serialization/serialization.xml.test.ts
@@ -17,7 +17,14 @@ limitations under the License.
 import { describe, expect, test } from '@jest/globals';
 import { ModelChecker } from './utils';
 import { createGraphWithoutContainer } from '../utils';
-import { Cell, Geometry, GraphDataModel, ModelXmlSerializer, Point } from '../../src';
+import {
+  Cell,
+  EdgeStyle,
+  Geometry,
+  GraphDataModel,
+  ModelXmlSerializer,
+  Point,
+} from '../../src';
 
 // inspired by VertexMixin.createVertex
 const newVertex = (id: string, value: string) => {
@@ -242,6 +249,58 @@ describe('export', () => {
         </Array>
       </Geometry>
       <Object as="style" />
+    </Cell>
+  </root>
+</GraphDataModel>
+`
+    );
+  });
+
+  test('model with edges using style.edgeStyle', () => {
+    const model = new GraphDataModel();
+    const parent = getParent(model);
+
+    const vertex1 = newVertex('v1', 'vertex 1');
+    model.add(parent, vertex1);
+    const vertex2 = newVertex('v2', 'vertex 2');
+    model.add(parent, vertex2);
+
+    const edge1 = newEdge('e1', 'edge 1');
+    // when passing a function for the edgeStyle, it is not serialized
+    edge1.setStyle({ edgeStyle: EdgeStyle.ElbowConnector, strokeColor: 'green' });
+    model.add(parent, edge1);
+    model.setTerminal(edge1, vertex1, true);
+    model.setTerminal(edge1, vertex2, false);
+
+    const edge2 = newEdge('e2', 'edge 2');
+    edge2.setStyle({ edgeStyle: 'manhattanEdgeStyle', strokeColor: 'orange' });
+    model.add(parent, edge2);
+    model.setTerminal(edge2, vertex1, false);
+    model.setTerminal(edge2, vertex2, true);
+
+    // FIX boolean values should be set to true/false instead of 1/0
+    expect(new ModelXmlSerializer(model).export()).toEqual(
+      `<GraphDataModel>
+  <root>
+    <Cell id="0">
+      <Object as="style" />
+    </Cell>
+    <Cell id="1" parent="0">
+      <Object as="style" />
+    </Cell>
+    <Cell id="v1" value="vertex 1" vertex="1" parent="1">
+      <Object as="style" />
+    </Cell>
+    <Cell id="v2" value="vertex 2" vertex="1" parent="1">
+      <Object as="style" />
+    </Cell>
+    <Cell id="e1" value="edge 1" edge="1" parent="1" source="v1" target="v2">
+      <Geometry as="geometry" />
+      <Object strokeColor="green" as="style" />
+    </Cell>
+    <Cell id="e2" value="edge 2" edge="1" parent="1" source="v2" target="v1">
+      <Geometry as="geometry" />
+      <Object edgeStyle="manhattanEdgeStyle" strokeColor="orange" as="style" />
     </Cell>
   </root>
 </GraphDataModel>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -391,12 +391,12 @@ export type CellStateStyle = {
   imageBorder?: ColorValue;
   /**
    * The value is the image height in pixels and must be greater than `0`.
-   * @default constants.DEFAULT_IMAGESIZE
+   * @default {@link DEFAULT_IMAGESIZE}
    */
   imageHeight?: number;
   /**
    * The value is the image width in pixels and must be greater than `0`.
-   * @default constants.DEFAULT_IMAGESIZE
+   * @default {@link DEFAULT_IMAGESIZE}
    */
   imageWidth?: number;
   /**
@@ -636,7 +636,7 @@ export type CellStateStyle = {
   /**
    * The type of this value is float and the value represents the size of the horizontal
    * segment of the entity relation style.
-   * @default constants.ENTITY_SEGMENT
+   * @default {@link ENTITY_SEGMENT}
    */
   segment?: number;
   /**
@@ -812,7 +812,7 @@ export type CellStateStyle = {
    */
   targetPortConstraint?: DIRECTION;
   /**
-   * @default constants.DEFAULT_TEXT_DIRECTION
+   * @default {@link DEFAULT_TEXT_DIRECTION}
    */
   textDirection?: TextDirectionValue;
   /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -172,7 +172,7 @@ export type CellStateStyle = {
    * This defines the style of the edge if the current cell is an Edge.
    *
    * The possible values are all names of the shapes registered with {@link StyleRegistry.putValue}.
-   * This includes {@link DefaultEdgeStyleValue} values and custom names that have been registered.
+   * This includes {@link EdgeStyleConnectorValue} values and custom names that have been registered.
    *
    * It is also possible to pass a {@link EdgeStyleFunction}.
    *
@@ -1177,10 +1177,10 @@ export type EdgeStyleFunction = (
 ) => void;
 
 /**
- * Names used to register the edge styles provided out-of-the-box by maxGraph with {@link StyleRegistry.putValue}.
+ * Names used to register the edge styles (a.k.a. connectors) provided out-of-the-box by maxGraph with {@link StyleRegistry.putValue}.
  * @since 0.14.0
  */
-export type DefaultEdgeStyleValue =
+export type EdgeStyleConnectorValue =
   | 'elbowEdgeStyle'
   | 'entityRelationEdgeStyle'
   | 'loopEdgeStyle'
@@ -1191,10 +1191,10 @@ export type DefaultEdgeStyleValue =
   | 'topToBottomEdgeStyle';
 
 /**
- * {@link DefaultEdgeStyleValue} with support for extensions and {@link EdgeStyleFunction}.
+ * {@link EdgeStyleConnectorValue} with support for extensions and {@link EdgeStyleFunction}.
  * @since 0.14.0
  */
-export type EdgeStyleValue = DefaultEdgeStyleValue | (string & {}) | EdgeStyleFunction;
+export type EdgeStyleValue = EdgeStyleConnectorValue | (string & {}) | EdgeStyleFunction;
 
 /**
  * @since 0.11.0

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -172,11 +172,11 @@ export type CellStateStyle = {
    * This defines the style of the edge if the current cell is an Edge.
    *
    * The possible values are all names of the shapes registered with {@link StyleRegistry.putValue}.
-   * This includes {@link EdgeStyleValue} values and custom names that have been registered.
+   * This includes {@link DefaultEdgeStyleValue} values and custom names that have been registered.
    *
    * See {@link noEdgeStyle}.
    */
-  edgeStyle?: EdgeStyleValue | (string & {}) | EdgeStyleFunction;
+  edgeStyle?: DefaultEdgeStyleValue | (string & {}) | EdgeStyleFunction;
   /**
    * This specifies if the value of a cell can be edited using the in-place editor.
    * See {@link Graph.isCellEditable}.
@@ -1178,7 +1178,7 @@ export type EdgeStyleFunction = (
  * Names used to register the edge styles provided out-of-the-box by maxGraph with {@link StyleRegistry.putValue}.
  * @since 0.14.0
  */
-export type EdgeStyleValue =
+export type DefaultEdgeStyleValue =
   | 'elbowEdgeStyle'
   | 'entityRelationEdgeStyle'
   | 'loopEdgeStyle'

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -171,11 +171,12 @@ export type CellStateStyle = {
   /**
    * This defines the style of the edge if the current cell is an Edge.
    *
-   * The possible values for the style provided out-of-the box by maxGraph are defined in {@link EDGESTYLE}.
+   * The possible values are all names of the shapes registered with {@link StyleRegistry.putValue}.
+   * This includes {@link EdgeStyleValue} values and custom names that have been registered.
    *
    * See {@link noEdgeStyle}.
    */
-  edgeStyle?: string;
+  edgeStyle?: EdgeStyleValue | (string & {}) | EdgeStyleFunction;
   /**
    * This specifies if the value of a cell can be edited using the in-place editor.
    * See {@link Graph.isCellEditable}.
@@ -1172,6 +1173,20 @@ export type EdgeStyleFunction = (
   points: Point[],
   result: Point[]
 ) => void;
+
+/**
+ * Names used to register the edge styles provided out-of-the-box by maxGraph with {@link StyleRegistry.putValue}.
+ * @since 0.14.0
+ */
+export type EdgeStyleValue =
+  | 'elbowEdgeStyle'
+  | 'entityRelationEdgeStyle'
+  | 'loopEdgeStyle'
+  | 'manhattanEdgeStyle'
+  | 'orthogonalEdgeStyle'
+  | 'segmentEdgeStyle'
+  | 'sideToSideEdgeStyle'
+  | 'topToBottomEdgeStyle';
 
 /**
  * @since 0.11.0

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -174,9 +174,11 @@ export type CellStateStyle = {
    * The possible values are all names of the shapes registered with {@link StyleRegistry.putValue}.
    * This includes {@link DefaultEdgeStyleValue} values and custom names that have been registered.
    *
+   * It is also possible to pass a {@link EdgeStyleFunction}.
+   *
    * See {@link noEdgeStyle}.
    */
-  edgeStyle?: DefaultEdgeStyleValue | (string & {}) | EdgeStyleFunction;
+  edgeStyle?: EdgeStyleValue;
   /**
    * This specifies if the value of a cell can be edited using the in-place editor.
    * See {@link Graph.isCellEditable}.
@@ -1187,6 +1189,12 @@ export type DefaultEdgeStyleValue =
   | 'segmentEdgeStyle'
   | 'sideToSideEdgeStyle'
   | 'topToBottomEdgeStyle';
+
+/**
+ * {@link DefaultEdgeStyleValue} with support for extensions and {@link EdgeStyleFunction}.
+ * @since 0.14.0
+ */
+export type EdgeStyleValue = DefaultEdgeStyleValue | (string & {}) | EdgeStyleFunction;
 
 /**
  * @since 0.11.0

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -172,13 +172,13 @@ export type CellStateStyle = {
    * This defines the style of the edge if the current cell is an Edge.
    *
    * The possible values are all names of the shapes registered with {@link StyleRegistry.putValue}.
-   * This includes {@link EdgeStyleConnectorValue} values and custom names that have been registered.
+   * This includes {@link EdgeStyleValue} values and custom names that have been registered.
    *
    * It is also possible to pass a {@link EdgeStyleFunction}.
    *
    * See {@link noEdgeStyle}.
    */
-  edgeStyle?: EdgeStyleValue;
+  edgeStyle?: StyleEdgeStyleValue;
   /**
    * This specifies if the value of a cell can be edited using the in-place editor.
    * See {@link Graph.isCellEditable}.
@@ -1180,7 +1180,7 @@ export type EdgeStyleFunction = (
  * Names used to register the edge styles (a.k.a. connectors) provided out-of-the-box by maxGraph with {@link StyleRegistry.putValue}.
  * @since 0.14.0
  */
-export type EdgeStyleConnectorValue =
+export type EdgeStyleValue =
   | 'elbowEdgeStyle'
   | 'entityRelationEdgeStyle'
   | 'loopEdgeStyle'
@@ -1191,10 +1191,14 @@ export type EdgeStyleConnectorValue =
   | 'topToBottomEdgeStyle';
 
 /**
- * {@link EdgeStyleConnectorValue} with support for extensions and {@link EdgeStyleFunction}.
+ * {@link EdgeStyleValue} with support for extensions and {@link EdgeStyleFunction}.
  * @since 0.14.0
  */
-export type EdgeStyleValue = EdgeStyleConnectorValue | (string & {}) | EdgeStyleFunction;
+export type StyleEdgeStyleValue =
+  | EdgeStyleFunction
+  | EdgeStyleValue
+  | (string & {})
+  | null;
 
 /**
  * @since 0.11.0

--- a/packages/core/src/view/style/EdgeStyle.ts
+++ b/packages/core/src/view/style/EdgeStyle.ts
@@ -46,28 +46,24 @@ import { TopToBottom as TopToBottomFunction } from './edge/TopToBottom';
 /**
  * Provides various edge styles to be used as the values for `edgeStyle` in a cell style.
  *
- * Example:
+ * The following example sets the default edge style to `ElbowConnector`:
  *
  * ```javascript
- * let style = stylesheet.getDefaultEdgeStyle();
+ * const style = stylesheet.getDefaultEdgeStyle();
  * style.edgeStyle = EdgeStyle.ElbowConnector;
  * ```
  *
- * Sets the default edge style to `ElbowConnector`.
- *
- * Custom edge style:
- *
- * To write a custom edge style, a function must be added to the EdgeStyle object as follows:
+ * To write a custom edge style, a function can be added to the `EdgeStyle` object as follows.
+ * In the example below, a right angle is created using a point on the horizontal center of the target vertex and the vertical center of the source vertex.
+ * The code checks if that point intersects the source vertex and makes the edge straight if it does.
+ * The point is then added into the result array, which acts as the return value of the function.
  *
  * ```javascript
- * EdgeStyle.MyStyle = (state, source, target, points, result)=>
- * {
- *   if (source != null && target != null)
- *   {
- *     let pt = new Point(target.getCenterX(), source.getCenterY());
+ * EdgeStyle.MyStyle = (state, source, target, points, result) => {
+ *   if (source && target) {
+ *     const pt = new Point(target.getCenterX(), source.getCenterY());
  *
- *     if (Utils.contains(source, pt.x, pt.y))
- *     {
+ *     if (mathUtils.contains(source, pt.x, pt.y)) {
  *       pt.y = source.y + source.height;
  *     }
  *
@@ -76,38 +72,30 @@ import { TopToBottom as TopToBottomFunction } from './edge/TopToBottom';
  * };
  * ```
  *
- * In the above example, a right angle is created using a point on the
- * horizontal center of the target vertex and the vertical center of the source
- * vertex. The code checks if that point intersects the source vertex and makes
- * the edge straight if it does. The point is then added into the result array,
- * which acts as the return value of the function.
- *
- * The new edge style should then be registered in the {@link StyleRegistry} as follows:
+ * The new edge style can then be registered in the {@link StyleRegistry} as follows:
  * ```javascript
  * StyleRegistry.putValue('myEdgeStyle', EdgeStyle.MyStyle);
  * ```
  *
  * The custom edge style above can now be used in a specific edge as follows:
- *
  * ```javascript
  * style.edgeStyle = 'myEdgeStyle';
  * ```
  *
- * Note that the key of the {@link StyleRegistry} entry for the function should
- * be used in string values, unless {@link GraphView#allowEval} is true, in
- * which case you can also use `EdgeStyle.MyStyle` for the value in the
- * cell style above.
+ * The key of the {@link StyleRegistry} entry for the function should be used in the {@link CellState.edgeStyle} values, unless {@link GraphView#allowEval} is `true.
+ * In this case, you can also use the `'EdgeStyle.MyStyle'` string for the value in the cell style above.
  *
- * Or it can be used for all edges in the graph as follows:
+ * The custom EdgeStyle can be used for all edges in the graph as follows:
  *
  * ```javascript
  * let style = graph.getStylesheet().getDefaultEdgeStyle();
  * style.edgeStyle = EdgeStyle.MyStyle;
  * ```
  *
- * Note that the object can be used directly when programmatically setting
- * the value, but the key in the {@link StyleRegistry} should be used when
- * setting the value via a key, value pair in a cell style.
+ * It can also be used directly when setting the value of the `edgeStyle` key in a style of a specific edge as follows:
+ * ```javascript
+ * style.edgeStyle = EdgeStyle.MyStyle;
+ * ```
  */
 class EdgeStyle {
   /**

--- a/packages/html/stories/Folding.stories.ts
+++ b/packages/html/stories/Folding.stories.ts
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { constants, Graph, LayoutManager, StackLayout } from '@maxgraph/core';
+import { constants, EdgeStyle, Graph, LayoutManager, StackLayout } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
 import {
   configureExpandedAndCollapsedImages,
@@ -57,9 +57,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
 
   // Sets global styles
   let style = graph.getStylesheet().getDefaultEdgeStyle();
-  // TODO was working in mxGraph, currently edgeStyle must be a string, but passing the function works at runtime
-  // style.edgeStyle = EdgeStyle.EntityRelation;
-  style.edgeStyle = constants.EDGESTYLE.ENTITY_RELATION;
+  style.edgeStyle = EdgeStyle.EntityRelation;
   style.rounded = true;
 
   style = graph.getStylesheet().getDefaultVertexStyle();

--- a/packages/html/stories/HelloPort.stories.ts
+++ b/packages/html/stories/HelloPort.stories.ts
@@ -65,7 +65,6 @@ const Template = ({ label, ...args }: Record<string, string>) => {
 
   // Sets the default edge style
   const style = graph.getStylesheet().getDefaultEdgeStyle();
-  // @ts-ignore TODO fix the type, this works
   style.edgeStyle = EdgeStyle.ElbowConnector;
 
   // Ports are not used as terminals for edges, they are

--- a/packages/html/stories/Monitor.stories.ts
+++ b/packages/html/stories/Monitor.stories.ts
@@ -19,6 +19,7 @@ import {
   CellOverlay,
   cloneUtils,
   DomHelpers,
+  EdgeStyle,
   Graph,
   type ImageBox,
   InternalEvent,
@@ -378,9 +379,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
     style.fontStyle = 1; // bold
 
     style = graph.getStylesheet().getDefaultEdgeStyle();
-    // TODO was working in mxGraph, currently edgeStyle must be a string, but passing the function works at runtime
-    // style.edgeStyle = EdgeStyle.ElbowConnector;
-    style.edgeStyle = 'elbowEdgeStyle';
+    style.edgeStyle = EdgeStyle.ElbowConnector;
     style.strokeColor = '#808080';
     style.rounded = true;
     // style.shadow = true; // TMP disable until we can change the shadow color

--- a/packages/html/stories/UserObject.stories.ts
+++ b/packages/html/stories/UserObject.stories.ts
@@ -204,7 +204,6 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   style = graph.getStylesheet().getDefaultEdgeStyle();
   style.strokeColor = '#0C0C0C';
   style.labelBackgroundColor = 'white';
-  // @ts-ignore TODO fix the type, this works
   style.edgeStyle = EdgeStyle.ElbowConnector;
   style.rounded = true;
   style.fontColor = 'black';


### PR DESCRIPTION
This was working but the type definition didn't allow it.
Some stories (mainly written in JavaScript) were already configured to use it. Some TypeScript
stories are now using it as well.

The actual support for the usage of a function was already implemented in `GraphView.getEdgeStyle`.

Also improve the JSDoc of EdgeStyle, in particular, code examples.