### PR TITLE
fix: correctly use the default value of `CellStateStyle.editable`

### DIFF
--- a/packages/core/__tests__/view/mixins/EditingMixin.test.ts
+++ b/packages/core/__tests__/view/mixins/EditingMixin.test.ts
@@ -33,13 +33,13 @@ describe('isCellEditable', () => {
     ).toBeTruthy();
   });
 
-  test('Using Cell with "editable" property set to "true"', () => {
+  test('Using Cell with the "editable" style property set to "true"', () => {
     expect(
       createGraphMockingGetCurrentCellStyle(true).isCellEditable(new Cell())
     ).toBeTruthy();
   });
 
-  test('Using Cell with "editable" property set to "false"', () => {
+  test('Using Cell with the "editable" style property set to "false"', () => {
     expect(
       createGraphMockingGetCurrentCellStyle(false).isCellEditable(new Cell())
     ).toBeFalsy();

--- a/packages/core/__tests__/view/mixins/EditingMixin.test.ts
+++ b/packages/core/__tests__/view/mixins/EditingMixin.test.ts
@@ -15,12 +15,12 @@ limitations under the License.
 */
 
 import { describe, expect, jest, test } from '@jest/globals';
-import { createGraphWithoutContainer } from '../../utils';
+import { createGraphWithoutPlugins } from '../../utils';
 import { Cell, type CellStateStyle } from '../../../src';
 
 describe('isCellEditable', () => {
   const createGraphMockingGetCurrentCellStyle = (cellIsEditable?: boolean) => {
-    const graph = createGraphWithoutContainer();
+    const graph = createGraphWithoutPlugins();
     graph.getCurrentCellStyle = jest
       .fn<(cell: Cell, ignoreState?: boolean) => CellStateStyle>()
       .mockReturnValue(cellIsEditable !== undefined ? { editable: cellIsEditable } : {});
@@ -40,20 +40,19 @@ describe('isCellEditable', () => {
   });
 
   test('Using Cell with "editable" property set to "false"', () => {
-    const graph = createGraphWithoutContainer();
     expect(
       createGraphMockingGetCurrentCellStyle(false).isCellEditable(new Cell())
     ).toBeFalsy();
   });
 
   test('Cells not editable in Graph', () => {
-    const graph = createGraphWithoutContainer();
+    const graph = createGraphWithoutPlugins();
     graph.setCellsEditable(false);
     expect(graph.isCellEditable(new Cell())).toBeFalsy();
   });
 
   test('Cells locked in Graph', () => {
-    const graph = createGraphWithoutContainer();
+    const graph = createGraphWithoutPlugins();
     graph.setCellsLocked(true);
     expect(graph.isCellEditable(new Cell())).toBeFalsy();
   });

--- a/packages/core/__tests__/view/mixins/EditingMixin.test.ts
+++ b/packages/core/__tests__/view/mixins/EditingMixin.test.ts
@@ -1,0 +1,60 @@
+/*
+Copyright 2024-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, expect, jest, test } from '@jest/globals';
+import { createGraphWithoutContainer } from '../../utils';
+import { Cell, type CellStateStyle } from '../../../src';
+
+describe('isCellEditable', () => {
+  const createGraphMockingGetCurrentCellStyle = (cellIsEditable?: boolean) => {
+    const graph = createGraphWithoutContainer();
+    graph.getCurrentCellStyle = jest
+      .fn<(cell: Cell, ignoreState?: boolean) => CellStateStyle>()
+      .mockReturnValue(cellIsEditable !== undefined ? { editable: cellIsEditable } : {});
+    return graph;
+  };
+
+  test('Using defaults', () => {
+    expect(
+      createGraphMockingGetCurrentCellStyle().isCellEditable(new Cell())
+    ).toBeTruthy();
+  });
+
+  test('Using Cell with "editable" property set to "true"', () => {
+    expect(
+      createGraphMockingGetCurrentCellStyle(true).isCellEditable(new Cell())
+    ).toBeTruthy();
+  });
+
+  test('Using Cell with "editable" property set to "false"', () => {
+    const graph = createGraphWithoutContainer();
+    expect(
+      createGraphMockingGetCurrentCellStyle(false).isCellEditable(new Cell())
+    ).toBeFalsy();
+  });
+
+  test('Cells not editable in Graph', () => {
+    const graph = createGraphWithoutContainer();
+    graph.setCellsEditable(false);
+    expect(graph.isCellEditable(new Cell())).toBeFalsy();
+  });
+
+  test('Cells locked in Graph', () => {
+    const graph = createGraphWithoutContainer();
+    graph.setCellsLocked(true);
+    expect(graph.isCellEditable(new Cell())).toBeFalsy();
+  });
+});

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -181,7 +181,8 @@ export type CellStateStyle = {
   edgeStyle?: StyleEdgeStyleValue;
   /**
    * This specifies if the value of a cell can be edited using the in-place editor.
-   * See {@link Graph.isCellEditable}.
+   *
+   * Note that a cell is in fact editable according to the value returned by {@link Graph.isCellEditable}.
    * @default true
    */
   editable?: boolean;

--- a/packages/core/src/view/mixins/EditingMixin.ts
+++ b/packages/core/src/view/mixins/EditingMixin.ts
@@ -131,9 +131,10 @@ export const EditingMixin: PartialType = {
   },
 
   isCellEditable(cell): boolean {
-    const style = this.getCurrentCellStyle(cell);
     return (
-      this.isCellsEditable() && !this.isCellLocked(cell) && (style.editable || false)
+      this.isCellsEditable() &&
+      !this.isCellLocked(cell) &&
+      (this.getCurrentCellStyle(cell).editable ?? true)
     );
   },
 


### PR DESCRIPTION
`Graph.isCellEditable` considered that the default value was `false`.
The code hadn't been correctly migrated from mxGraph, see https://github.com/jgraph/mxgraph/blob/v4.2.2/javascript/src/js/view/mxGraph.js#L10542-L10557
So, to configure a Cell as "editable", the style of Cell had to be explicitly configured the editable
property to `true`.


## Notes

Covers #544
First detected in #532


