### PR TITLE
refactor(CellMixin): simplify `isCell*able` methods

### DIFF
--- a/packages/core/__tests__/utils.ts
+++ b/packages/core/__tests__/utils.ts
@@ -14,9 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Graph } from '../src';
+import { type Cell, type CellStateStyle, Graph } from '../src';
+import { jest } from '@jest/globals';
 
 // no need for a container, we don't check the view here
 export const createGraphWithoutContainer = (): Graph => new Graph(null!);
 
 export const createGraphWithoutPlugins = (): Graph => new Graph(null!, null!, []);
+
+export const createGraphMockingGetCurrentCellStyle = (style: CellStateStyle) => {
+  const graph = createGraphWithoutPlugins();
+  graph.getCurrentCellStyle = jest
+    .fn<(cell: Cell, ignoreState?: boolean) => CellStateStyle>()
+    .mockReturnValue(style);
+  return graph;
+};

--- a/packages/core/__tests__/utils.ts
+++ b/packages/core/__tests__/utils.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { type Cell, type CellStateStyle, Graph } from '../src';
+import { Cell, type CellStateStyle, Graph } from '../src';
 import { jest } from '@jest/globals';
 
 // no need for a container, we don't check the view here
@@ -22,10 +22,8 @@ export const createGraphWithoutContainer = (): Graph => new Graph(null!);
 
 export const createGraphWithoutPlugins = (): Graph => new Graph(null!, null!, []);
 
