### PR TITLE
fix(label): improve editing position and 'label changed" event

### DIFF
--- a/packages/core/src/view/handler/CellEditorHandler.ts
+++ b/packages/core/src/view/handler/CellEditorHandler.ts
@@ -312,7 +312,7 @@ class CellEditorHandler implements GraphPlugin {
       this.textarea.style.minHeight = '1em';
     }
 
-    this.textarea.style.position = 'relative';
+    this.textarea.style.position = 'absolute';
     this.installListeners(this.textarea);
   }
 
@@ -854,7 +854,6 @@ class CellEditorHandler implements GraphPlugin {
       const initial = this.initialValue;
       this.initialValue = null;
       this.editingCell = null;
-      this.trigger = null;
       this.bounds = null;
       textarea.blur();
       clearSelection();
@@ -882,7 +881,7 @@ class CellEditorHandler implements GraphPlugin {
           }
         });
       }
-
+      this.trigger = null;
       // Forces new instance on next edit for undo history reset
       if (this.textarea) InternalEvent.release(this.textarea);
 


### PR DESCRIPTION
Updated the Editing story and CellMixing to make Editing storywork. Vertex is now editable and value is saved after stopEditing has been called.

<!--
👋 Hi, thanks for sending a Pull Request to maxGraph! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.

All contributions to this project are done under the terms of the Apache 2.0 license as stated in the LICENSE file located at the root of this repository.


Note: core contributors are not required to use this template.
-->

## PR Checklist

- [x] Addresses an existing open issue: Fixes #544.
- [ ] You have discussed this issue with the maintainers of `maxGraph`, and you are assigned to the issue.
- [x] The scope of the PR is sufficiently narrow to be examined in a single session. A PR covering several issues must be split into separate PRs. Do not create a large PR, otherwise it cannot be reviewed and you will be asked to split it later or the PR will be closed.
- [x] I have added tests to prove my fix is effective or my feature works. This can be done in the form of automatic tests in `packages/core/_tests_` or a new or altered Storybook story in `packages/html/stories` (an existing story may also demonstrate the change).
- [x] I have provided screenshot/videos to demonstrate the change. If no releavant, explain why.
- [x] I have added or edited necessary documentation, ~~or no docs changes are needed~~.
- [x] The PR title follows the ["Conventional Commits"](https://www.conventionalcommits.org/en/v1.0.0/) guidelines.

<!--
The PR title must look like `<type>[optional scope]: <lower case description>`

*type* can be (see existing Pull Request for more elements):
- chore
- docs
- feat
- fix
- refactor
  ...

If defined, the _optional scope_ must be put in parentheses.

Note: The title is used as proposal for the maintainer merging the Pull Request.
-->


## Overview
Editing story functionality after this change:

https://github.com/user-attachments/assets/e1db9ff2-f5ff-4406-9670-1f7fd56d9e51




- "editable" property for vertex in story is now true when inserting
- mxPlainTextEditor has position absolute instead of relative that prevents snappy behaviour.
- Setting trigger to null was moved after the applyValue function since applyValue had to use the original fieldName from event to update the value.


## Notes
fixes #544 



