### PR TITLE
refactor: use constants.NS_SVG instead of hard coded values

### DIFF
--- a/packages/core/src/Client.ts
+++ b/packages/core/src/Client.ts
@@ -16,6 +16,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { NS_SVG } from './util/Constants';
+
 class Client {
   /**
    * The version of the `maxGraph` library.
@@ -215,9 +217,8 @@ class Client {
   static NO_FO =
     typeof window !== 'undefined' &&
     (!document.createElementNS ||
-      document
-        .createElementNS('http://www.w3.org/2000/svg', 'foreignObject')
-        .toString() !== '[object SVGForeignObjectElement]' ||
+      document.createElementNS(NS_SVG, 'foreignObject').toString() !==
+        '[object SVGForeignObjectElement]' ||
       navigator.userAgent.indexOf('Opera/') >= 0);
 
   /**

--- a/packages/core/src/view/GraphView.ts
+++ b/packages/core/src/view/GraphView.ts
@@ -22,7 +22,7 @@ import Dictionary from '../util/Dictionary';
 import EventSource from './event/EventSource';
 import EventObject from './event/EventObject';
 import RectangleShape from './geometry/node/RectangleShape';
-import { ALIGN } from '../util/Constants';
+import { ALIGN, NS_SVG } from '../util/Constants';
 import Client from '../Client';
 import InternalEvent from './event/InternalEvent';
 import { convertPoint, getCurrentStyle, getOffset } from '../util/styleUtils';
@@ -2215,26 +2215,23 @@ export class GraphView extends EventSource {
    */
   createSvg(): void {
     const { container } = this.graph;
-    const canvas = (this.canvas = document.createElementNS(
-      'http://www.w3.org/2000/svg',
-      'g'
-    ));
+    const canvas = (this.canvas = document.createElementNS(NS_SVG, 'g'));
 
     // For background image
-    this.backgroundPane = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    this.backgroundPane = document.createElementNS(NS_SVG, 'g');
     canvas.appendChild(this.backgroundPane);
 
     // Adds two layers (background is early feature)
-    this.drawPane = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    this.drawPane = document.createElementNS(NS_SVG, 'g');
     canvas.appendChild(this.drawPane);
 
-    this.overlayPane = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    this.overlayPane = document.createElementNS(NS_SVG, 'g');
     canvas.appendChild(this.overlayPane);
 
-    this.decoratorPane = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    this.decoratorPane = document.createElementNS(NS_SVG, 'g');
     canvas.appendChild(this.decoratorPane);
 
-    const root = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    const root = document.createElementNS(NS_SVG, 'svg');
     root.style.left = '0px';
     root.style.top = '0px';
     root.style.width = '100%';

--- a/packages/core/src/view/geometry/Shape.ts
+++ b/packages/core/src/view/geometry/Shape.ts
@@ -23,6 +23,7 @@ import {
   DIRECTION,
   LINE_ARCSIZE,
   NONE,
+  NS_SVG,
   RECTANGLE_ROUNDING_FACTOR,
   SHADOW_OFFSET_X,
   SHADOW_OFFSET_Y,
@@ -322,7 +323,7 @@ class Shape {
    * This implementation assumes that `maxGraph` produces SVG elements.
    */
   create() {
-    return document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    return document.createElementNS(NS_SVG, 'g');
   }
 
   redraw() {
@@ -1138,7 +1139,7 @@ class Shape {
    * Adds a transparent rectangle that catches all events.
    */
   createTransparentSvgRectangle(x: number, y: number, w: number, h: number) {
-    const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    const rect = document.createElementNS(NS_SVG, 'rect');
     rect.setAttribute('x', String(x));
     rect.setAttribute('y', String(y));
     rect.setAttribute('width', String(w));

--- a/packages/core/src/view/image/ImageBundle.ts
+++ b/packages/core/src/view/image/ImageBundle.ts
@@ -56,7 +56,7 @@ type ImageMap = {
  * turned into a data URI if the returned value has a short data URI format
  * as specified above.
  *
- * A typical value for the fallback is a MTHML link as defined in RFC 2557.
+ * A typical value for the fallback is a HTML link as defined in RFC 2557.
  * Note that this format requires a file to be dynamically created on the
  * server-side, or the page that contains the graph to be modified to contain
  * the resources, this can be done by adding a comment that contains the


### PR DESCRIPTION
This reduces duplication and helps reduce the size of maxGraph.
For example, the size of the maxGraph chunk in `ts-example` decreases from 444.79 kB to 444.59 kB.