### PR TITLE
feat: allow the use of circles for edge handles

### DIFF
--- a/packages/core/src/view/handler/EdgeHandler.ts
+++ b/packages/core/src/view/handler/EdgeHandler.ts
@@ -37,6 +37,7 @@ import {
   ptSegDistSq,
 } from '../../util/mathUtils';
 import { convertPoint, getOffset, setOpacity } from '../../util/styleUtils';
+import EllipseShape from '../geometry/node/EllipseShape';
 import ImageShape from '../geometry/node/ImageShape';
 import RectangleShape from '../geometry/node/RectangleShape';
 import ConnectionConstraint from '../other/ConnectionConstraint';
@@ -633,13 +634,14 @@ class EdgeHandler {
   }
 
   /**
-   * Creates the shape used to display the given bend. Note that the index may be
-   * null for special cases, such as when called from
-   * {@link ElbowEdgeHandler#createVirtualBend}. Only images and rectangles should be
-   * returned if support for HTML labels with not foreign objects is required.
-   * Index if null for virtual handles.
+   * Creates the shape used to display the given bend.
+   * Note that the index
+   * - may be `null` for special cases, such as when called from {@link ElbowEdgeHandler.createVirtualBend}.
+   * - is `null` for virtual handles.
+   *
+   * Only images and rectangles should be returned if support for HTML labels with not foreign objects is required.
    */
-  createHandleShape(index?: number) {
+  createHandleShape(_index?: number): Shape {
     if (this.handleImage) {
       const shape = new ImageShape(
         new Rectangle(0, 0, this.handleImage.width, this.handleImage.height),
@@ -657,7 +659,9 @@ class EdgeHandler {
       s -= 1;
     }
 
-    return new RectangleShape(
+    const shapeConstructor =
+      EdgeHandlerConfig.handleShape === 'circle' ? EllipseShape : RectangleShape;
+    return new shapeConstructor(
       new Rectangle(0, 0, s, s),
       HandleConfig.fillColor,
       HandleConfig.strokeColor
@@ -926,7 +930,6 @@ class EdgeHandler {
   /**
    * Returns the point for the given event.
    */
-  // getPointForEvent(me: mxMouseEvent): mxPoint;
   getPointForEvent(me: InternalMouseEvent) {
     const view = this.graph.getView();
     const { scale } = view;

--- a/packages/core/src/view/handler/config.ts
+++ b/packages/core/src/view/handler/config.ts
@@ -31,34 +31,55 @@ import {
 import { shallowCopy } from '../../util/cloneUtils';
 
 /**
+ * Describes {@link EdgeHandlerConfig}.
+ *
+ * @experimental Subject to change or removal. maxGraph's global configuration may be modified in the future without prior notice.
+ * @since 0.14.0
+ * @category Configuration
+ */
+export type EdgeHandlerConfigType = {
+  /**
+   * Defines the color to be used for the connect handle fill color. Use `none` for no color.
+   * @default {@link CONNECT_HANDLE_FILLCOLOR}
+   */
+  connectFillColor: string;
+  /**
+   * Kind of shape to be used for edge handles.
+   */
+  handleShape: 'circle' | 'square';
+  /**
+   * Defines the default color to be used for the selection border of edges. Use `none` for no color.
+   * @default {@link EDGE_SELECTION_COLOR}
+   */
+  selectionColor: string;
+  /**
+   * Defines the default stroke width to be used for edge selections.
+   * @default {@link EDGE_SELECTION_STROKEWIDTH}
+   */
+  selectionStrokeWidth: number;
+  /**
+   * Defines the default dashed state to be used for the edge selection border.
+   * @default {@link EDGE_SELECTION_DASHED}
+   */
+  selectionDashed: boolean;
+};
+
+/**
  * Global configuration for {@link EdgeHandler} (including subclasses).
  *
  * @experimental Subject to change or removal. maxGraph's global configuration may be modified in the future without prior notice.
  * @since 0.14.0
  * @category Configuration
  */
-export const EdgeHandlerConfig = {
-  /**
-   * Defines the color to be used for the connect handle fill color. Use `none` for no color.
-   * @default {@link CONNECT_HANDLE_FILLCOLOR}
-   */
+export const EdgeHandlerConfig: EdgeHandlerConfigType = {
   connectFillColor: CONNECT_HANDLE_FILLCOLOR,
-  /**
-   * Defines the default color to be used for the selection border of edges. Use `none` for no color.
-   * @default {@link EDGE_SELECTION_COLOR}
-   */
+
+  handleShape: 'square',
+
   selectionColor: EDGE_SELECTION_COLOR,
 
-  /**
-   * Defines the default stroke width to be used for edge selections.
-   * @default {@link EDGE_SELECTION_STROKEWIDTH}
-   */
   selectionStrokeWidth: EDGE_SELECTION_STROKEWIDTH,
 
-  /**
-   * Defines the default dashed state to be used for the edge selection border.
-   * @default {@link EDGE_SELECTION_DASHED}
-   */
   selectionDashed: EDGE_SELECTION_DASHED,
 };
 

--- a/packages/core/src/view/handler/config.ts
+++ b/packages/core/src/view/handler/config.ts
@@ -45,6 +45,7 @@ export type EdgeHandlerConfigType = {
   connectFillColor: string;
   /**
    * Kind of shape to be used for edge handles.
+   * @default 'square'
    */
   handleShape: 'circle' | 'square';
   /**

--- a/packages/html/stories/CustomHandlesConfiguration.stories.ts
+++ b/packages/html/stories/CustomHandlesConfiguration.stories.ts
@@ -65,6 +65,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
     const selectionColor = '#00a8ff';
 
     EdgeHandlerConfig.connectFillColor = 'pink';
+    EdgeHandlerConfig.handleShape = 'circle';
     EdgeHandlerConfig.selectionColor = selectionColor;
     EdgeHandlerConfig.selectionDashed = false;
     EdgeHandlerConfig.selectionStrokeWidth = 3;


### PR DESCRIPTION
Provide a configuration property that lets you choose another shape for the edge handle.
Previously, it was only possible to use square handles (which is still the default).

### Demo

[PR_586_edge_handles_circle.webm](https://github.com/user-attachments/assets/0e2b3bc2-53bd-4548-ad7b-d20454a9fe7a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced edge handle customization with the addition of `handleShape` property, allowing selection between circle and square shapes.
	- Introduced a new property `selectionDashed` for configurable selection border style.

- **Bug Fixes**
	- Improved type safety and clarity in the `createHandleShape` method and `EdgeHandlerConfig`.

- **Documentation**
	- Refined documentation comments for the `createHandleShape` method to clarify parameter usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->