### PR TITLE
docs: mention examples in the documentation introduction

### DIFF
--- a/packages/website/docs/intro.md
+++ b/packages/website/docs/intro.md
@@ -51,3 +51,13 @@ Please check the maxGraph repository **README**:
 Let's continue with the [Manual](./manual/index.md) to understand the `maxGraph` concepts.
 
 For more information on how to use specific features, please refer to the [Usage](/docs/category/usage) documentation.
+
+:::tip
+
+The documentation does not cover all the features available in `maxGraph`. However, `maxGraph` does provide numerous examples. These examples show how to use the features and how `maxGraph` can be extended to meet new needs:
+- To see the features in action, please play with the [live demo](https://maxgraph.github.io/maxGraph/demo/)
+- Source code for the stories is available at https://github.com/maxGraph/maxGraph/blob/main/packages/html/stories
+
+Other examples are also listed in the [project README](https://github.com/maxGraph/maxGraph/blob/main/README.md#examples).
+
+:::


### PR DESCRIPTION

### Notes

Try to prevent newcomers from getting an impression as in #584
> "The documentation lacks complete examples."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the documentation for the `maxGraph` library with a new "Quick Start" section, highlighting available examples and providing links to a live demo and source code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->