### PR TITLE
fix: improve the panning on iOS/iPadOS

### DIFF
--- a/packages/core/src/view/GraphView.ts
+++ b/packages/core/src/view/GraphView.ts
@@ -2023,21 +2023,18 @@ export class GraphView extends EventSource {
     );
   }
 
-  /**
-   * Returns true if the event origin is one of the scrollbars of the
-   * container in IE. Such events are ignored.
-   */
   isScrollEvent(evt: MouseEvent | TouchEvent) {
     const graph = this.graph;
     const offset = getOffset(graph.container);
-    let points = [0, 0];
-    if (evt instanceof MouseEvent) {
-      points = [evt.clientX, evt.clientY];
-    } else if (evt instanceof TouchEvent) {
-      points = [evt.touches[0].clientX, evt.touches[0].clientY];
-    }
+    const eventClientPosition =
+      evt instanceof MouseEvent
+        ? [evt.clientX, evt.clientY]
+        : [evt.touches[0].clientX, evt.touches[0].clientY];
 
-    const pt = new Point(points[0] - offset.x, points[1] - offset.y);
+    const pt = new Point(
+      eventClientPosition[0] - offset.x,
+      eventClientPosition[1] - offset.y
+    );
     const container = graph.container;
 
     const outWidth = container.offsetWidth;

--- a/packages/core/src/view/GraphView.ts
+++ b/packages/core/src/view/GraphView.ts
@@ -2027,10 +2027,17 @@ export class GraphView extends EventSource {
    * Returns true if the event origin is one of the scrollbars of the
    * container in IE. Such events are ignored.
    */
-  isScrollEvent(evt: MouseEvent) {
+  isScrollEvent(evt: MouseEvent | TouchEvent) {
     const graph = this.graph;
     const offset = getOffset(graph.container);
-    const pt = new Point(evt.clientX - offset.x, evt.clientY - offset.y);
+    let points = [0, 0];
+    if (evt instanceof MouseEvent) {
+      points = [evt.clientX, evt.clientY];
+    } else if (evt instanceof TouchEvent) {
+      points = [evt.touches[0].clientX, evt.touches[0].clientY];
+    }
+
+    const pt = new Point(points[0] - offset.x, points[1] - offset.y);
     const container = graph.container;
 
     const outWidth = container.offsetWidth;


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a Pull Request to maxGraph! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.

All contributions to this project are done under the terms of the Apache 2.0 license as stated in the LICENSE file located at the root of this repository.


Note: core contributors are not required to use this template.
-->

## PR Checklist

- [x] Addresses an existing open issue: improves pinch to zoom  #62. This doesn't completely resolve it since this only works in Safari but it improves UX a ton.
- [x] You have discussed this issue with the maintainers of `maxGraph`, and you are assigned to the issue. ℹ️ discussed in #562
- [x] The scope of the PR is sufficiently narrow to be examined in a single session. A PR covering several issues must be split into separate PRs. Do not create a large PR, otherwise it cannot be reviewed and you will be asked to split it later or the PR will be closed.
- [x] I have added tests to prove my fix is effective or my feature works. This can be done in the form of automatic tests in `packages/core/_tests_` or a new or altered Storybook story in `packages/html/stories` (an existing story may also demonstrate the change).
- [x] I have provided screenshot/videos to demonstrate the change. If no releavant, explain why.
- [x] ~~I have added or edited necessary documentation,~~ or no docs changes are needed.
- [x] The PR title follows the ["Conventional Commits"](https://www.conventionalcommits.org/en/v1.0.0/) guidelines.

<!--
The PR title must look like `<type>[optional scope]: <lower case description>`

*type* can be (see existing Pull Request for more elements):
- chore
- docs
- feat
- fix
- refactor
  ...

If defined, the _optional scope_ must be put in parentheses.

Note: The title is used as proposal for the maintainer merging the Pull Request.
-->


## Overview

Current definition of isScrollEvent assumes that the event "evt" passed to function would be MouseEvent. If the evt was triggered from Touch Device(in my case iPad Air)  it would pass TouchEvent which doesn't directly have access to clientX and clientY which was causing the function to throw error "Invalid X supplied" when creating a new Point.

<!-- Description of what and why is changed, and how the code change does that. -->
This PR fixes some parts of #62 .
fix isScrollEvent targeting clientX and clientY on TouchEvents and causing error which affected Panning motions on Safari(iPad).

While zoom in and out using two fingers kinda worked, moving the graph using 2 fingers caused twitching of the box. Same happened with using three fingers. Here is an example when using the `AutoLayout` story:

https://github.com/user-attachments/assets/355fbbaa-1e51-4136-8694-22c44847b9a0

After the changes:

https://github.com/user-attachments/assets/02ff463c-8566-4d2f-bf34-3aa7e0748cf3



## Notes

I've tested this on desktop in few browsers and Android Tablets. They all pass either MouseEvent or PointerEvent and are going inside the if with condition "evt instanceof MouseEvent". It seemed to be working the same while on iPad I got much better results regarding UX while Panning.