-export const createGraphMockingGetCurrentCellStyle = (style: CellStateStyle) => {
-  const graph = createGraphWithoutPlugins();
-  graph.getCurrentCellStyle = jest
-    .fn<(cell: Cell, ignoreState?: boolean) => CellStateStyle>()
-    .mockReturnValue(style);
-  return graph;
+export const createCellWithStyle = (style: CellStateStyle): Cell => {
+  const cell = new Cell();
+  cell.style = style;
+  return cell;
 };

--- a/packages/core/__tests__/view/mixins/CellMixin.test.ts
+++ b/packages/core/__tests__/view/mixins/CellMixin.test.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { describe, expect, test } from '@jest/globals';
 import { createCellWithStyle, createGraphWithoutPlugins } from '../../utils';
-import { Cell, CellStyle } from '../../../src';
+import { Cell, type CellStyle } from '../../../src';
 import { FONT } from '../../../src/util/Constants';
 
 test('setCellStyles on vertex', () => {

--- a/packages/core/__tests__/view/mixins/CellMixin.test.ts
+++ b/packages/core/__tests__/view/mixins/CellMixin.test.ts
@@ -15,10 +15,7 @@ limitations under the License.
 */
 
 import { describe, expect, test } from '@jest/globals';
-import {
-  createGraphMockingGetCurrentCellStyle,
-  createGraphWithoutPlugins,
-} from '../../utils';
+import { createCellWithStyle, createGraphWithoutPlugins } from '../../utils';
 import { Cell, CellStyle } from '../../../src';
 import { FONT } from '../../../src/util/Constants';
 
@@ -60,22 +57,18 @@ test('setCellStyleFlags on vertex', () => {
 
 describe('isAutoSizeCell', () => {
   test('Using defaults', () => {
-    expect(
-      createGraphMockingGetCurrentCellStyle({}).isAutoSizeCell(new Cell())
-    ).toBeFalsy();
+    expect(createGraphWithoutPlugins().isAutoSizeCell(new Cell())).toBeFalsy();
   });
 
   test('Using Cell with the "autoSize" style property set to "true"', () => {
     expect(
-      createGraphMockingGetCurrentCellStyle({ autoSize: true }).isAutoSizeCell(new Cell())
+      createGraphWithoutPlugins().isAutoSizeCell(createCellWithStyle({ autoSize: true }))
     ).toBeTruthy();
   });
 
   test('Using Cell with the "autoSize" style property set to "false"', () => {
     expect(
-      createGraphMockingGetCurrentCellStyle({ cloneable: false }).isAutoSizeCell(
-        new Cell()
-      )
+      createGraphWithoutPlugins().isAutoSizeCell(createCellWithStyle({ autoSize: false }))
     ).toBeFalsy();
   });
 
@@ -94,22 +87,18 @@ describe('isAutoSizeCell', () => {
 
 describe('isCellBendable', () => {
   test('Using defaults', () => {
-    expect(
-      createGraphMockingGetCurrentCellStyle({}).isCellBendable(new Cell())
-    ).toBeTruthy();
+    expect(createGraphWithoutPlugins().isCellBendable(new Cell())).toBeTruthy();
   });
 
   test('Using Cell with the "bendable" style property set to "true"', () => {
     expect(
-      createGraphMockingGetCurrentCellStyle({ bendable: true }).isCellBendable(new Cell())
+      createGraphWithoutPlugins().isCellBendable(createCellWithStyle({ bendable: true }))
     ).toBeTruthy();
   });
 
   test('Using Cell with the "bendable" style property set to "false"', () => {
     expect(
-      createGraphMockingGetCurrentCellStyle({ bendable: false }).isCellBendable(
-        new Cell()
-      )
+      createGraphWithoutPlugins().isCellBendable(createCellWithStyle({ bendable: false }))
     ).toBeFalsy();
   });
 
@@ -128,23 +117,21 @@ describe('isCellBendable', () => {
 
 describe('isCellCloneable', () => {
   test('Using defaults', () => {
-    expect(
-      createGraphMockingGetCurrentCellStyle({}).isCellCloneable(new Cell())
-    ).toBeTruthy();
+    expect(createGraphWithoutPlugins().isCellCloneable(new Cell())).toBeTruthy();
   });
 
   test('Using Cell with the "cloneable" style property set to "true"', () => {
     expect(
-      createGraphMockingGetCurrentCellStyle({ cloneable: true }).isCellCloneable(
-        new Cell()
+      createGraphWithoutPlugins().isCellCloneable(
+        createCellWithStyle({ cloneable: true })
       )
     ).toBeTruthy();
   });
 
   test('Using Cell with the "cloneable" style property set to "false"', () => {
     expect(
-      createGraphMockingGetCurrentCellStyle({ cloneable: false }).isCellCloneable(
-        new Cell()
+      createGraphWithoutPlugins().isCellCloneable(
+        createCellWithStyle({ cloneable: false })
       )
     ).toBeFalsy();
   });
@@ -158,23 +145,21 @@ describe('isCellCloneable', () => {
 
 describe('isCellDeletable', () => {
   test('Using defaults', () => {
-    expect(
-      createGraphMockingGetCurrentCellStyle({}).isCellDeletable(new Cell())
-    ).toBeTruthy();
+    expect(createGraphWithoutPlugins().isCellDeletable(new Cell())).toBeTruthy();
   });
 
   test('Using Cell with the "deletable" style property set to "true"', () => {
     expect(
-      createGraphMockingGetCurrentCellStyle({ deletable: true }).isCellDeletable(
-        new Cell()
+      createGraphWithoutPlugins().isCellDeletable(
+        createCellWithStyle({ deletable: true })
       )
     ).toBeTruthy();
   });
 
   test('Using Cell with the "deletable" style property set to "false"', () => {
     expect(
-      createGraphMockingGetCurrentCellStyle({ deletable: false }).isCellDeletable(
-        new Cell()
+      createGraphWithoutPlugins().isCellDeletable(
+        createCellWithStyle({ deletable: false })
       )
     ).toBeFalsy();
   });
@@ -188,20 +173,18 @@ describe('isCellDeletable', () => {
 
 describe('isCellMovable', () => {
   test('Using defaults', () => {
-    expect(
-      createGraphMockingGetCurrentCellStyle({}).isCellMovable(new Cell())
-    ).toBeTruthy();
+    expect(createGraphWithoutPlugins().isCellMovable(new Cell())).toBeTruthy();
   });
 
   test('Using Cell with the "movable" style property set to "true"', () => {
     expect(
-      createGraphMockingGetCurrentCellStyle({ movable: true }).isCellMovable(new Cell())
+      createGraphWithoutPlugins().isCellMovable(createCellWithStyle({ movable: true }))
     ).toBeTruthy();
   });
 
   test('Using Cell with the "movable" style property set to "false"', () => {
     expect(
-      createGraphMockingGetCurrentCellStyle({ movable: false }).isCellMovable(new Cell())
+      createGraphWithoutPlugins().isCellMovable(createCellWithStyle({ movable: false }))
     ).toBeFalsy();
   });
 
@@ -220,23 +203,21 @@ describe('isCellMovable', () => {
 
 describe('isCellResizable', () => {
   test('Using defaults', () => {
-    expect(
-      createGraphMockingGetCurrentCellStyle({}).isCellResizable(new Cell())
-    ).toBeTruthy();
+    expect(createGraphWithoutPlugins().isCellResizable(new Cell())).toBeTruthy();
   });
 
   test('Using Cell with the "resizable" style property set to "true"', () => {
     expect(
-      createGraphMockingGetCurrentCellStyle({ resizable: true }).isCellResizable(
-        new Cell()
+      createGraphWithoutPlugins().isCellResizable(
+        createCellWithStyle({ resizable: true })
       )
     ).toBeTruthy();
   });
 
   test('Using Cell with the "resizable" style property set to "false"', () => {
     expect(
-      createGraphMockingGetCurrentCellStyle({ resizable: false }).isCellResizable(
-        new Cell()
+      createGraphWithoutPlugins().isCellResizable(
+        createCellWithStyle({ resizable: false })
       )
     ).toBeFalsy();
   });
@@ -256,23 +237,21 @@ describe('isCellResizable', () => {
 
 describe('isCellRotatable', () => {
   test('Using defaults', () => {
-    expect(
-      createGraphMockingGetCurrentCellStyle({}).isCellRotatable(new Cell())
-    ).toBeTruthy();
+    expect(createGraphWithoutPlugins().isCellRotatable(new Cell())).toBeTruthy();
   });
 
   test('Using Cell with the "rotatable" style property set to "true"', () => {
     expect(
-      createGraphMockingGetCurrentCellStyle({ rotatable: true }).isCellRotatable(
-        new Cell()
+      createGraphWithoutPlugins().isCellRotatable(
+        createCellWithStyle({ rotatable: true })
       )
     ).toBeTruthy();
   });
 
   test('Using Cell with the "rotatable" style property set to "false"', () => {
     expect(
-      createGraphMockingGetCurrentCellStyle({ rotatable: false }).isCellRotatable(
-        new Cell()
+      createGraphWithoutPlugins().isCellRotatable(
+        createCellWithStyle({ rotatable: false })
       )
     ).toBeFalsy();
   });

--- a/packages/core/__tests__/view/mixins/CellMixin.test.ts
+++ b/packages/core/__tests__/view/mixins/CellMixin.test.ts
@@ -14,9 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { expect, test } from '@jest/globals';
-import { createGraphWithoutPlugins } from '../../utils';
-import type { CellStyle } from '../../../src';
+import { describe, expect, test } from '@jest/globals';
+import {
+  createGraphMockingGetCurrentCellStyle,
+  createGraphWithoutPlugins,
+} from '../../utils';
+import { Cell, CellStyle } from '../../../src';
 import { FONT } from '../../../src/util/Constants';
 
 test('setCellStyles on vertex', () => {
@@ -53,4 +56,224 @@ test('setCellStyleFlags on vertex', () => {
   graph.setCellStyleFlags('fontStyle', FONT.UNDERLINE, null, [cell]);
   expect(cell.style.fontStyle).toBe(7);
   expect(graph.getView().getState(cell)?.style?.fontStyle).toBe(7);
+});
+
+describe('isAutoSizeCell', () => {
+  test('Using defaults', () => {
+    expect(
+      createGraphMockingGetCurrentCellStyle({}).isAutoSizeCell(new Cell())
+    ).toBeFalsy();
+  });
+
+  test('Using Cell with the "autoSize" style property set to "true"', () => {
+    expect(
+      createGraphMockingGetCurrentCellStyle({ autoSize: true }).isAutoSizeCell(new Cell())
+    ).toBeTruthy();
+  });
+
+  test('Using Cell with the "autoSize" style property set to "false"', () => {
+    expect(
+      createGraphMockingGetCurrentCellStyle({ cloneable: false }).isAutoSizeCell(
+        new Cell()
+      )
+    ).toBeFalsy();
+  });
+
+  test('Cells not "autoSize" in Graph', () => {
+    const graph = createGraphWithoutPlugins();
+    graph.setAutoSizeCells(false);
+    expect(graph.isAutoSizeCell(new Cell())).toBeFalsy();
+  });
+
+  test('Cells "autoSize" in Graph', () => {
+    const graph = createGraphWithoutPlugins();
+    graph.setAutoSizeCells(true);
+    expect(graph.isAutoSizeCell(new Cell())).toBeTruthy();
+  });
+});
+
+describe('isCellBendable', () => {
+  test('Using defaults', () => {
+    expect(
+      createGraphMockingGetCurrentCellStyle({}).isCellBendable(new Cell())
+    ).toBeTruthy();
+  });
+
+  test('Using Cell with the "bendable" style property set to "true"', () => {
+    expect(
+      createGraphMockingGetCurrentCellStyle({ bendable: true }).isCellBendable(new Cell())
+    ).toBeTruthy();
+  });
+
+  test('Using Cell with the "bendable" style property set to "false"', () => {
+    expect(
+      createGraphMockingGetCurrentCellStyle({ bendable: false }).isCellBendable(
+        new Cell()
+      )
+    ).toBeFalsy();
+  });
+
+  test('Cells not "bendable" in Graph', () => {
+    const graph = createGraphWithoutPlugins();
+    graph.setCellsBendable(false);
+    expect(graph.isCellBendable(new Cell())).toBeFalsy();
+  });
+
+  test('Cells locked in Graph', () => {
+    const graph = createGraphWithoutPlugins();
+    graph.setCellsLocked(true);
+    expect(graph.isCellBendable(new Cell())).toBeFalsy();
+  });
+});
+
+describe('isCellCloneable', () => {
+  test('Using defaults', () => {
+    expect(
+      createGraphMockingGetCurrentCellStyle({}).isCellCloneable(new Cell())
+    ).toBeTruthy();
+  });
+
+  test('Using Cell with the "cloneable" style property set to "true"', () => {
+    expect(
+      createGraphMockingGetCurrentCellStyle({ cloneable: true }).isCellCloneable(
+        new Cell()
+      )
+    ).toBeTruthy();
+  });
+
+  test('Using Cell with the "cloneable" style property set to "false"', () => {
+    expect(
+      createGraphMockingGetCurrentCellStyle({ cloneable: false }).isCellCloneable(
+        new Cell()
+      )
+    ).toBeFalsy();
+  });
+
+  test('Cells not "cloneable" in Graph', () => {
+    const graph = createGraphWithoutPlugins();
+    graph.setCellsCloneable(false);
+    expect(graph.isCellCloneable(new Cell())).toBeFalsy();
+  });
+});
+
+describe('isCellDeletable', () => {
+  test('Using defaults', () => {
+    expect(
+      createGraphMockingGetCurrentCellStyle({}).isCellDeletable(new Cell())
+    ).toBeTruthy();
+  });
+
+  test('Using Cell with the "deletable" style property set to "true"', () => {
+    expect(
+      createGraphMockingGetCurrentCellStyle({ deletable: true }).isCellDeletable(
+        new Cell()
+      )
+    ).toBeTruthy();
+  });
+
+  test('Using Cell with the "deletable" style property set to "false"', () => {
+    expect(
+      createGraphMockingGetCurrentCellStyle({ deletable: false }).isCellDeletable(
+        new Cell()
+      )
+    ).toBeFalsy();
+  });
+
+  test('Cells not "deletable" in Graph', () => {
+    const graph = createGraphWithoutPlugins();
+    graph.setCellsDeletable(false);
+    expect(graph.isCellDeletable(new Cell())).toBeFalsy();
+  });
+});
+
+describe('isCellMovable', () => {
+  test('Using defaults', () => {
+    expect(
+      createGraphMockingGetCurrentCellStyle({}).isCellMovable(new Cell())
+    ).toBeTruthy();
+  });
+
+  test('Using Cell with the "movable" style property set to "true"', () => {
+    expect(
+      createGraphMockingGetCurrentCellStyle({ movable: true }).isCellMovable(new Cell())
+    ).toBeTruthy();
+  });
+
+  test('Using Cell with the "movable" style property set to "false"', () => {
+    expect(
+      createGraphMockingGetCurrentCellStyle({ movable: false }).isCellMovable(new Cell())
+    ).toBeFalsy();
+  });
+
+  test('Cells not "movable" in Graph', () => {
+    const graph = createGraphWithoutPlugins();
+    graph.setCellsMovable(false);
+    expect(graph.isCellMovable(new Cell())).toBeFalsy();
+  });
+
+  test('Cells locked in Graph', () => {
+    const graph = createGraphWithoutPlugins();
+    graph.setCellsLocked(true);
+    expect(graph.isCellMovable(new Cell())).toBeFalsy();
+  });
+});
+
+describe('isCellResizable', () => {
+  test('Using defaults', () => {
+    expect(
+      createGraphMockingGetCurrentCellStyle({}).isCellResizable(new Cell())
+    ).toBeTruthy();
+  });
+
+  test('Using Cell with the "resizable" style property set to "true"', () => {
+    expect(
+      createGraphMockingGetCurrentCellStyle({ resizable: true }).isCellResizable(
+        new Cell()
+      )
+    ).toBeTruthy();
+  });
+
+  test('Using Cell with the "resizable" style property set to "false"', () => {
+    expect(
+      createGraphMockingGetCurrentCellStyle({ resizable: false }).isCellResizable(
+        new Cell()
+      )
+    ).toBeFalsy();
+  });
+
+  test('Cells not "resizable" in Graph', () => {
+    const graph = createGraphWithoutPlugins();
+    graph.setCellsResizable(false);
+    expect(graph.isCellResizable(new Cell())).toBeFalsy();
+  });
+
+  test('Cells locked in Graph', () => {
+    const graph = createGraphWithoutPlugins();
+    graph.setCellsLocked(true);
+    expect(graph.isCellResizable(new Cell())).toBeFalsy();
+  });
+});
+
+describe('isCellRotatable', () => {
+  test('Using defaults', () => {
+    expect(
+      createGraphMockingGetCurrentCellStyle({}).isCellRotatable(new Cell())
+    ).toBeTruthy();
+  });
+
+  test('Using Cell with the "rotatable" style property set to "true"', () => {
+    expect(
+      createGraphMockingGetCurrentCellStyle({ rotatable: true }).isCellRotatable(
+        new Cell()
+      )
+    ).toBeTruthy();
+  });
+
+  test('Using Cell with the "rotatable" style property set to "false"', () => {
+    expect(
+      createGraphMockingGetCurrentCellStyle({ rotatable: false }).isCellRotatable(
+        new Cell()
+      )
+    ).toBeFalsy();
+  });
 });

--- a/packages/core/__tests__/view/mixins/EditingMixin.test.ts
+++ b/packages/core/__tests__/view/mixins/EditingMixin.test.ts
@@ -14,34 +14,31 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { describe, expect, jest, test } from '@jest/globals';
-import { createGraphWithoutPlugins } from '../../utils';
-import { Cell, type CellStateStyle } from '../../../src';
+import { describe, expect, test } from '@jest/globals';
+import {
+  createGraphMockingGetCurrentCellStyle,
+  createGraphWithoutPlugins,
+} from '../../utils';
+import { Cell } from '../../../src';
 
 describe('isCellEditable', () => {
-  const createGraphMockingGetCurrentCellStyle = (cellIsEditable?: boolean) => {
-    const graph = createGraphWithoutPlugins();
-    graph.getCurrentCellStyle = jest
-      .fn<(cell: Cell, ignoreState?: boolean) => CellStateStyle>()
-      .mockReturnValue(cellIsEditable !== undefined ? { editable: cellIsEditable } : {});
-    return graph;
-  };
-
   test('Using defaults', () => {
     expect(
-      createGraphMockingGetCurrentCellStyle().isCellEditable(new Cell())
+      createGraphMockingGetCurrentCellStyle({}).isCellEditable(new Cell())
     ).toBeTruthy();
   });
 
   test('Using Cell with the "editable" style property set to "true"', () => {
     expect(
-      createGraphMockingGetCurrentCellStyle(true).isCellEditable(new Cell())
+      createGraphMockingGetCurrentCellStyle({ editable: true }).isCellEditable(new Cell())
     ).toBeTruthy();
   });
 
   test('Using Cell with the "editable" style property set to "false"', () => {
     expect(
-      createGraphMockingGetCurrentCellStyle(false).isCellEditable(new Cell())
+      createGraphMockingGetCurrentCellStyle({ editable: false }).isCellEditable(
+        new Cell()
+      )
     ).toBeFalsy();
   });
 

--- a/packages/core/__tests__/view/mixins/EditingMixin.test.ts
+++ b/packages/core/__tests__/view/mixins/EditingMixin.test.ts
@@ -15,30 +15,23 @@ limitations under the License.
 */
 
 import { describe, expect, test } from '@jest/globals';
-import {
-  createGraphMockingGetCurrentCellStyle,
-  createGraphWithoutPlugins,
-} from '../../utils';
+import { createCellWithStyle, createGraphWithoutPlugins } from '../../utils';
 import { Cell } from '../../../src';
 
 describe('isCellEditable', () => {
   test('Using defaults', () => {
-    expect(
-      createGraphMockingGetCurrentCellStyle({}).isCellEditable(new Cell())
-    ).toBeTruthy();
+    expect(createGraphWithoutPlugins().isCellEditable(new Cell())).toBeTruthy();
   });
 
   test('Using Cell with the "editable" style property set to "true"', () => {
     expect(
-      createGraphMockingGetCurrentCellStyle({ editable: true }).isCellEditable(new Cell())
+      createGraphWithoutPlugins().isCellEditable(createCellWithStyle({ editable: true }))
     ).toBeTruthy();
   });
 
   test('Using Cell with the "editable" style property set to "false"', () => {
     expect(
-      createGraphMockingGetCurrentCellStyle({ editable: false }).isCellEditable(
-        new Cell()
-      )
+      createGraphWithoutPlugins().isCellEditable(createCellWithStyle({ editable: false }))
     ).toBeFalsy();
   });
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -133,7 +133,8 @@ export type CellStateStyle = {
   bendable?: boolean;
   /**
    * This specifies if a cell can be cloned.
-   * See {@link Graph.isCellCloneable}.
+   *
+   * Note that a cell is in fact cloneable according to the value returned by {@link Graph.isCellCloneable}.
    * @default true
    */
   cloneable?: boolean;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -116,7 +116,9 @@ export type CellStateStyle = {
   aspect?: string;
   /**
    * This specifies if a cell should be resized automatically if its value changed.
-   * See {@link Graph.isAutoSizeCell}. This is normally combined with {@link resizable} to disable manual resizing.
+   * This is normally combined with {@link resizable} to disable manual resizing.
+   *
+   * Note that a cell is in fact auto-resizable according to the value returned by {@link Graph.isAutoSizeCell}.
    * @default false
    */
   autoSize?: boolean;
@@ -127,7 +129,8 @@ export type CellStateStyle = {
   backgroundOutline?: boolean;
   /**
    * This specifies if the control points of an edge can be moved.
-   * See {@link Graph.isCellBendable}.
+   *
+   * Note that a cell is in fact bendable according to the value returned by {@link Graph.isCellBendable}.
    * @default true
    */
   bendable?: boolean;
@@ -160,7 +163,8 @@ export type CellStateStyle = {
   dashPattern?: string;
   /**
    * This specifies if a cell can be deleted.
-   * See {@link Graph.isCellDeletable}.
+   *
+   * Note that a cell is in fact deletable according to the value returned by {@link Graph.isCellDeletable}.
    * @default true
    */
   deletable?: boolean;
@@ -489,7 +493,7 @@ export type CellStateStyle = {
   /**
    * This specifies if a cell can be moved.
    *
-   * See {@link Graph.isCellMovable}.
+   * Note that a cell is in fact movable according to the value returned by {@link Graph.isCellMovable}.
    * @default true
    */
   movable?: boolean;
@@ -585,7 +589,7 @@ export type CellStateStyle = {
   /**
    * This specifies if a cell can be resized.
    *
-   * See {@link Graph.isCellResizable}.
+   * Note that a cell is in fact resizable according to the value returned by {@link Graph.isCellResizable}.
    * @default true
    */
   resizable?: boolean;
@@ -605,6 +609,8 @@ export type CellStateStyle = {
   resizeWidth?: boolean;
   /**
    * This specifies if a cell can be rotated.
+   *
+   * Note that a cell is in fact rotatable according to the value returned by {@link Graph.isCellRotatable}.
    * @default true
    */
   rotatable?: boolean;

--- a/packages/core/src/view/mixins/CellsMixin.ts
+++ b/packages/core/src/view/mixins/CellsMixin.ts
@@ -1778,9 +1778,7 @@ export const CellsMixin: PartialType = {
   },
 
   isCellCloneable(cell) {
-    const style = this.getCurrentCellStyle(cell);
-    const cloneable = style.cloneable == null ? true : style.cloneable;
-    return this.isCellsCloneable() && cloneable;
+    return this.isCellsCloneable() && (this.getCurrentCellStyle(cell).cloneable ?? true);
   },
 
   isCellsCloneable() {
@@ -1830,9 +1828,7 @@ export const CellsMixin: PartialType = {
   },
 
   isCellDeletable(cell) {
-    const style = this.getCurrentCellStyle(cell);
-    const deletable = style.deletable == null ? true : style.deletable;
-    return this.isCellsDeletable() && deletable;
+    return this.isCellsDeletable() && (this.getCurrentCellStyle(cell).deletable ?? true);
   },
 
   isCellsDeletable() {
@@ -1844,8 +1840,7 @@ export const CellsMixin: PartialType = {
   },
 
   isCellRotatable(cell) {
-    const style = this.getCurrentCellStyle(cell);
-    return style.rotatable == null ? true : style.rotatable;
+    return this.getCurrentCellStyle(cell).rotatable ?? true;
   },
 
   getMovableCells(cells) {
@@ -1855,8 +1850,11 @@ export const CellsMixin: PartialType = {
   },
 
   isCellMovable(cell) {
-    const style = this.getCurrentCellStyle(cell);
-    return this.isCellsMovable() && !this.isCellLocked(cell) && (style.movable ?? true);
+    return (
+      this.isCellsMovable() &&
+      !this.isCellLocked(cell) &&
+      (this.getCurrentCellStyle(cell).movable ?? true)
+    );
   },
 
   isCellsMovable() {
@@ -1868,9 +1866,10 @@ export const CellsMixin: PartialType = {
   },
 
   isCellResizable(cell) {
-    const style = this.getCurrentCellStyle(cell);
     return (
-      this.isCellsResizable() && !this.isCellLocked(cell) && (style.resizable ?? true)
+      this.isCellsResizable() &&
+      !this.isCellLocked(cell) &&
+      (this.getCurrentCellStyle(cell).resizable ?? true)
     );
   },
 
@@ -1883,8 +1882,11 @@ export const CellsMixin: PartialType = {
   },
 
   isCellBendable(cell) {
-    const style = this.getCurrentCellStyle(cell);
-    return this.isCellsBendable() && !this.isCellLocked(cell) && style.bendable != false;
+    return (
+      this.isCellsBendable() &&
+      !this.isCellLocked(cell) &&
+      (this.getCurrentCellStyle(cell).bendable ?? true)
+    );
   },
 
   isCellsBendable() {
@@ -1896,8 +1898,7 @@ export const CellsMixin: PartialType = {
   },
 
   isAutoSizeCell(cell) {
-    const style = this.getCurrentCellStyle(cell);
-    return this.isAutoSizeCells() || (style.autoSize ?? false);
+    return this.isAutoSizeCells() || (this.getCurrentCellStyle(cell).autoSize ?? false);
   },
 
   isAutoSizeCells() {

--- a/packages/website/docs/usage/migrate-from-mxgraph.md
+++ b/packages/website/docs/usage/migrate-from-mxgraph.md
@@ -256,6 +256,7 @@ an array of plugins to the constructor.
 
 | property removed        | method removed                | new plugin              |
 |-------------------------|-------------------------------|-------------------------|
+| `cellEditor`            | `createCellEditor`            | `CellEditorHandler`     |
 | `connectionHandler`     | `createConnectionHandler`     | `ConnectionHandler`     |
 | `graphHandler`          | `createGraphHandler`          | `SelectionHandler`      |
 | `panningHandler`        | `createPanningHandler`        | `PanningHandler`        |
@@ -435,6 +436,7 @@ Others were removed:
 ### Misc
 
 - Codec renaming and output: see [Pull Request #70](https://github.com/maxGraph/maxGraph/pull/70)
+- `mxCellEditor` to `CellEditorHandler`
 - `mxDictionary`&lt;T&gt; to `Dictionary`&lt;K, V&gt;
 - `mxRubberband` to `RubberBandHandler`
 - `mxVertexHandler.rotationEnabled` has been removed. Use `VertexHandlerConfig.rotationEnabled` instead (since `0.12.0`).


### PR DESCRIPTION
Only call `getCurrentCellStyle` when other criteria match (avoid extra call) and inline the style constant.
Test all modified methods: the tests were written prior the refactoring to ensure that the original
behavior remains the same.