### PR TITLE
feat: let configure the defaults value of the shadow styles

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -142,7 +142,7 @@ export * as styleUtils from './util/styleUtils';
 export * as utils from './util/Utils';
 export * as xmlUtils from './util/xmlUtils';
 
-export { GlobalConfig } from './util/config';
+export * from './util/config';
 export * from './util/logger';
 
 export { default as Animation } from './view/animate/Animation';

--- a/packages/core/src/util/Constants.ts
+++ b/packages/core/src/util/Constants.ts
@@ -67,25 +67,16 @@ export const NS_SVG = 'http://www.w3.org/2000/svg';
  */
 export const NS_XLINK = 'http://www.w3.org/1999/xlink';
 
-/**
- * Defines the color to be used to draw shadows in shapes and windows.
- * Default is gray.
- */
+/** Default value of {@link StyleDefaultsConfig.shadowColor}. */
 export const SHADOWCOLOR = 'gray';
 
-/**
- * Specifies the x-offset of the shadow. Default is 2.
- */
+/** Default value of {@link StyleDefaultsConfig.shadowOffsetX}. */
 export const SHADOW_OFFSET_X = 2;
 
-/**
- * Specifies the y-offset of the shadow. Default is 3.
- */
+/** Default value of {@link StyleDefaultsConfig.shadowOffsetY}. */
 export const SHADOW_OFFSET_Y = 3;
 
-/**
- * Defines the opacity for shadows. Default is 1.
- */
+/** Default value of {@link StyleDefaultsConfig.shadowOpacity}. */
 export const SHADOW_OPACITY = 1;
 
 export enum NODETYPE {

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -16,6 +16,12 @@ limitations under the License.
 
 import type { Logger } from '../types';
 import { NoOpLogger } from './logger';
+import {
+  SHADOW_OFFSET_X,
+  SHADOW_OFFSET_Y,
+  SHADOW_OPACITY,
+  SHADOWCOLOR,
+} from './Constants';
 
 /**
  * Global configuration for maxGraph.
@@ -44,4 +50,48 @@ export const GlobalConfig = {
    * @default `NoOpLogger`
    */
   logger: new NoOpLogger() as Logger,
+};
+
+/**
+ * Configure style defaults for maxGraph.
+ *
+ * @experimental subject to change or removal. maxGraph's global configuration may be modified in the future without prior notice.
+ * @since 0.14.0
+ * @category Configuration
+ */
+export const StyleDefaultsConfig = {
+  /**
+   * Defines the color to be used to draw shadows in shapes and windows.
+   * @default {@link SHADOWCOLOR}
+   */
+  shadowColor: SHADOWCOLOR,
+  /**
+   * Specifies the x-offset of the shadow.
+   * @default {@link SHADOW_OFFSET_X}
+   */
+  shadowOffsetX: SHADOW_OFFSET_X,
+  /**
+   * Specifies the y-offset of the shadow.
+   * @default {@link SHADOW_OFFSET_Y}
+   */
+  shadowOffsetY: SHADOW_OFFSET_Y,
+  /**
+   * Defines the opacity for shadow. Possible values are between 1 (opaque) and 0 (transparent).
+   * @default {@link SHADOW_OPACITY}
+   */
+  shadowOpacity: SHADOW_OPACITY,
+};
+
+/**
+ * Resets {@link StyleDefaultsConfig} to default values.
+ *
+ * @experimental Subject to change or removal. maxGraph's global configuration may be modified in the future without prior notice.
+ * @since 0.14.0
+ * @category Configuration
+ */
+export const resetStyleDefaultsConfig = (): void => {
+  StyleDefaultsConfig.shadowColor = SHADOWCOLOR;
+  StyleDefaultsConfig.shadowOffsetX = SHADOW_OFFSET_X;
+  StyleDefaultsConfig.shadowOffsetY = SHADOW_OFFSET_Y;
+  StyleDefaultsConfig.shadowOpacity = SHADOW_OPACITY;
 };

