### PR TITLE
ci: improve the template of the GitHub release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
     - name: Get milestone number (do not exist)
       env:
+        GH_TOKEN: ${{ github.token }}
         VERSION: 0.1.8
       run: |
         MILESTONE_NUMBER=$(gh api graphql -f query='
@@ -28,6 +29,7 @@ jobs:
 
     - name: Get milestone number (exist)
       env:
+        GH_TOKEN: ${{ github.token }}
         VERSION: 0.15.0
       run: |
         MILESTONE_NUMBER=$(gh api graphql -f query='

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,49 +1,76 @@
 name: Build
 
-# TMP validate the graphql query
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/actions/build-setup/**/*'
+      - '.github/workflows/build.yml'
+      - '.eslint*'
+      - '.nvmrc'
+      - 'packages/**/*'
+      - '!packages/**/*.md'
+      - '!packages/website/**/*'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
   pull_request:
     branches:
       - main
     paths:
+      - '.github/actions/build-setup/**/*'
       - '.github/workflows/build.yml'
+      - '.eslint*'
+      - '.nvmrc'
+      - 'packages/**/*'
+      - '!packages/**/*.md'
+      - '!packages/website/**/*'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # we want to run the full build on all os: don't cancel running jobs even if one fails
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-22.04', 'macos-14', 'windows-2022']
     steps:
-    - name: Get milestone number (do not exist)
-      env:
-        GH_TOKEN: ${{ github.token }}
-        VERSION: 0.1.8
-      run: |
-        MILESTONE_NUMBER=$(gh api graphql -f query='
-          query($version: String!) {
-            repository(owner: "maxGraph", name: "maxGraph") {
-              milestones(first: 1, query: $version) {
-                nodes { number }
-              }
-            }
-          }' -f version="${{ env.VERSION }}" --jq '.data.repository.milestones.nodes[0].number')
-        echo "MILESTONE_NUMBER_1=${MILESTONE_NUMBER:-unknown}" >> $GITHUB_ENV
-
-    - name: Get milestone number (exist)
-      env:
-        GH_TOKEN: ${{ github.token }}
-        VERSION: 0.15.0
-      run: |
-        MILESTONE_NUMBER=$(gh api graphql -f query='
-          query($version: String!) {
-            repository(owner: "maxGraph", name: "maxGraph") {
-              milestones(first: 1, query: $version) {
-                nodes { number }
-              }
-            }
-          }' -f version="${{ env.VERSION }}" --jq '.data.repository.milestones.nodes[0].number')
-        echo "MILESTONE_NUMBER_2=${MILESTONE_NUMBER:-unknown}" >> $GITHUB_ENV
-
-    - name: List milestone numbers
-      run: |
-        echo "MILESTONE_NUMBER_1=${{ env.MILESTONE_NUMBER_1 }}"
-        echo "MILESTONE_NUMBER_2=${{ env.MILESTONE_NUMBER_2 }}"
-
+      - uses: actions/checkout@v4
+      - name: Build Setup
+        uses: ./.github/actions/build-setup
+      - name: Build @maxgraph/core - esm
+        run: npm run build -w packages/core
+      - name: Check TS compilation of the tests of @maxgraph/core
+        run: npm run test-check -w packages/core
+      - name: Test @maxgraph/core
+        run: npm test -w packages/core -- --coverage
+      - name: Upload test results as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-coverage-${{runner.os}}-${{github.sha}}
+          path: packages/core/coverage/lcov-report
+      - name: Test TypeScript support
+        run: npm test -w packages/ts-support
+      - name: Build ts-example (custom shapes)
+        run: npm run build -w packages/ts-example
+      - name: Build ts-example (without defaults)
+        run: npm run build -w packages/ts-example-without-defaults
+      - name: Build Storybook mini-site
+        run: npm run build -w packages/html
+      - name: Build js-example
+        run: npm run build -w packages/js-example
+      - name: Upload all examples as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: examples-${{runner.os}}-${{github.sha}}
+          path: |
+            packages/html/dist/
+            packages/js-example/dist/
+            packages/ts-example/dist/
+            packages/ts-example-without-defaults/dist/
+      - name: Ensure no lint errors
+        run: npm run lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,76 +1,47 @@
 name: Build
 
+# TMP validate the graphql query
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - '.github/actions/build-setup/**/*'
-      - '.github/workflows/build.yml'
-      - '.eslint*'
-      - '.nvmrc'
-      - 'packages/**/*'
-      - '!packages/**/*.md'
-      - '!packages/website/**/*'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'tsconfig.json'
   pull_request:
     branches:
       - main
     paths:
-      - '.github/actions/build-setup/**/*'
       - '.github/workflows/build.yml'
-      - '.eslint*'
-      - '.nvmrc'
-      - 'packages/**/*'
-      - '!packages/**/*.md'
-      - '!packages/website/**/*'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'tsconfig.json'
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      # we want to run the full build on all os: don't cancel running jobs even if one fails
-      fail-fast: false
-      matrix:
-        os: ['ubuntu-22.04', 'macos-14', 'windows-2022']
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
-      - name: Build Setup
-        uses: ./.github/actions/build-setup
-      - name: Build @maxgraph/core - esm
-        run: npm run build -w packages/core
-      - name: Check TS compilation of the tests of @maxgraph/core
-        run: npm run test-check -w packages/core
-      - name: Test @maxgraph/core
-        run: npm test -w packages/core -- --coverage
-      - name: Upload test results as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-coverage-${{runner.os}}-${{github.sha}}
-          path: packages/core/coverage/lcov-report
-      - name: Test TypeScript support
-        run: npm test -w packages/ts-support
-      - name: Build ts-example (custom shapes)
-        run: npm run build -w packages/ts-example
-      - name: Build ts-example (without defaults)
-        run: npm run build -w packages/ts-example-without-defaults
-      - name: Build Storybook mini-site
-        run: npm run build -w packages/html
-      - name: Build js-example
-        run: npm run build -w packages/js-example
-      - name: Upload all examples as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: examples-${{runner.os}}-${{github.sha}}
-          path: |
-            packages/html/dist/
-            packages/js-example/dist/
-            packages/ts-example/dist/
-            packages/ts-example-without-defaults/dist/
-      - name: Ensure no lint errors
-        run: npm run lint
+    - name: Get milestone number (do not exist)
+      env:
+        VERSION: 0.1.8
+      run: |
+        MILESTONE_NUMBER=$(gh api graphql -f query='
+          query($version: String!) {
+            repository(owner: "maxGraph", name: "maxGraph") {
+              milestones(first: 1, query: $version) {
+                nodes { number }
+              }
+            }
+          }' -f version="${{ env.VERSION }}" --jq '.data.repository.milestones.nodes[0].number')
+        echo "MILESTONE_NUMBER_1=${MILESTONE_NUMBER:-unknown}" >> $GITHUB_ENV
+
+    - name: Get milestone number (exist)
+      env:
+        VERSION: 0.15.0
+      run: |
+        MILESTONE_NUMBER=$(gh api graphql -f query='
+          query($version: String!) {
+            repository(owner: "maxGraph", name: "maxGraph") {
+              milestones(first: 1, query: $version) {
+                nodes { number }
+              }
+            }
+          }' -f version="${{ env.VERSION }}" --jq '.data.repository.milestones.nodes[0].number')
+        echo "MILESTONE_NUMBER_2=${MILESTONE_NUMBER:-unknown}" >> $GITHUB_ENV
+
+    - name: List milestone numbers
+      run: |
+        echo "MILESTONE_NUMBER_1=${{ env.MILESTONE_NUMBER_1 }}"
+        echo "MILESTONE_NUMBER_2=${{ env.MILESTONE_NUMBER_2 }}"
+

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -27,11 +27,11 @@ jobs:
 
             **TODO: Update the milestone URL**
 
-            - **npm package**: [${{ env.VERSION }}](https://www.npmjs.com/package/@maxgraph/core/v/${{ env.VERSION }})
+            - **npm package**: [@maxgraph/core ${{ env.VERSION }}](https://www.npmjs.com/package/@maxgraph/core/v/${{ env.VERSION }})
             - **Fixed issues**: [milestone ${{ env.VERSION }}](https://github.com/maxGraph/maxGraph/milestone/x?closed=1)
             - **Documentation**: [maxgraph_${{ env.VERSION }}_website.zip](https://github.com/maxGraph/maxGraph/releases/download/v${{ env.VERSION }}/maxgraph_${{ env.VERSION }}_website.zip)
             - **Examples**: [maxgraph_${{ env.VERSION }}_examples.zip](https://github.com/maxGraph/maxGraph/releases/download/v${{ env.VERSION }}/maxgraph_${{ env.VERSION }}_examples.zip)
-            - **Changelog** (only includes a summary and breaking changes): [Changelog](https://github.com/maxGraph/maxGraph/tree/v${{ env.VERSION }}/CHANGELOG.md)
+            - **Changelog** (only includes a summary and breaking changes): [changelog](https://github.com/maxGraph/maxGraph/tree/v${{ env.VERSION }}/CHANGELOG.md)
 
 
             ## Breaking changes

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -18,14 +18,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          echo "Fetching milestone for version ${{ env.VERSION }}..."
           MILESTONE_NUMBER=$(gh api graphql -f query='
           query($version: String!) {
-           repository(owner: "maxGraph", name: "maxGraph") {
+           repository(owner: "${{ github.repository_owner }}", name: "${{ github.event.repository.name }}) {
              milestones(first: 1, query: $version) {
                nodes { number }
              }
            }
           }' -f version="${{ env.VERSION }}" --jq '.data.repository.milestones.nodes[0].number')
+          echo "Found milestone: ${MILESTONE_NUMBER}"
           echo "MILESTONE_NUMBER=${MILESTONE_NUMBER:-x}" >> $GITHUB_ENV
 
       - name: Create release

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -29,7 +29,9 @@ jobs:
 
             - **npm package**: [${{ env.VERSION }}](https://www.npmjs.com/package/@maxgraph/core/v/${{ env.VERSION }})
             - **Fixed issues**: [milestone ${{ env.VERSION }}](https://github.com/maxGraph/maxGraph/milestone/x?closed=1)
-            - **Changelog**: [Changelog](https://github.com/maxGraph/maxGraph/tree/v${{ env.VERSION }}/CHANGELOG.md)
+            - **Documentation**: [maxgraph_${{ env.VERSION }}_website.zip](https://github.com/maxGraph/maxGraph/releases/download/v${{ env.VERSION }}/maxgraph_${{ env.VERSION }}_website.zip)
+            - **Examples**: [maxgraph_${{ env.VERSION }}_examples.zip](https://github.com/maxGraph/maxGraph/releases/download/v${{ env.VERSION }}/maxgraph_${{ env.VERSION }}_examples.zip)
+            - **Changelog** (only includes a summary and breaking changes): [Changelog](https://github.com/maxGraph/maxGraph/tree/v${{ env.VERSION }}/CHANGELOG.md)
 
 
             ## Breaking changes

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -23,10 +23,13 @@ jobs:
 
             _If appropriate, briefly explain the contents of the new version._
 
-            npm package: [${{ env.VERSION }}](https://www.npmjs.com/package/@maxgraph/core/v/${{ env.VERSION }})
-            **Update the milestone URL**
-            Fixed issues: [milestone ${{ env.VERSION }}](https://github.com/maxGraph/maxGraph/milestone/x?closed=1)
-            See also the [Changelog](https://github.com/maxGraph/maxGraph/tree/v${{ env.VERSION }}/CHANGELOG.md) file.
+            ## Resources
+
+            **TODO: Update the milestone URL**
+
+            - **npm package**: [${{ env.VERSION }}](https://www.npmjs.com/package/@maxgraph/core/v/${{ env.VERSION }})
+            - **Fixed issues**: [milestone ${{ env.VERSION }}](https://github.com/maxGraph/maxGraph/milestone/x?closed=1)
+            - **Changelog**: [Changelog](https://github.com/maxGraph/maxGraph/tree/v${{ env.VERSION }}/CHANGELOG.md)
 
 
             ## Breaking changes
@@ -63,7 +66,8 @@ jobs:
 
             some explanations....
 
-            ℹ️ For more details, see #<PR_NUMBER>.
+            > [!NOTE]
+            >  For more details, see #<PR_NUMBER>.
 
             ### Other changes.... adapt and create more paragraphs
           draft: true

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -14,6 +14,20 @@ jobs:
       - name: Set env
         run: |
           echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+      - name: Get milestone number
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          MILESTONE_NUMBER=$(gh api graphql -f query='
+          query($version: String!) {
+           repository(owner: "maxGraph", name: "maxGraph") {
+             milestones(first: 1, query: $version) {
+               nodes { number }
+             }
+           }
+          }' -f version="${{ env.VERSION }}" --jq '.data.repository.milestones.nodes[0].number')
+          echo "MILESTONE_NUMBER=${MILESTONE_NUMBER:-x}" >> $GITHUB_ENV
+
       - name: Create release
         uses: ncipollo/release-action@v1
         with:
@@ -25,10 +39,10 @@ jobs:
 
             ## Resources
 
-            **TODO: Update the milestone URL**
+            **TODO: Validate the milestone URL and update it if needed**
 
             - **npm package**: [@maxgraph/core ${{ env.VERSION }}](https://www.npmjs.com/package/@maxgraph/core/v/${{ env.VERSION }})
-            - **Fixed issues**: [milestone ${{ env.VERSION }}](https://github.com/maxGraph/maxGraph/milestone/x?closed=1)
+            - **Fixed issues**: [milestone ${{ env.VERSION }}](https://github.com/maxGraph/maxGraph/milestone/${{ env.MILESTONE_NUMBER }}?closed=1)
             - **Documentation**: [maxgraph_${{ env.VERSION }}_website.zip](https://github.com/maxGraph/maxGraph/releases/download/v${{ env.VERSION }}/maxgraph_${{ env.VERSION }}_website.zip)
             - **Examples**: [maxgraph_${{ env.VERSION }}_examples.zip](https://github.com/maxGraph/maxGraph/releases/download/v${{ env.VERSION }}/maxgraph_${{ env.VERSION }}_examples.zip)
             - **Changelog** (only includes a summary and breaking changes): [changelog](https://github.com/maxGraph/maxGraph/tree/v${{ env.VERSION }}/CHANGELOG.md)


### PR DESCRIPTION
Implement feedback from the 0.14.0 release:
- add a dedicated paragraph for npm package, milestone, ...
- use GitHub markdown alert instead of emoji: this better highlight the contents

Also retrieve the milestone with the GH API to create the URL to the milestone

### Notes

Partially tested on commit 7a28b9f (additions in 44a5ecf and 00f80d4 have not been tested) with the build workflow in this PR, with both existing and not existing milestone for the given version https://github.com/maxGraph/maxGraph/actions/runs/13014585416/job/36300456635?pr=593
```
# version 0.1.8
MILESTONE_NUMBER_1=unknown
# version 0.15.0
MILESTONE_NUMBER_2=14
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a "Resources" section in release notes for easy access to npm package, documentation, and changelog.
	- Expanded sections for breaking changes and deprecated APIs with detailed guidelines.

- **Improvements**
	- Enhanced overall structure and clarity of release notes for better organization.
	- Reformatted additional details for improved visibility. 
	- Added a step to retrieve the milestone number associated with the release version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->