--- a/packages/core/src/view/canvas/AbstractCanvas2D.ts
+++ b/packages/core/src/view/canvas/AbstractCanvas2D.ts
@@ -22,10 +22,6 @@ import {
   DEFAULT_FONTSIZE,
   DIRECTION,
   NONE,
-  SHADOWCOLOR,
-  SHADOW_OFFSET_X,
-  SHADOW_OFFSET_Y,
-  SHADOW_OPACITY,
 } from '../../util/Constants';
 import UrlConverter from '../../util/UrlConverter';
 import Point from '../geometry/Point';
@@ -40,17 +36,33 @@ import type {
   TextDirectionValue,
   VAlignValue,
 } from '../../types';
+import { StyleDefaultsConfig } from '../../util/config';
 
 /**
- * Base class for all canvases. A description of the public API is available in <mxXmlCanvas2D>.
- * All color values of {@link Constants#NONE} will be converted to null in the state.
+ * Base class for all canvases.
  *
- * Constructor: D
+ * The following methods make up the public interface of the canvas 2D for all painting in mxGraph:
  *
- * Constructs a new abstract canvas.
+ * - {@link save}, {@link restore}
+ * - {@link scale}, {@link translate}, {@link rotate}
+ * - {@link setAlpha}, {@link setFillAlpha}, {@link setStrokeAlpha}, {@link setFillColor}, {@link setGradient},
+ *   {@link setStrokeColor}, {@link setStrokeWidth}, {@link setDashed}, {@link setDashPattern}, {@link setLineCap},
+ *   {@link setLineJoin}, {@link setMiterLimit}
+ * - {@link setFontColor}, {@link setFontBackgroundColor}, {@link setFontBorderColor}, {@link setFontSize},
+ *   {@link setFontFamily}, {@link setFontStyle}
+ * - {@link setShadow}, {@link setShadowColor}, {@link setShadowAlpha}, {@link setShadowOffset}
+ * - {@link rect}, {@link roundrect}, {@link ellipse}, {@link image}, {@link text}
+ * - {@link begin}, {@link moveTo}, {@link lineTo}, {@link quadTo}, {@link curveTo}
+ * - {@link stroke}, {@link fill}, {@link fillAndStroke}
+ *
+ * {@link arcTo} is an additional method for drawing paths.
+ * This is a synthetic method, meaning that it is turned into a sequence of curves by default.
+ * Subclasses may add native support for arcs.
+ *
+ * All color values of {@link NONE} will be converted to null in the state.
  */
 abstract class AbstractCanvas2D {
-  constructor() {
+  protected constructor() {
     this.converter = this.createUrlConverter();
     this.reset();
   }
@@ -169,10 +181,10 @@ abstract class AbstractCanvas2D {
       fontFamily: DEFAULT_FONTFAMILY,
       fontStyle: 0,
       shadow: false,
-      shadowColor: SHADOWCOLOR,
-      shadowAlpha: SHADOW_OPACITY,
-      shadowDx: SHADOW_OFFSET_X,
-      shadowDy: SHADOW_OFFSET_Y,
+      shadowColor: StyleDefaultsConfig.shadowColor,
+      shadowAlpha: StyleDefaultsConfig.shadowOpacity,
+      shadowDx: StyleDefaultsConfig.shadowOffsetX,
+      shadowDy: StyleDefaultsConfig.shadowOffsetY,
       rotation: 0,
       rotationCx: 0,
       rotationCy: 0,
@@ -418,21 +430,28 @@ abstract class AbstractCanvas2D {
   }
 
   /**
-   * Enables or disables and configures the current shadow.
+   * Sets the current shadow color. Default {@link StyleDefaultsConfig.shadowColor}
+   *
+   * @param value Hexadecimal representation of the color or `none`.
    */
   setShadowColor(value: ColorValue | null) {
     this.state.shadowColor = value ?? NONE;
   }
 
   /**
-   * Enables or disables and configures the current shadow.
+   * Sets the current shadow alpha. Default is {@link StyleDefaultsConfig.shadowOpacity}
+   *
+   * @param value Number that represents the new alpha. Possible values are between 1 (opaque) and 0 (transparent).
    */
   setShadowAlpha(value: number) {
     this.state.shadowAlpha = value;
   }
 
   /**
-   * Enables or disables and configures the current shadow.
+   * Sets the current shadow offset.
+   *
+   * @param dx Number that represents the horizontal offset of the shadow.
+   * @param dy Number that represents the vertical offset of the shadow.
    */
   setShadowOffset(dx: number, dy: number) {
     this.state.shadowDx = dx;

--- a/packages/core/src/view/canvas/AbstractCanvas2D.ts
+++ b/packages/core/src/view/canvas/AbstractCanvas2D.ts
@@ -430,7 +430,7 @@ abstract class AbstractCanvas2D {
   }
 
   /**
-   * Sets the current shadow color. Default {@link StyleDefaultsConfig.shadowColor}
+   * Sets the current shadow color.
    *
    * @param value Hexadecimal representation of the color or `none`.
    */
@@ -439,7 +439,7 @@ abstract class AbstractCanvas2D {
   }
 
   /**
-   * Sets the current shadow alpha. Default is {@link StyleDefaultsConfig.shadowOpacity}
+   * Sets the current shadow alpha.
    *
    * @param value Number that represents the new alpha. Possible values are between 1 (opaque) and 0 (transparent).
    */

--- a/packages/core/src/view/canvas/SvgCanvas2D.ts
+++ b/packages/core/src/view/canvas/SvgCanvas2D.ts
@@ -31,7 +31,6 @@ import {
   NONE,
   NS_SVG,
   NS_XLINK,
-  SHADOWCOLOR,
   WORD_WRAP,
 } from '../../util/Constants';
 import Rectangle from '../geometry/Rectangle';
@@ -49,6 +48,7 @@ import {
   TextDirectionValue,
   VAlignValue,
 } from '../../types';
+import { StyleDefaultsConfig } from '../../util/config';
 
 // Activates workaround for gradient ID resolution if base tag is used.
 const useAbsoluteIds =
@@ -858,7 +858,7 @@ class SvgCanvas2D extends AbstractCanvas2D {
       shadow.getAttribute('fill') !== 'none' &&
       (!Client.IS_FF || shadow.getAttribute('fill') !== 'transparent')
     ) {
-      shadow.setAttribute('fill', <string>(s.shadowColor ? s.shadow : SHADOWCOLOR));
+      shadow.setAttribute('fill', s.shadowColor);
     }
 
     if (

--- a/packages/core/src/view/canvas/XmlCanvas2D.ts
+++ b/packages/core/src/view/canvas/XmlCanvas2D.ts
@@ -17,42 +17,11 @@ limitations under the License.
 */
 
 import AbstractCanvas2D from './AbstractCanvas2D';
-import {
-  DEFAULT_FONTFAMILY,
-  DEFAULT_FONTSIZE,
-  NONE,
-  SHADOWCOLOR,
-  SHADOW_OFFSET_X,
-  SHADOW_OFFSET_Y,
-  SHADOW_OPACITY,
-} from '../../util/Constants';
+import { DEFAULT_FONTFAMILY, DEFAULT_FONTSIZE, NONE } from '../../util/Constants';
 import { getOuterHtml, isNode } from '../../util/domUtils';
 import { DirectionValue, TextDirectionValue } from '../../types';
+import { StyleDefaultsConfig } from '../../util/config';
 
-/**
- * Base class for all canvases. The following methods make up the public
- * interface of the canvas 2D for all painting in mxGraph:
- *
- * - <save>, <restore>
- * - <scale>, <translate>, <rotate>
- * - <setAlpha>, <setFillAlpha>, <setStrokeAlpha>, <setFillColor>, <setGradient>,
- *   <setStrokeColor>, <setStrokeWidth>, <setDashed>, <setDashPattern>, <setLineCap>,
- *   <setLineJoin>, <setMiterLimit>
- * - <setFontColor>, <setFontBackgroundColor>, <setFontBorderColor>, <setFontSize>,
- *   <setFontFamily>, <setFontStyle>
- * - <setShadow>, <setShadowColor>, <setShadowAlpha>, <setShadowOffset>
- * - <rect>, <roundrect>, <ellipse>, <image>, <text>
- * - <begin>, {@link moveTo}, <lineTo>, <quadTo>, <curveTo>
- * - <stroke>, <fill>, <fillAndStroke>
- *
- * <AbstractCanvas2D.arcTo> is an additional method for drawing paths. This is
- * a synthetic method, meaning that it is turned into a sequence of curves by
- * default. Subclassers may add native support for arcs.
- *
- * Constructor: D
- *
- * Constructs a new abstract canvas.
- */
 class XmlCanvas2D extends AbstractCanvas2D {
   constructor(root: Element) {
     super();
@@ -97,16 +66,16 @@ class XmlCanvas2D extends AbstractCanvas2D {
 
     // Writes shadow defaults
     elem = this.createElement('shadowcolor');
-    elem.setAttribute('color', SHADOWCOLOR);
+    elem.setAttribute('color', StyleDefaultsConfig.shadowColor);
     this.root.appendChild(elem);
 
     elem = this.createElement('shadowalpha');
-    elem.setAttribute('alpha', String(SHADOW_OPACITY));
+    elem.setAttribute('alpha', String(StyleDefaultsConfig.shadowOpacity));
     this.root.appendChild(elem);
 
     elem = this.createElement('shadowoffset');
-    elem.setAttribute('dx', String(SHADOW_OFFSET_X));
-    elem.setAttribute('dy', String(SHADOW_OFFSET_Y));
+    elem.setAttribute('dx', String(StyleDefaultsConfig.shadowOffsetX));
+    elem.setAttribute('dy', String(StyleDefaultsConfig.shadowOffsetY));
     this.root.appendChild(elem);
   }
 
@@ -635,12 +604,6 @@ class XmlCanvas2D extends AbstractCanvas2D {
     this.root.appendChild(elem);
   }
 
-  /**
-   * Sets the current shadow color. Default {@link mxConstants.SHADOWCOLOR}
-   *
-   *
-   * @param value Hexadecimal representation of the color or 'none'.
-   */
   setShadowColor(value: string | null = null): void {
     if (this.compressed) {
       if (value === NONE) {
@@ -659,11 +622,6 @@ class XmlCanvas2D extends AbstractCanvas2D {
     this.root.appendChild(elem);
   }
 
-  /**
-   * Sets the current shadows alpha. Default is {@link mxConstants.SHADOW_OPACITY}
-   *
-   * @param value Number that represents the new alpha. Possible values are between 1 (opaque) and 0 (transparent).
-   */
   setShadowAlpha(value: number): void {
     if (this.compressed) {
       if (this.state.shadowAlpha === value) {
@@ -677,12 +635,6 @@ class XmlCanvas2D extends AbstractCanvas2D {
     this.root.appendChild(elem);
   }
 
-  /**
-   * Sets the current shadow offset.
-   *
-   * @param dx Number that represents the horizontal offset of the shadow.
-   * @param dy Number that represents the vertical offset of the shadow.
-   */
   setShadowOffset(dx: number, dy: number): void {
     if (this.compressed) {
       if (this.state.shadowDx === dx && this.state.shadowDy === dy) {

--- a/packages/core/src/view/geometry/Shape.ts
+++ b/packages/core/src/view/geometry/Shape.ts
@@ -24,8 +24,6 @@ import {
   LINE_ARCSIZE,
   NONE,
   RECTANGLE_ROUNDING_FACTOR,
-  SHADOW_OFFSET_X,
-  SHADOW_OFFSET_Y,
 } from '../../util/Constants';
 import Point from './Point';
 import type AbstractCanvas2D from '../canvas/AbstractCanvas2D';
@@ -44,6 +42,7 @@ import type {
   DirectionValue,
   GradientMap,
 } from '../../types';
+import { StyleDefaultsConfig } from '../../util/config';
 
 /**
  * Base class for all shapes.
@@ -1078,8 +1077,8 @@ class Shape {
    */
   augmentBoundingBox(bbox: Rectangle) {
     if (this.isShadow) {
-      bbox.width += Math.ceil(SHADOW_OFFSET_X * this.scale);
-      bbox.height += Math.ceil(SHADOW_OFFSET_Y * this.scale);
+      bbox.width += Math.ceil(StyleDefaultsConfig.shadowOffsetX * this.scale);
+      bbox.height += Math.ceil(StyleDefaultsConfig.shadowOffsetX * this.scale);
     }
 
     // Adds strokeWidth

--- a/packages/html/.storybook/preview.ts
+++ b/packages/html/.storybook/preview.ts
@@ -3,6 +3,7 @@ import {
   GlobalConfig,
   NoOpLogger,
   resetHandleConfig,
+  resetStyleDefaultsConfig,
   resetVertexHandlerConfig,
 } from '@maxgraph/core';
 
@@ -16,8 +17,9 @@ const defaultLogger = new NoOpLogger();
 const resetMaxGraphConfigs = (): void => {
   GlobalConfig.logger = defaultLogger;
 
-  resetVertexHandlerConfig();
   resetHandleConfig();
+  resetStyleDefaultsConfig();
+  resetVertexHandlerConfig();
 };
 
 const preview: Preview = {

--- a/packages/html/stories/CustomStyleDefaults.stories.ts
+++ b/packages/html/stories/CustomStyleDefaults.stories.ts
@@ -1,0 +1,148 @@
+/*
+Copyright 2024-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {
+  type ConnectionHandler,
+  getDefaultPlugins,
+  Graph,
+  InternalEvent,
+  Point,
+  RubberBandHandler,
+  StyleDefaultsConfig,
+} from '@maxgraph/core';
+import {
+  contextMenuTypes,
+  contextMenuValues,
+  globalTypes,
+  globalValues,
+  rubberBandTypes,
+  rubberBandValues,
+} from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
+import '@maxgraph/core/css/common.css'; // style required by RubberBand
+
+export default {
+  title: 'Styles/CustomStyleDefaults',
+  argTypes: {
+    ...contextMenuTypes,
+    ...globalTypes,
+    ...rubberBandTypes,
+    customStyleDefaults: {
+      type: 'boolean',
+      defaultValue: true,
+    },
+  },
+  args: {
+    ...contextMenuValues,
+    ...globalValues,
+    ...rubberBandValues,
+    customStyleDefaults: true,
+  },
+};
+
+const Template = ({ label, ...args }: Record<string, string>) => {
+  const div = document.createElement('div');
+  const container = createGraphContainer(args);
+  div.appendChild(container);
+
+  // Toggle custom handle defaults with storybook args
+  if (args.customStyleDefaults) {
+    StyleDefaultsConfig.shadowColor = 'orange';
+    StyleDefaultsConfig.shadowOffsetX = 4;
+    StyleDefaultsConfig.shadowOffsetY = -4;
+    StyleDefaultsConfig.shadowOpacity = 0.5;
+  }
+
+  // Enables rubberband selection
+  const plugins = getDefaultPlugins();
+  if (args.rubberBand) plugins.push(RubberBandHandler);
+
+  if (!args.contextMenu) InternalEvent.disableContextMenu(container);
+
+  // Creates the graph inside the given container and apply configuration
+  const graph = new Graph(container, undefined, plugins);
+  graph.setConnectable(true);
+  graph.setAllowDanglingEdges(false);
+  graph.setVertexLabelsMovable(true);
+  graph.setEdgeLabelsMovable(true);
+
+  const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler');
+  connectionHandler.outlineConnect = true;
+
+  // Changes default styles to increase the contrast
+  const defaultEdgeStyle = graph.getStylesheet().getDefaultEdgeStyle();
+  defaultEdgeStyle.shadow = true;
+  defaultEdgeStyle.strokeColor = '#c7cad0';
+  const defaultVertexStyle = graph.getStylesheet().getDefaultVertexStyle();
+  defaultVertexStyle.shadow = true;
+  defaultVertexStyle.fillColor = '#eaebef';
+  defaultVertexStyle.strokeColor = '#c7cad0';
+
+  // Gets the default parent for inserting new cells. This is normally the first child of the root (i.e. layer 0).
+  const parent = graph.getDefaultParent();
+
+  // Adds cells to the model in a single step
+  graph.batchUpdate(() => {
+    const v1 = graph.insertVertex(parent, null, 'A1', 20, 20, 40, 80, { shape: 'and' });
+    const v2 = graph.insertVertex(parent, null, 'A2', 20, 220, 40, 80, { shape: 'and' });
+    const v3 = graph.insertVertex(parent, null, 'X1', 160, 110, 80, 80, { shape: 'xor' });
+    const e1 = graph.insertEdge(parent, null, 'Edge from A1 to X1', v1, v3);
+    e1.geometry!.points = [new Point(90, 60), new Point(90, 130)];
+    const e2 = graph.insertEdge(parent, null, 'Edge from A2 to X1', v2, v3);
+    e2.geometry!.points = [new Point(90, 260), new Point(90, 170)];
+
+    const v4 = graph.insertVertex(parent, null, 'A3', 520, 20, 40, 80, {
+      shape: 'customShape',
+      flipH: true,
+    });
+    const v5 = graph.insertVertex(parent, null, 'A4', 520, 220, 40, 80, {
+      shape: 'and',
+      flipH: true,
+    });
+    const v6 = graph.insertVertex(parent, null, 'X2', 340, 110, 80, 80, {
+      shape: 'xor',
+      flipH: true,
+    });
+    const e3 = graph.insertEdge(parent, null, 'Edge from A3 to X2', v4, v6, {
+      edgeStyle: 'orthogonalEdgeStyle',
+    });
+    e3.geometry!.points = [new Point(490, 60), new Point(130, 130)];
+    const e4 = graph.insertEdge(parent, null, 'Edge from A4 to X2', v5, v6);
+    e4.geometry!.points = [new Point(490, 260), new Point(350, 220)];
+
+    const v7 = graph.insertVertex(parent, null, 'O1', 250, 260, 80, 60, {
+      shape: 'or',
+      direction: 'south',
+    });
+    const e5 = graph.insertEdge(parent, null, '', v6, v7);
+    e5.geometry!.points = [new Point(310, 150)];
+    const e6 = graph.insertEdge(parent, null, '', v3, v7);
+    e6.geometry!.points = [new Point(270, 150)];
+
+    const e7 = graph.insertEdge(parent, null, 'Edge from O1 to A4', v7, v5);
+    e7.geometry!.points = [
+      new Point(290, 370),
+      new Point(350, 470),
+      new Point(480, 410),
+      new Point(590, 390),
+      new Point(630, 290),
+    ];
+  });
+
+  return div;
+};
+
+export const Default = Template.bind({});

--- a/packages/html/stories/FixedIcons.stories.js
+++ b/packages/html/stories/FixedIcons.stories.js
@@ -22,6 +22,7 @@ import {
   constants,
   utils,
   LabelShape,
+  StyleDefaultsConfig,
 } from '@maxgraph/core';
 
 import {
@@ -61,9 +62,8 @@ const Template = ({ label, ...args }) => {
     return new Rectangle(x + ix, y + iy, iw, ih);
   };
 
-  // Should we allow overriding constants?
   // Makes the shadow brighter
-  //constants.SHADOWCOLOR = '#C0C0C0';
+  StyleDefaultsConfig.shadowColor = '#C0C0C0';
 
   // Creates the graph inside the given container
   const graph = new Graph(container);

--- a/packages/html/stories/Folding.stories.ts
+++ b/packages/html/stories/Folding.stories.ts
@@ -37,7 +37,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   configureImagesBasePath();
   const container = createGraphContainer(args);
 
-  // Should we allow overriding constant values?
+  // TODO Allow overriding constants. See https://github.com/maxGraph/maxGraph/issues/192
   // Enables crisp rendering of rectangles in SVG
   // constants.ENTITY_SEGMENT = 20;
 

--- a/packages/html/stories/Merge.stories.ts
+++ b/packages/html/stories/Merge.stories.ts
@@ -15,7 +15,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { getDefaultPlugins, Graph, Perimeter, RubberBandHandler } from '@maxgraph/core';
+import {
+  getDefaultPlugins,
+  Graph,
+  Perimeter,
+  RubberBandHandler,
+  StyleDefaultsConfig,
+} from '@maxgraph/core';
 import {
   globalTypes,
   globalValues,
@@ -41,8 +47,7 @@ export default {
 const Template = ({ label, ...args }: Record<string, any>) => {
   const container = createGraphContainer(args);
 
-  // Should we allow overriding constants?
-  // constants.SHADOWCOLOR = '#c0c0c0';
+  StyleDefaultsConfig.shadowColor = '#c0c0c0';
 
   // Enables rubberband selection
   const plugins = getDefaultPlugins();

--- a/packages/html/stories/Monitor.stories.ts
+++ b/packages/html/stories/Monitor.stories.ts
@@ -25,6 +25,7 @@ import {
   InternalEvent,
   ModelXmlSerializer,
   Perimeter,
+  StyleDefaultsConfig,
   xmlUtils,
 } from '@maxgraph/core';
 import { globalTypes } from './shared/args.js';
@@ -49,8 +50,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   container.style.background = ''; // no grid
   div.appendChild(container);
 
-  // Should we allow overriding constants?
-  // constants.SHADOWCOLOR = '#e0e0e0';
+  StyleDefaultsConfig.shadowColor = '#e0e0e0';
 
   // Creates the graph inside the given container
   const graph = createGraph(container);
@@ -375,14 +375,14 @@ const Template = ({ label, ...args }: Record<string, string>) => {
     style.gradientColor = 'white';
     style.gradientDirection = 'east';
     style.rounded = true;
-    // style.shadow = true; // TMP disable until we can change the shadow color
+    style.shadow = true;
     style.fontStyle = 1; // bold
 
     style = graph.getStylesheet().getDefaultEdgeStyle();
     style.edgeStyle = EdgeStyle.ElbowConnector;
     style.strokeColor = '#808080';
     style.rounded = true;
-    // style.shadow = true; // TMP disable until we can change the shadow color
+    style.shadow = true;
 
     style = {};
     style.shape = 'swimlane';

--- a/packages/html/stories/OrgChart.stories.js
+++ b/packages/html/stories/OrgChart.stories.js
@@ -30,6 +30,7 @@ import {
   ImageBox,
   utils,
   MaxToolbar,
+  StyleDefaultsConfig,
 } from '@maxgraph/core';
 import {
   contextMenuTypes,
@@ -56,9 +57,8 @@ const Template = ({ label, ...args }) => {
   const container = createGraphContainer(args);
   div.appendChild(container);
 
-  // Should we allow overriding constants?
   // Makes the shadow brighter
-  //constants.SHADOWCOLOR = '#C0C0C0';
+  StyleDefaultsConfig.shadowColor = '#C0C0C0';
 
   const outline = document.getElementById('outlineContainer');
 

--- a/packages/html/stories/Stencils.stories.ts
+++ b/packages/html/stories/Stencils.stories.ts
@@ -35,6 +35,7 @@ import {
   Shape,
   StencilShape,
   StencilShapeRegistry,
+  StyleDefaultsConfig,
   VertexHandler,
   VertexHandlerConfig,
 } from '@maxgraph/core';
@@ -68,12 +69,12 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   const container = createGraphContainer(args);
   div.appendChild(container);
 
-  // TODO Allow overriding constants. See https://github.com/maxGraph/maxGraph/issues/192
-  // Sets the global shadow color
-  // constants.SHADOWCOLOR = '#C0C0C0';
-  // constants.SHADOW_OPACITY = 0.5;
-  // constants.SHADOW_OFFSET_X = 4;
-  // constants.SHADOW_OFFSET_Y = 4;
+  // Sets the global configurations
+  StyleDefaultsConfig.shadowColor = '#C0C0C0';
+  StyleDefaultsConfig.shadowOpacity = 0.5;
+  StyleDefaultsConfig.shadowOffsetX = 4;
+  StyleDefaultsConfig.shadowOffsetY = 4;
+
   HandleConfig.fillColor = '#99ccff';
   HandleConfig.strokeColor = '#0088cf';
   VertexHandlerConfig.selectionColor = '#00a8ff';

--- a/packages/html/stories/Wires.stories.js
+++ b/packages/html/stories/Wires.stories.js
@@ -82,6 +82,7 @@ import {
   SelectionCellsHandler,
   PopupMenuHandler,
   cellArrayUtils,
+  StyleDefaultsConfig,
 } from '@maxgraph/core';
 
 import {
@@ -125,8 +126,7 @@ const Template = ({ label, ...args }) => {
   parentContainer.appendChild(container);
 
   // Changes some default colors
-  // TODO Find a way of modifying globally or setting locally! See https://github.com/maxGraph/maxGraph/issues/192
-  //constants.SHADOWCOLOR = '#C0C0C0';
+  StyleDefaultsConfig.shadowColor = '#C0C0C0';
 
   let joinNodeSize = 7;
   let strokeWidth = 2;

--- a/packages/website/docs/usage/global-configuration.md
+++ b/packages/website/docs/usage/global-configuration.md
@@ -16,11 +16,13 @@ The following objects can be used to configure `maxGraph` globally:
   - `GlobalConfig` (since 0.11.0): for shared resources (logger).
   - `HandleConfig` (since 0.14.0): for shared handle configurations.
   - `StencilShapeConfig` (since 0.11.0): for stencil shapes.
+  - `StyleDefaultsConfig` (since 0.14.0): for the default values of the Cell styles.
   - `VertexHandlerConfig` (since 0.12.0): for `VertexHandler`.
 
 Some functions are provided to reset the global configuration to the default values. For example:
 
   - `resetHandleConfig` (since 0.14.0)
+  - `resetStyleDefaultsConfig` (since 0.14.0)
   - `resetVertexHandlerConfig` (since 0.14.0)
 
 :::note


### PR DESCRIPTION
In `mxGraph`, such configuration was possible by updating certain `mxConstants` values, but in `maxGraph`, constants are immutable.
It is now possible to use `StyleDefaultsConfig` to globally configure various shadow style parameters.
Previously, setting such parameters was a real pain. Certain methods had to be reimplemented in Canvas2D classes.

Finally, it is now possible to reset `StyleDefaultsConfig` properties to their default values using a dedicated reset function.

A new story has been added to demonstrate the effects of customizing style defaults and compare them with the original defaults.
Some existing stories have also been modified to change the default shadow settings to better match the related mxGraph examples from which they were taken.

## Screenshots

A new story demonstrates how it is possible to changes the default shadow style values 👇🏿 

[PR_577_custom_default_shadow_styles.webm](https://github.com/user-attachments/assets/c2a4020e-7e1d-4dc6-adf3-88b97724b62d)


## Notes

Covers #192


