### PR TITLE
chore(deps-dev): bump docusaurus from 3.6.2 to 3.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,15 +100,15 @@
       }
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.15.0.tgz",
-      "integrity": "sha512-FaEM40iuiv1mAipYyiptP4EyxkJ8qHfowCpEeusdHUC4C7spATJYArD2rX3AxkVeREkDIgYEOuXcwKUbDCr7Nw==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.17.1.tgz",
+      "integrity": "sha512-Os/xkQbDp5A5RdGYq1yS3fF69GoBJH5FIfrkVh+fXxCSe714i1Xdl9XoXhS4xG76DGKm6EFMlUqP024qjps8cg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.15.0",
-        "@algolia/requester-browser-xhr": "5.15.0",
-        "@algolia/requester-fetch": "5.15.0",
-        "@algolia/requester-node-http": "5.15.0"
+        "@algolia/client-common": "5.17.1",
+        "@algolia/requester-browser-xhr": "5.17.1",
+        "@algolia/requester-fetch": "5.17.1",
+        "@algolia/requester-node-http": "5.17.1"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -180,24 +180,24 @@
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.15.0.tgz",
-      "integrity": "sha512-IofrVh213VLsDkPoSKMeM9Dshrv28jhDlBDLRcVJQvlL8pzue7PEB1EZ4UoJFYS3NSn7JOcJ/V+olRQzXlJj1w==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.17.1.tgz",
+      "integrity": "sha512-5rb5+yPIie6912riAypTSyzbE23a7UM1UpESvD8GEPI4CcWQvA9DBlkRNx9qbq/nJ5pvv8VjZjUxJj7rFkzEAA==",
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.15.0.tgz",
-      "integrity": "sha512-bDDEQGfFidDi0UQUCbxXOCdphbVAgbVmxvaV75cypBTQkJ+ABx/Npw7LkFGw1FsoVrttlrrQbwjvUB6mLVKs/w==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.17.1.tgz",
+      "integrity": "sha512-nb/tfwBMn209TzFv1DDTprBKt/wl5btHVKoAww9fdEVdoKK02R2KAqxe5tuXLdEzAsS+LevRyOM/YjXuLmPtjQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.15.0",
-        "@algolia/requester-browser-xhr": "5.15.0",
-        "@algolia/requester-fetch": "5.15.0",
-        "@algolia/requester-node-http": "5.15.0"
+        "@algolia/client-common": "5.17.1",
+        "@algolia/requester-browser-xhr": "5.17.1",
+        "@algolia/requester-fetch": "5.17.1",
+        "@algolia/requester-node-http": "5.17.1"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -225,30 +225,30 @@
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.15.0.tgz",
-      "integrity": "sha512-wu8GVluiZ5+il8WIRsGKu8VxMK9dAlr225h878GGtpTL6VBvwyJvAyLdZsfFIpY0iN++jiNb31q2C1PlPL+n/A==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.17.1.tgz",
+      "integrity": "sha512-RBIFIv1QE3IlAikJKWTOpd6pwE4d2dY6t02iXH7r/SLXWn0HzJtsAPPeFg/OKkFvWAXt0H7In2/Mp7a1/Dy2pw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.15.0",
-        "@algolia/requester-browser-xhr": "5.15.0",
-        "@algolia/requester-fetch": "5.15.0",
-        "@algolia/requester-node-http": "5.15.0"
+        "@algolia/client-common": "5.17.1",
+        "@algolia/requester-browser-xhr": "5.17.1",
+        "@algolia/requester-fetch": "5.17.1",
+        "@algolia/requester-node-http": "5.17.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.15.0.tgz",
-      "integrity": "sha512-Z32gEMrRRpEta5UqVQA612sLdoqY3AovvUPClDfMxYrbdDAebmGDVPtSogUba1FZ4pP5dx20D3OV3reogLKsRA==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.17.1.tgz",
+      "integrity": "sha512-bd5JBUOP71kPsxwDcvOxqtqXXVo/706NFifZ/O5Rx5GB8ZNVAhg4l7aGoT6jBvEfgmrp2fqPbkdIZ6JnuOpGcw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.15.0",
-        "@algolia/requester-browser-xhr": "5.15.0",
-        "@algolia/requester-fetch": "5.15.0",
-        "@algolia/requester-node-http": "5.15.0"
+        "@algolia/client-common": "5.17.1",
+        "@algolia/requester-browser-xhr": "5.17.1",
+        "@algolia/requester-fetch": "5.17.1",
+        "@algolia/requester-node-http": "5.17.1"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -261,15 +261,15 @@
       "license": "MIT"
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.15.0.tgz",
-      "integrity": "sha512-MkqkAxBQxtQ5if/EX2IPqFA7LothghVyvPoRNA/meS2AW2qkHwcxjuiBxv4H6mnAVEPfJlhu9rkdVz9LgCBgJg==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.17.1.tgz",
+      "integrity": "sha512-T18tvePi1rjRYcIKhd82oRukrPWHxG/Iy1qFGaxCplgRm9Im5z96qnYOq75MSKGOUHkFxaBKJOLmtn8xDR+Mcw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.15.0",
-        "@algolia/requester-browser-xhr": "5.15.0",
-        "@algolia/requester-fetch": "5.15.0",
-        "@algolia/requester-node-http": "5.15.0"
+        "@algolia/client-common": "5.17.1",
+        "@algolia/requester-browser-xhr": "5.17.1",
+        "@algolia/requester-fetch": "5.17.1",
+        "@algolia/requester-node-http": "5.17.1"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -291,15 +291,15 @@
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.15.0.tgz",
-      "integrity": "sha512-QPrFnnGLMMdRa8t/4bs7XilPYnoUXDY8PMQJ1sf9ZFwhUysYYhQNX34/enoO0LBjpoOY6rLpha39YQEFbzgKyQ==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.17.1.tgz",
+      "integrity": "sha512-gDtow+AUywTehRP8S1tWKx2IvhcJOxldAoqBxzN3asuQobF7er5n72auBeL++HY4ImEuzMi7PDOA/Iuwxs2IcA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.15.0",
-        "@algolia/requester-browser-xhr": "5.15.0",
-        "@algolia/requester-fetch": "5.15.0",
-        "@algolia/requester-node-http": "5.15.0"
+        "@algolia/client-common": "5.17.1",
+        "@algolia/requester-browser-xhr": "5.17.1",
+        "@algolia/requester-fetch": "5.17.1",
+        "@algolia/requester-node-http": "5.17.1"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -364,12 +364,12 @@
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.15.0.tgz",
-      "integrity": "sha512-Po/GNib6QKruC3XE+WKP1HwVSfCDaZcXu48kD+gwmtDlqHWKc7Bq9lrS0sNZ456rfCKhXksOmMfUs4wRM/Y96w==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.17.1.tgz",
+      "integrity": "sha512-XpKgBfyczVesKgr7DOShNyPPu5kqlboimRRPjdqAw5grSyHhCmb8yoTIKy0TCqBABZeXRPMYT13SMruUVRXvHA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.15.0"
+        "@algolia/client-common": "5.17.1"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -382,24 +382,24 @@
       "license": "MIT"
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.15.0.tgz",
-      "integrity": "sha512-rOZ+c0P7ajmccAvpeeNrUmEKoliYFL8aOR5qGW5pFq3oj3Iept7Y5mEtEsOBYsRt6qLnaXn4zUKf+N8nvJpcIw==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.17.1.tgz",
+      "integrity": "sha512-EhUomH+DZP5vb6DnEjT0GvXaXBSwzZnuU6hPGNU1EYKRXDouRjII/bIWpVjt7ycMgL2D2oQruqDh6rAWUhQwRw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.15.0"
+        "@algolia/client-common": "5.17.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.15.0.tgz",
-      "integrity": "sha512-b1jTpbFf9LnQHEJP5ddDJKE2sAlhYd7EVSOWgzo/27n/SfCoHfqD0VWntnWYD83PnOKvfe8auZ2+xCb0TXotrQ==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.17.1.tgz",
+      "integrity": "sha512-PSnENJtl4/wBWXlGyOODbLYm6lSiFqrtww7UpQRCJdsHXlJKF8XAP6AME8NxvbE0Qo/RJUxK0mvyEh9sQcx6bg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.15.0"
+        "@algolia/client-common": "5.17.1"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -2202,9 +2202,9 @@
       }
     },
     "node_modules/@babel/preset-react": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.25.9.tgz",
-      "integrity": "sha512-D3to0uSPiWE7rBrdIICCd0tJSIGpLaaGptna2+w7Pft5xMqLpA1sz99DK5TZ1TjGbdQ/VI1eCSZ06dv3lT4JOw==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.26.3.tgz",
+      "integrity": "sha512-Nl03d6T9ky516DGK2YMxrTqvnpUW63TnJMOMonj+Zae0JiPC5BC9xPMSL6L8fiSpA5vP88qfygavVQvnLp+6Cw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
@@ -3591,21 +3591,21 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.0.tgz",
-      "integrity": "sha512-pieeipSOW4sQ0+bE5UFC51AOZp9NGxg89wAlZ1BAQFaiRAGK1IKUaPQ0UGZeNctJXyqZ1UvBtOQh2HH+U5GtmA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.1.tgz",
+      "integrity": "sha512-XiPhKT+ghUi4pEi/ACE9iDmwWsLA6d6xSwtR5ab48iB63OtYWFLZHUKdH7jHKTmwOs0Eg22TX4Kb3H5liFm5bQ==",
       "license": "MIT"
     },
     "node_modules/@docsearch/react": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.0.tgz",
-      "integrity": "sha512-WnFK720+iwTVt94CxY3u+FgX6exb3BfN5kE9xUY6uuAH/9W/UFboBZFLlrw/zxFRHoHZCOXRtOylsXF+6LHI+Q==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.1.tgz",
+      "integrity": "sha512-7vgQuktQNBQdNWO1jbkiwgIrTZ0r5nPIHqcO3Z2neAWgkdUuldvvMfEOEaPXT5lqcezEv7i0h+tC285nD3jpZg==",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-core": "1.17.7",
         "@algolia/autocomplete-preset-algolia": "1.17.7",
-        "@docsearch/css": "3.8.0",
-        "algoliasearch": "^5.12.0"
+        "@docsearch/css": "3.8.1",
+        "algoliasearch": "^5.14.2"
       },
       "peerDependencies": {
         "@types/react": ">= 16.8.0 < 19.0.0",
@@ -3629,78 +3629,78 @@
       }
     },
     "node_modules/@docsearch/react/node_modules/@algolia/client-analytics": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.15.0.tgz",
-      "integrity": "sha512-lho0gTFsQDIdCwyUKTtMuf9nCLwq9jOGlLGIeQGKDxXF7HbiAysFIu5QW/iQr1LzMgDyM9NH7K98KY+BiIFriQ==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.17.1.tgz",
+      "integrity": "sha512-WKpGC+cUhmdm3wndIlTh8RJXoVabUH+4HrvZHC4hXtvCYojEXYeep8RZstatwSZ7Ocg6Y2u67bLw90NEINuYEw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.15.0",
-        "@algolia/requester-browser-xhr": "5.15.0",
-        "@algolia/requester-fetch": "5.15.0",
-        "@algolia/requester-node-http": "5.15.0"
+        "@algolia/client-common": "5.17.1",
+        "@algolia/requester-browser-xhr": "5.17.1",
+        "@algolia/requester-fetch": "5.17.1",
+        "@algolia/requester-node-http": "5.17.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@docsearch/react/node_modules/@algolia/client-personalization": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.15.0.tgz",
-      "integrity": "sha512-LfaZqLUWxdYFq44QrasCDED5bSYOswpQjSiIL7Q5fYlefAAUO95PzBPKCfUhSwhb4rKxigHfDkd81AvEicIEoA==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.17.1.tgz",
+      "integrity": "sha512-JuNlZe1SdW9KbV0gcgdsiVkFfXt0mmPassdS3cBSGvZGbPB9JsHthD719k5Y6YOY4dGvw1JmC1i9CwCQHAS8hg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.15.0",
-        "@algolia/requester-browser-xhr": "5.15.0",
-        "@algolia/requester-fetch": "5.15.0",
-        "@algolia/requester-node-http": "5.15.0"
+        "@algolia/client-common": "5.17.1",
+        "@algolia/requester-browser-xhr": "5.17.1",
+        "@algolia/requester-fetch": "5.17.1",
+        "@algolia/requester-node-http": "5.17.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@docsearch/react/node_modules/@algolia/recommend": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.15.0.tgz",
-      "integrity": "sha512-5eupMwSqMLDObgSMF0XG958zR6GJP3f7jHDQ3/WlzCM9/YIJiWIUoJFGsko9GYsA5xbLDHE/PhWtq4chcCdaGQ==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.17.1.tgz",
+      "integrity": "sha512-2992tTHkRe18qmf5SP57N78kN1D3e5t4PO1rt10sJncWtXBZWiNOK6K/UcvWsFbNSGAogFcIcvIMAl5mNp6RWA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.15.0",
-        "@algolia/requester-browser-xhr": "5.15.0",
-        "@algolia/requester-fetch": "5.15.0",
-        "@algolia/requester-node-http": "5.15.0"
+        "@algolia/client-common": "5.17.1",
+        "@algolia/requester-browser-xhr": "5.17.1",
+        "@algolia/requester-fetch": "5.17.1",
+        "@algolia/requester-node-http": "5.17.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@docsearch/react/node_modules/algoliasearch": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.15.0.tgz",
-      "integrity": "sha512-Yf3Swz1s63hjvBVZ/9f2P1Uu48GjmjCN+Esxb6MAONMGtZB1fRX8/S1AhUTtsuTlcGovbYLxpHgc7wEzstDZBw==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.17.1.tgz",
+      "integrity": "sha512-3CcbT5yTWJDIcBe9ZHgsPi184SkT1kyZi3GWlQU5EFgvq1V73X2sqHRkPCQMe0RA/uvZbB+1sFeAk73eWygeLg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-abtesting": "5.15.0",
-        "@algolia/client-analytics": "5.15.0",
-        "@algolia/client-common": "5.15.0",
-        "@algolia/client-insights": "5.15.0",
-        "@algolia/client-personalization": "5.15.0",
-        "@algolia/client-query-suggestions": "5.15.0",
-        "@algolia/client-search": "5.15.0",
-        "@algolia/ingestion": "1.15.0",
-        "@algolia/monitoring": "1.15.0",
-        "@algolia/recommend": "5.15.0",
-        "@algolia/requester-browser-xhr": "5.15.0",
-        "@algolia/requester-fetch": "5.15.0",
-        "@algolia/requester-node-http": "5.15.0"
+        "@algolia/client-abtesting": "5.17.1",
+        "@algolia/client-analytics": "5.17.1",
+        "@algolia/client-common": "5.17.1",
+        "@algolia/client-insights": "5.17.1",
+        "@algolia/client-personalization": "5.17.1",
+        "@algolia/client-query-suggestions": "5.17.1",
+        "@algolia/client-search": "5.17.1",
+        "@algolia/ingestion": "1.17.1",
+        "@algolia/monitoring": "1.17.1",
+        "@algolia/recommend": "5.17.1",
+        "@algolia/requester-browser-xhr": "5.17.1",
+        "@algolia/requester-fetch": "5.17.1",
+        "@algolia/requester-node-http": "5.17.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@docusaurus/babel": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.6.2.tgz",
-      "integrity": "sha512-v8N8TWGXDsb5sxQC3Rcqb1CZr0LlU1OgqqVBUchN6cpIUr7EJuVJs5eHcIu5Ag8mwO/hWN3f7FE9uaHTMapAbg==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.6.3.tgz",
+      "integrity": "sha512-7dW9Hat9EHYCVicFXYA4hjxBY38+hPuCURL8oRF9fySRm7vzNWuEOghA1TXcykuXZp0HLG2td4RhDxCvGG7tNw==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.9",
@@ -3713,8 +3713,8 @@
         "@babel/runtime": "^7.25.9",
         "@babel/runtime-corejs3": "^7.25.9",
         "@babel/traverse": "^7.25.9",
-        "@docusaurus/logger": "3.6.2",
-        "@docusaurus/utils": "3.6.2",
+        "@docusaurus/logger": "3.6.3",
+        "@docusaurus/utils": "3.6.3",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -3724,17 +3724,17 @@
       }
     },
     "node_modules/@docusaurus/bundler": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.6.2.tgz",
-      "integrity": "sha512-YkEifEVs4lV931SrHBB4n6WqRowMw+aM/QPH3z8aU+5t1dWa+1p2OPqARS+tSbh3la9ns+L1zIfSbd8RHi2/PQ==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.6.3.tgz",
+      "integrity": "sha512-47JLuc8D4wA+6VOvmMd5fUC9rFppBQpQOnxDYiVXffm/DeV/wmm3sbpNd5Y+O+G2+nevLTRnvCm/qyancv0Y3A==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.9",
-        "@docusaurus/babel": "3.6.2",
-        "@docusaurus/cssnano-preset": "3.6.2",
-        "@docusaurus/logger": "3.6.2",
-        "@docusaurus/types": "3.6.2",
-        "@docusaurus/utils": "3.6.2",
+        "@docusaurus/babel": "3.6.3",
+        "@docusaurus/cssnano-preset": "3.6.3",
+        "@docusaurus/logger": "3.6.3",
+        "@docusaurus/types": "3.6.3",
+        "@docusaurus/utils": "3.6.3",
         "babel-loader": "^9.2.1",
         "clean-css": "^5.3.2",
         "copy-webpack-plugin": "^11.0.0",
@@ -3820,16 +3820,16 @@
       }
     },
     "node_modules/@docusaurus/bundler/node_modules/webpack": {
-      "version": "5.96.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
-      "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
+      "version": "5.97.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
+      "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
-        "@webassemblyjs/ast": "^1.12.1",
-        "@webassemblyjs/wasm-edit": "^1.12.1",
-        "@webassemblyjs/wasm-parser": "^1.12.1",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
         "acorn": "^8.14.0",
         "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
@@ -3866,9 +3866,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.6.2.tgz",
-      "integrity": "sha512-mBkVa4QMHRwCFCVLYdBlOZuAT1iVVsS7GGSgliSVAeTOagP/AbtlBsCVrBs+keEuDuRF1w/6QEcqDoZe9fa5pw==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.6.3.tgz",
+      "integrity": "sha512-qP7SXrwZ+23GFJdPN4aIHQrZW+oH/7tzwEuc/RNL0+BdZdmIjYQqUxdXsjE4lFxLNZjj0eUrSNYIS6xwfij+5Q==",
       "license": "MIT",
       "dependencies": {
         "cssnano-preset-advanced": "^6.1.2",
@@ -3881,12 +3881,12 @@
       }
     },
     "node_modules/@docusaurus/faster": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/faster/-/faster-3.6.2.tgz",
-      "integrity": "sha512-r+soceklUKPaP6KRh5JXsN/Y6WBAqbsi6It/TuLppHNpSwZF/kZzSCvjG+XigIr92G2bdHUDpPocFOfNrANv0w==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/faster/-/faster-3.6.3.tgz",
+      "integrity": "sha512-cHad4m/SPDEMRHJTLsGCe194NVYwD4D3ebCd1WvjJtbq7EJSkZ0u7WULY9pccQfHcv01tbrdUixzzJn0jVAWVg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.6.2",
+        "@docusaurus/types": "3.6.3",
         "@rspack/core": "^1.1.1",
         "@swc/core": "^1.7.39",
         "@swc/html": "^1.7.39",
@@ -4200,9 +4200,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.6.2.tgz",
-      "integrity": "sha512-1p4IQhhgLyIfsey4UAdAIW69aUE1Ei6O91Nsw30ryZeDWSG5dh4o3zaRGOLxfAX69Ac/yDm6YCwJOafUxL6Vxg==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.6.3.tgz",
+      "integrity": "sha512-xSubJixcNyMV9wMV4q0s47CBz3Rlc5jbcCCuij8pfQP8qn/DIpt0ks8W6hQWzHAedg/J/EwxxUOUrnEoKzJo8g==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -4265,14 +4265,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.6.2.tgz",
-      "integrity": "sha512-7fbRmNgF3CR96Ja82Ya0/Cdu1OL9UJ/22llNMY8lr5gAbw718Y5ryXMVRIYn0JNLTiSxzgtvW4DIsUWEB8NMpw==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.6.3.tgz",
+      "integrity": "sha512-3iJdiDz9540ppBseeI93tWTDtUGVkxzh59nMq4ignylxMuXBLK8dFqVeaEor23v1vx6TrGKZ2FuLaTB+U7C0QQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.6.2",
-        "@docusaurus/utils": "3.6.2",
-        "@docusaurus/utils-validation": "3.6.2",
+        "@docusaurus/logger": "3.6.3",
+        "@docusaurus/utils": "3.6.3",
+        "@docusaurus/utils-validation": "3.6.3",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -4304,12 +4304,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.6.2.tgz",
-      "integrity": "sha512-NrJkL2rLTCjHtWOqUvWzwqvJrsKLj0gVJeV6q5yeKdKKgItietcTf2fTRkM9LHKSUN8CBDXxwHABeQvTahvmXQ==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.6.3.tgz",
+      "integrity": "sha512-MjaXX9PN/k5ugNvfRZdWyKWq4FsrhN4LEXaj0pEmMebJuBNlFeGyKQUa9DRhJHpadNaiMLrbo9m3U7Ig5YlsZg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.6.2",
+        "@docusaurus/types": "3.6.3",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -4323,19 +4323,19 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.6.2.tgz",
-      "integrity": "sha512-6bJxr6Or4NslEVH3BJuPH30kUWiqUjDRdGPhvxpHmt9W/RY2/6u72WICG3bW3dLFxJ/2uDLBU92lHnatpvo7Ew==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.6.3.tgz",
+      "integrity": "sha512-k0ogWwwJU3pFRFfvW1kRVHxzf2DutLGaaLjAnHVEU6ju+aRP0Z5ap/13DHyPOfHeE4WKpn/M0TqjdwZAcY3kAw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.6.2",
-        "@docusaurus/logger": "3.6.2",
-        "@docusaurus/mdx-loader": "3.6.2",
-        "@docusaurus/theme-common": "3.6.2",
-        "@docusaurus/types": "3.6.2",
-        "@docusaurus/utils": "3.6.2",
-        "@docusaurus/utils-common": "3.6.2",
-        "@docusaurus/utils-validation": "3.6.2",
+        "@docusaurus/core": "3.6.3",
+        "@docusaurus/logger": "3.6.3",
+        "@docusaurus/mdx-loader": "3.6.3",
+        "@docusaurus/theme-common": "3.6.3",
+        "@docusaurus/types": "3.6.3",
+        "@docusaurus/utils": "3.6.3",
+        "@docusaurus/utils-common": "3.6.3",
+        "@docusaurus/utils-validation": "3.6.3",
         "cheerio": "1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
@@ -4357,18 +4357,18 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/core": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.6.2.tgz",
-      "integrity": "sha512-irMts/mGLZv8dWcy0WUtbY/U6b5qIfHgQd1/kXMyAxUJo99fL0wFSqhMI+tcxjk0HYy427MXerLMqFJj+Arg1w==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.6.3.tgz",
+      "integrity": "sha512-xL7FRY9Jr5DWqB6pEnqgKqcMPJOX5V0pgWXi5lCiih11sUBmcFKM7c3+GyxcVeeWFxyYSDP3grLTWqJoP4P9Vw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/babel": "3.6.2",
-        "@docusaurus/bundler": "3.6.2",
-        "@docusaurus/logger": "3.6.2",
-        "@docusaurus/mdx-loader": "3.6.2",
-        "@docusaurus/utils": "3.6.2",
-        "@docusaurus/utils-common": "3.6.2",
-        "@docusaurus/utils-validation": "3.6.2",
+        "@docusaurus/babel": "3.6.3",
+        "@docusaurus/bundler": "3.6.3",
+        "@docusaurus/logger": "3.6.3",
+        "@docusaurus/mdx-loader": "3.6.3",
+        "@docusaurus/utils": "3.6.3",
+        "@docusaurus/utils-common": "3.6.3",
+        "@docusaurus/utils-validation": "3.6.3",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
@@ -4553,16 +4553,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog/node_modules/webpack": {
-      "version": "5.96.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
-      "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
+      "version": "5.97.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
+      "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
-        "@webassemblyjs/ast": "^1.12.1",
-        "@webassemblyjs/wasm-edit": "^1.12.1",
-        "@webassemblyjs/wasm-parser": "^1.12.1",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
         "acorn": "^8.14.0",
         "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
@@ -4613,20 +4613,20 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.6.2.tgz",
-      "integrity": "sha512-e6WW1g10RIXXLN/rrtqTi/FyJ1Hj3X9Mmgz4V11/0pDCxIGGI8m4ocbAglUlLtgvbLD5viNLefl/NwbOW3JXiQ==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.6.3.tgz",
+      "integrity": "sha512-r2wS8y/fsaDcxkm20W5bbYJFPzdWdEaTWVYjNxlHlcmX086eqQR1Fomlg9BHTJ0dLXPzAlbC8EN4XqMr3QzNCQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.6.2",
-        "@docusaurus/logger": "3.6.2",
-        "@docusaurus/mdx-loader": "3.6.2",
-        "@docusaurus/module-type-aliases": "3.6.2",
-        "@docusaurus/theme-common": "3.6.2",
-        "@docusaurus/types": "3.6.2",
-        "@docusaurus/utils": "3.6.2",
-        "@docusaurus/utils-common": "3.6.2",
-        "@docusaurus/utils-validation": "3.6.2",
+        "@docusaurus/core": "3.6.3",
+        "@docusaurus/logger": "3.6.3",
+        "@docusaurus/mdx-loader": "3.6.3",
+        "@docusaurus/module-type-aliases": "3.6.3",
+        "@docusaurus/theme-common": "3.6.3",
+        "@docusaurus/types": "3.6.3",
+        "@docusaurus/utils": "3.6.3",
+        "@docusaurus/utils-common": "3.6.3",
+        "@docusaurus/utils-validation": "3.6.3",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -4645,18 +4645,18 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/core": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.6.2.tgz",
-      "integrity": "sha512-irMts/mGLZv8dWcy0WUtbY/U6b5qIfHgQd1/kXMyAxUJo99fL0wFSqhMI+tcxjk0HYy427MXerLMqFJj+Arg1w==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.6.3.tgz",
+      "integrity": "sha512-xL7FRY9Jr5DWqB6pEnqgKqcMPJOX5V0pgWXi5lCiih11sUBmcFKM7c3+GyxcVeeWFxyYSDP3grLTWqJoP4P9Vw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/babel": "3.6.2",
-        "@docusaurus/bundler": "3.6.2",
-        "@docusaurus/logger": "3.6.2",
-        "@docusaurus/mdx-loader": "3.6.2",
-        "@docusaurus/utils": "3.6.2",
-        "@docusaurus/utils-common": "3.6.2",
-        "@docusaurus/utils-validation": "3.6.2",
+        "@docusaurus/babel": "3.6.3",
+        "@docusaurus/bundler": "3.6.3",
+        "@docusaurus/logger": "3.6.3",
+        "@docusaurus/mdx-loader": "3.6.3",
+        "@docusaurus/utils": "3.6.3",
+        "@docusaurus/utils-common": "3.6.3",
+        "@docusaurus/utils-validation": "3.6.3",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
@@ -4841,16 +4841,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs/node_modules/webpack": {
-      "version": "5.96.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
-      "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
+      "version": "5.97.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
+      "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
-        "@webassemblyjs/ast": "^1.12.1",
-        "@webassemblyjs/wasm-edit": "^1.12.1",
-        "@webassemblyjs/wasm-parser": "^1.12.1",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
         "acorn": "^8.14.0",
         "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
@@ -4901,16 +4901,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.6.2.tgz",
-      "integrity": "sha512-fo4NyGkw10lYHyHaTxE6TZLYnxNtCfRHeZkNK1N9pBYqe7TT2dBUNAEeVW2U3ed9m6YuB7JKSQsa++GGmcP+6g==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.6.3.tgz",
+      "integrity": "sha512-eHrmTgjgLZsuqfsYr5X2xEwyIcck0wseSofWrjTwT9FLOWp+KDmMAuVK+wRo7sFImWXZk3oV/xX/g9aZrhD7OA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.6.2",
-        "@docusaurus/mdx-loader": "3.6.2",
-        "@docusaurus/types": "3.6.2",
-        "@docusaurus/utils": "3.6.2",
-        "@docusaurus/utils-validation": "3.6.2",
+        "@docusaurus/core": "3.6.3",
+        "@docusaurus/mdx-loader": "3.6.3",
+        "@docusaurus/types": "3.6.3",
+        "@docusaurus/utils": "3.6.3",
+        "@docusaurus/utils-validation": "3.6.3",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -4924,18 +4924,18 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/core": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.6.2.tgz",
-      "integrity": "sha512-irMts/mGLZv8dWcy0WUtbY/U6b5qIfHgQd1/kXMyAxUJo99fL0wFSqhMI+tcxjk0HYy427MXerLMqFJj+Arg1w==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.6.3.tgz",
+      "integrity": "sha512-xL7FRY9Jr5DWqB6pEnqgKqcMPJOX5V0pgWXi5lCiih11sUBmcFKM7c3+GyxcVeeWFxyYSDP3grLTWqJoP4P9Vw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/babel": "3.6.2",
-        "@docusaurus/bundler": "3.6.2",
-        "@docusaurus/logger": "3.6.2",
-        "@docusaurus/mdx-loader": "3.6.2",
-        "@docusaurus/utils": "3.6.2",
-        "@docusaurus/utils-common": "3.6.2",
-        "@docusaurus/utils-validation": "3.6.2",
+        "@docusaurus/babel": "3.6.3",
+        "@docusaurus/bundler": "3.6.3",
+        "@docusaurus/logger": "3.6.3",
+        "@docusaurus/mdx-loader": "3.6.3",
+        "@docusaurus/utils": "3.6.3",
+        "@docusaurus/utils-common": "3.6.3",
+        "@docusaurus/utils-validation": "3.6.3",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
@@ -5120,16 +5120,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages/node_modules/webpack": {
-      "version": "5.96.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
-      "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
+      "version": "5.97.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
+      "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
-        "@webassemblyjs/ast": "^1.12.1",
-        "@webassemblyjs/wasm-edit": "^1.12.1",
-        "@webassemblyjs/wasm-parser": "^1.12.1",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
         "acorn": "^8.14.0",
         "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
@@ -5180,14 +5180,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.6.2.tgz",
-      "integrity": "sha512-T/eS3VvHElpeV5S8uwp7Si4ujEynmgFtJLvA2CSa5pzQuOF1EEghF9nekAIj0cWtDHsqNUDZNr8hK1brivFXSg==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.6.3.tgz",
+      "integrity": "sha512-zB9GXfIZNPRfzKnNjU6xGVrqn9bPXuGhpjgsuc/YtcTDjnjhasg38NdYd5LEqXex5G/zIorQgWB3n6x/Ut62vQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.6.2",
-        "@docusaurus/types": "3.6.2",
-        "@docusaurus/utils": "3.6.2",
+        "@docusaurus/core": "3.6.3",
+        "@docusaurus/types": "3.6.3",
+        "@docusaurus/utils": "3.6.3",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^1.2.0",
         "tslib": "^2.6.0"
@@ -5201,18 +5201,18 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/core": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.6.2.tgz",
-      "integrity": "sha512-irMts/mGLZv8dWcy0WUtbY/U6b5qIfHgQd1/kXMyAxUJo99fL0wFSqhMI+tcxjk0HYy427MXerLMqFJj+Arg1w==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.6.3.tgz",
+      "integrity": "sha512-xL7FRY9Jr5DWqB6pEnqgKqcMPJOX5V0pgWXi5lCiih11sUBmcFKM7c3+GyxcVeeWFxyYSDP3grLTWqJoP4P9Vw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/babel": "3.6.2",
-        "@docusaurus/bundler": "3.6.2",
-        "@docusaurus/logger": "3.6.2",
-        "@docusaurus/mdx-loader": "3.6.2",
-        "@docusaurus/utils": "3.6.2",
-        "@docusaurus/utils-common": "3.6.2",
-        "@docusaurus/utils-validation": "3.6.2",
+        "@docusaurus/babel": "3.6.3",
+        "@docusaurus/bundler": "3.6.3",
+        "@docusaurus/logger": "3.6.3",
+        "@docusaurus/mdx-loader": "3.6.3",
+        "@docusaurus/utils": "3.6.3",
+        "@docusaurus/utils-common": "3.6.3",
+        "@docusaurus/utils-validation": "3.6.3",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
@@ -5397,16 +5397,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug/node_modules/webpack": {
-      "version": "5.96.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
-      "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
+      "version": "5.97.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
+      "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
-        "@webassemblyjs/ast": "^1.12.1",
-        "@webassemblyjs/wasm-edit": "^1.12.1",
-        "@webassemblyjs/wasm-parser": "^1.12.1",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
         "acorn": "^8.14.0",
         "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
@@ -5457,14 +5457,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.6.2.tgz",
-      "integrity": "sha512-B7ihrr3wz8e4XqW+dIAtq844u3Z83u5CeiL1xrCqzFH+vDCjUZHTamS3zKXNcgi6YVVe6hUQXPG15ltaqQaVPQ==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.6.3.tgz",
+      "integrity": "sha512-rCDNy1QW8Dag7nZq67pcum0bpFLrwvxJhYuVprhFh8BMBDxV0bY+bAkGHbSf68P3Bk9C3hNOAXX1srGLIDvcTA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.6.2",
-        "@docusaurus/types": "3.6.2",
-        "@docusaurus/utils-validation": "3.6.2",
+        "@docusaurus/core": "3.6.3",
+        "@docusaurus/types": "3.6.3",
+        "@docusaurus/utils-validation": "3.6.3",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -5476,18 +5476,18 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/core": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.6.2.tgz",
-      "integrity": "sha512-irMts/mGLZv8dWcy0WUtbY/U6b5qIfHgQd1/kXMyAxUJo99fL0wFSqhMI+tcxjk0HYy427MXerLMqFJj+Arg1w==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.6.3.tgz",
+      "integrity": "sha512-xL7FRY9Jr5DWqB6pEnqgKqcMPJOX5V0pgWXi5lCiih11sUBmcFKM7c3+GyxcVeeWFxyYSDP3grLTWqJoP4P9Vw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/babel": "3.6.2",
-        "@docusaurus/bundler": "3.6.2",
-        "@docusaurus/logger": "3.6.2",
-        "@docusaurus/mdx-loader": "3.6.2",
-        "@docusaurus/utils": "3.6.2",
-        "@docusaurus/utils-common": "3.6.2",
-        "@docusaurus/utils-validation": "3.6.2",
+        "@docusaurus/babel": "3.6.3",
+        "@docusaurus/bundler": "3.6.3",
+        "@docusaurus/logger": "3.6.3",
+        "@docusaurus/mdx-loader": "3.6.3",
+        "@docusaurus/utils": "3.6.3",
+        "@docusaurus/utils-common": "3.6.3",
+        "@docusaurus/utils-validation": "3.6.3",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
@@ -5672,16 +5672,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics/node_modules/webpack": {
-      "version": "5.96.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
-      "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
+      "version": "5.97.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
+      "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
-        "@webassemblyjs/ast": "^1.12.1",
-        "@webassemblyjs/wasm-edit": "^1.12.1",
-        "@webassemblyjs/wasm-parser": "^1.12.1",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
         "acorn": "^8.14.0",
         "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
@@ -5732,14 +5732,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.6.2.tgz",
-      "integrity": "sha512-V8ijI6qddAAkJ0vd8sjZ7S/apRTLJn9dAwvj/rSMd93witGdKINemL+9TyfLkhcXKTxyqRT8zKdu8ewjPXqKHg==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.6.3.tgz",
+      "integrity": "sha512-+OyDvhM6rqVkQOmLVkQWVJAizEEfkPzVWtIHXlWPOCFGK9X4/AWeBSrU0WG4iMg9Z4zD4YDRrU+lvI4s6DSC+w==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.6.2",
-        "@docusaurus/types": "3.6.2",
-        "@docusaurus/utils-validation": "3.6.2",
+        "@docusaurus/core": "3.6.3",
+        "@docusaurus/types": "3.6.3",
+        "@docusaurus/utils-validation": "3.6.3",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       },
@@ -5752,18 +5752,18 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/core": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.6.2.tgz",
-      "integrity": "sha512-irMts/mGLZv8dWcy0WUtbY/U6b5qIfHgQd1/kXMyAxUJo99fL0wFSqhMI+tcxjk0HYy427MXerLMqFJj+Arg1w==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.6.3.tgz",
+      "integrity": "sha512-xL7FRY9Jr5DWqB6pEnqgKqcMPJOX5V0pgWXi5lCiih11sUBmcFKM7c3+GyxcVeeWFxyYSDP3grLTWqJoP4P9Vw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/babel": "3.6.2",
-        "@docusaurus/bundler": "3.6.2",
-        "@docusaurus/logger": "3.6.2",
-        "@docusaurus/mdx-loader": "3.6.2",
-        "@docusaurus/utils": "3.6.2",
-        "@docusaurus/utils-common": "3.6.2",
-        "@docusaurus/utils-validation": "3.6.2",
+        "@docusaurus/babel": "3.6.3",
+        "@docusaurus/bundler": "3.6.3",
+        "@docusaurus/logger": "3.6.3",
+        "@docusaurus/mdx-loader": "3.6.3",
+        "@docusaurus/utils": "3.6.3",
+        "@docusaurus/utils-common": "3.6.3",
+        "@docusaurus/utils-validation": "3.6.3",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
@@ -5948,16 +5948,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag/node_modules/webpack": {
-      "version": "5.96.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
-      "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
+      "version": "5.97.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
+      "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
-        "@webassemblyjs/ast": "^1.12.1",
-        "@webassemblyjs/wasm-edit": "^1.12.1",
-        "@webassemblyjs/wasm-parser": "^1.12.1",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
         "acorn": "^8.14.0",
         "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
@@ -6008,14 +6008,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.6.2.tgz",
-      "integrity": "sha512-fnWQ5FdN9f8c8VTgjaQ98208Y+d/JjHhD506rWIIL9rt1cJOf29XElxvOeKpMJadfkgY5KLZSAiHkGt+4qgN4g==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.6.3.tgz",
+      "integrity": "sha512-1M6UPB13gWUtN2UHX083/beTn85PlRI9ABItTl/JL1FJ5dJTWWFXXsHf9WW/6hrVwthwTeV/AGbGKvLKV+IlCA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.6.2",
-        "@docusaurus/types": "3.6.2",
-        "@docusaurus/utils-validation": "3.6.2",
+        "@docusaurus/core": "3.6.3",
+        "@docusaurus/types": "3.6.3",
+        "@docusaurus/utils-validation": "3.6.3",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -6027,18 +6027,18 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/core": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.6.2.tgz",
-      "integrity": "sha512-irMts/mGLZv8dWcy0WUtbY/U6b5qIfHgQd1/kXMyAxUJo99fL0wFSqhMI+tcxjk0HYy427MXerLMqFJj+Arg1w==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.6.3.tgz",
+      "integrity": "sha512-xL7FRY9Jr5DWqB6pEnqgKqcMPJOX5V0pgWXi5lCiih11sUBmcFKM7c3+GyxcVeeWFxyYSDP3grLTWqJoP4P9Vw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/babel": "3.6.2",
-        "@docusaurus/bundler": "3.6.2",
-        "@docusaurus/logger": "3.6.2",
-        "@docusaurus/mdx-loader": "3.6.2",
-        "@docusaurus/utils": "3.6.2",
-        "@docusaurus/utils-common": "3.6.2",
-        "@docusaurus/utils-validation": "3.6.2",
+        "@docusaurus/babel": "3.6.3",
+        "@docusaurus/bundler": "3.6.3",
+        "@docusaurus/logger": "3.6.3",
+        "@docusaurus/mdx-loader": "3.6.3",
+        "@docusaurus/utils": "3.6.3",
+        "@docusaurus/utils-common": "3.6.3",
+        "@docusaurus/utils-validation": "3.6.3",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
@@ -6223,16 +6223,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/webpack": {
-      "version": "5.96.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
-      "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
+      "version": "5.97.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
+      "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
-        "@webassemblyjs/ast": "^1.12.1",
-        "@webassemblyjs/wasm-edit": "^1.12.1",
-        "@webassemblyjs/wasm-parser": "^1.12.1",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
         "acorn": "^8.14.0",
         "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
@@ -6283,17 +6283,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.6.2.tgz",
-      "integrity": "sha512-qcAQAP1Ot0dZpeRoJ0L/Zck5FVDkll2IleVZQLzxeRVDZIw1P9/TK7/Aw1w2pmH7dmw/Cwk/cLSVRvLAmp9k7A==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.6.3.tgz",
+      "integrity": "sha512-94qOO4M9Fwv9KfVQJsgbe91k+fPJ4byf1L3Ez8TUa6TAFPo/BrLwQ80zclHkENlL1824TuxkcMKv33u6eydQCg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.6.2",
-        "@docusaurus/logger": "3.6.2",
-        "@docusaurus/types": "3.6.2",
-        "@docusaurus/utils": "3.6.2",
-        "@docusaurus/utils-common": "3.6.2",
-        "@docusaurus/utils-validation": "3.6.2",
+        "@docusaurus/core": "3.6.3",
+        "@docusaurus/logger": "3.6.3",
+        "@docusaurus/types": "3.6.3",
+        "@docusaurus/utils": "3.6.3",
+        "@docusaurus/utils-common": "3.6.3",
+        "@docusaurus/utils-validation": "3.6.3",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -6307,18 +6307,18 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/core": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.6.2.tgz",
-      "integrity": "sha512-irMts/mGLZv8dWcy0WUtbY/U6b5qIfHgQd1/kXMyAxUJo99fL0wFSqhMI+tcxjk0HYy427MXerLMqFJj+Arg1w==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.6.3.tgz",
+      "integrity": "sha512-xL7FRY9Jr5DWqB6pEnqgKqcMPJOX5V0pgWXi5lCiih11sUBmcFKM7c3+GyxcVeeWFxyYSDP3grLTWqJoP4P9Vw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/babel": "3.6.2",
-        "@docusaurus/bundler": "3.6.2",
-        "@docusaurus/logger": "3.6.2",
-        "@docusaurus/mdx-loader": "3.6.2",
-        "@docusaurus/utils": "3.6.2",
-        "@docusaurus/utils-common": "3.6.2",
-        "@docusaurus/utils-validation": "3.6.2",
+        "@docusaurus/babel": "3.6.3",
+        "@docusaurus/bundler": "3.6.3",
+        "@docusaurus/logger": "3.6.3",
+        "@docusaurus/mdx-loader": "3.6.3",
+        "@docusaurus/utils": "3.6.3",
+        "@docusaurus/utils-common": "3.6.3",
+        "@docusaurus/utils-validation": "3.6.3",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
@@ -6503,16 +6503,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap/node_modules/webpack": {
-      "version": "5.96.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
-      "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
+      "version": "5.97.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
+      "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
-        "@webassemblyjs/ast": "^1.12.1",
-        "@webassemblyjs/wasm-edit": "^1.12.1",
-        "@webassemblyjs/wasm-parser": "^1.12.1",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
         "acorn": "^8.14.0",
         "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
@@ -6563,24 +6563,24 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.6.2.tgz",
-      "integrity": "sha512-r2n5eHdhiNSrJGsrrYcw+WsyStmXxe0ZG3RdA9LVyK5+jBHM8blrUWJEDugnzCNbyhUzhdtcmgCC9fhdAvKuQw==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.6.3.tgz",
+      "integrity": "sha512-VHSYWROT3flvNNI1SrnMOtW1EsjeHNK9dhU6s9eY5hryZe79lUqnZJyze/ymDe2LXAqzyj6y5oYvyBoZZk6ErA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.6.2",
-        "@docusaurus/plugin-content-blog": "3.6.2",
-        "@docusaurus/plugin-content-docs": "3.6.2",
-        "@docusaurus/plugin-content-pages": "3.6.2",
-        "@docusaurus/plugin-debug": "3.6.2",
-        "@docusaurus/plugin-google-analytics": "3.6.2",
-        "@docusaurus/plugin-google-gtag": "3.6.2",
-        "@docusaurus/plugin-google-tag-manager": "3.6.2",
-        "@docusaurus/plugin-sitemap": "3.6.2",
-        "@docusaurus/theme-classic": "3.6.2",
-        "@docusaurus/theme-common": "3.6.2",
-        "@docusaurus/theme-search-algolia": "3.6.2",
-        "@docusaurus/types": "3.6.2"
+        "@docusaurus/core": "3.6.3",
+        "@docusaurus/plugin-content-blog": "3.6.3",
+        "@docusaurus/plugin-content-docs": "3.6.3",
+        "@docusaurus/plugin-content-pages": "3.6.3",
+        "@docusaurus/plugin-debug": "3.6.3",
+        "@docusaurus/plugin-google-analytics": "3.6.3",
+        "@docusaurus/plugin-google-gtag": "3.6.3",
+        "@docusaurus/plugin-google-tag-manager": "3.6.3",
+        "@docusaurus/plugin-sitemap": "3.6.3",
+        "@docusaurus/theme-classic": "3.6.3",
+        "@docusaurus/theme-common": "3.6.3",
+        "@docusaurus/theme-search-algolia": "3.6.3",
+        "@docusaurus/types": "3.6.3"
       },
       "engines": {
         "node": ">=18.0"
@@ -6591,18 +6591,18 @@
       }
     },
     "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/core": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.6.2.tgz",
-      "integrity": "sha512-irMts/mGLZv8dWcy0WUtbY/U6b5qIfHgQd1/kXMyAxUJo99fL0wFSqhMI+tcxjk0HYy427MXerLMqFJj+Arg1w==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.6.3.tgz",
+      "integrity": "sha512-xL7FRY9Jr5DWqB6pEnqgKqcMPJOX5V0pgWXi5lCiih11sUBmcFKM7c3+GyxcVeeWFxyYSDP3grLTWqJoP4P9Vw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/babel": "3.6.2",
-        "@docusaurus/bundler": "3.6.2",
-        "@docusaurus/logger": "3.6.2",
-        "@docusaurus/mdx-loader": "3.6.2",
-        "@docusaurus/utils": "3.6.2",
-        "@docusaurus/utils-common": "3.6.2",
-        "@docusaurus/utils-validation": "3.6.2",
+        "@docusaurus/babel": "3.6.3",
+        "@docusaurus/bundler": "3.6.3",
+        "@docusaurus/logger": "3.6.3",
+        "@docusaurus/mdx-loader": "3.6.3",
+        "@docusaurus/utils": "3.6.3",
+        "@docusaurus/utils-common": "3.6.3",
+        "@docusaurus/utils-validation": "3.6.3",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
@@ -6787,16 +6787,16 @@
       }
     },
     "node_modules/@docusaurus/preset-classic/node_modules/webpack": {
-      "version": "5.96.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
-      "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
+      "version": "5.97.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
+      "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
-        "@webassemblyjs/ast": "^1.12.1",
-        "@webassemblyjs/wasm-edit": "^1.12.1",
-        "@webassemblyjs/wasm-parser": "^1.12.1",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
         "acorn": "^8.14.0",
         "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
@@ -6847,24 +6847,24 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.6.2.tgz",
-      "integrity": "sha512-bCdOPqPNezhLx+hgNVO2Cf+8/1AHa9uHDOqTx/CKAx2I0J/jV9G+6JiMtpSRKGNfBoLT1O+56/7+WtkOf54xTw==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.6.3.tgz",
+      "integrity": "sha512-1RRLK1tSArI2c00qugWYO3jRocjOZwGF1mBzPPylDVRwWCS/rnWWR91ChdbbaxIupRJ+hX8ZBYrwr5bbU0oztQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.6.2",
-        "@docusaurus/logger": "3.6.2",
-        "@docusaurus/mdx-loader": "3.6.2",
-        "@docusaurus/module-type-aliases": "3.6.2",
-        "@docusaurus/plugin-content-blog": "3.6.2",
-        "@docusaurus/plugin-content-docs": "3.6.2",
-        "@docusaurus/plugin-content-pages": "3.6.2",
-        "@docusaurus/theme-common": "3.6.2",
-        "@docusaurus/theme-translations": "3.6.2",
-        "@docusaurus/types": "3.6.2",
-        "@docusaurus/utils": "3.6.2",
-        "@docusaurus/utils-common": "3.6.2",
-        "@docusaurus/utils-validation": "3.6.2",
+        "@docusaurus/core": "3.6.3",
+        "@docusaurus/logger": "3.6.3",
+        "@docusaurus/mdx-loader": "3.6.3",
+        "@docusaurus/module-type-aliases": "3.6.3",
+        "@docusaurus/plugin-content-blog": "3.6.3",
+        "@docusaurus/plugin-content-docs": "3.6.3",
+        "@docusaurus/plugin-content-pages": "3.6.3",
+        "@docusaurus/theme-common": "3.6.3",
+        "@docusaurus/theme-translations": "3.6.3",
+        "@docusaurus/types": "3.6.3",
+        "@docusaurus/utils": "3.6.3",
+        "@docusaurus/utils-common": "3.6.3",
+        "@docusaurus/utils-validation": "3.6.3",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
@@ -6888,18 +6888,18 @@
       }
     },
     "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/core": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.6.2.tgz",
-      "integrity": "sha512-irMts/mGLZv8dWcy0WUtbY/U6b5qIfHgQd1/kXMyAxUJo99fL0wFSqhMI+tcxjk0HYy427MXerLMqFJj+Arg1w==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.6.3.tgz",
+      "integrity": "sha512-xL7FRY9Jr5DWqB6pEnqgKqcMPJOX5V0pgWXi5lCiih11sUBmcFKM7c3+GyxcVeeWFxyYSDP3grLTWqJoP4P9Vw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/babel": "3.6.2",
-        "@docusaurus/bundler": "3.6.2",
-        "@docusaurus/logger": "3.6.2",
-        "@docusaurus/mdx-loader": "3.6.2",
-        "@docusaurus/utils": "3.6.2",
-        "@docusaurus/utils-common": "3.6.2",
-        "@docusaurus/utils-validation": "3.6.2",
+        "@docusaurus/babel": "3.6.3",
+        "@docusaurus/bundler": "3.6.3",
+        "@docusaurus/logger": "3.6.3",
+        "@docusaurus/mdx-loader": "3.6.3",
+        "@docusaurus/utils": "3.6.3",
+        "@docusaurus/utils-common": "3.6.3",
+        "@docusaurus/utils-validation": "3.6.3",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
@@ -7083,16 +7083,16 @@
       }
     },
     "node_modules/@docusaurus/theme-classic/node_modules/webpack": {
-      "version": "5.96.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
-      "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
+      "version": "5.97.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
+      "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
-        "@webassemblyjs/ast": "^1.12.1",
-        "@webassemblyjs/wasm-edit": "^1.12.1",
-        "@webassemblyjs/wasm-parser": "^1.12.1",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
         "acorn": "^8.14.0",
         "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
@@ -7143,15 +7143,15 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.6.2.tgz",
-      "integrity": "sha512-lfgsL064KEHpCkgGUc0OYoUPCpYfzggp6Hof8sz59UuKiLvb/Z7raewE9/NfocrJ2HZI17rLgMX3SQlRDh/5gg==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.6.3.tgz",
+      "integrity": "sha512-b8ZkhczXHDxWWyvz+YJy4t/PlPbEogTTbgnHoflYnH7rmRtyoodTsu8WVM12la5LmlMJBclBXFl29OH8kPE7gg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.6.2",
-        "@docusaurus/module-type-aliases": "3.6.2",
-        "@docusaurus/utils": "3.6.2",
-        "@docusaurus/utils-common": "3.6.2",
+        "@docusaurus/mdx-loader": "3.6.3",
+        "@docusaurus/module-type-aliases": "3.6.3",
+        "@docusaurus/utils": "3.6.3",
+        "@docusaurus/utils-common": "3.6.3",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -7171,19 +7171,19 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.6.2.tgz",
-      "integrity": "sha512-SFLS+Rq8Cg2yepnHucA9sRpIR97yHvZWlCgMzBLunV3KHbB6hD2h5HPhFV39wYHYCjJUAOH1lX9poJ1qKYuSvg==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.6.3.tgz",
+      "integrity": "sha512-rt+MGCCpYgPyWCGXtbxlwFbTSobu15jWBTPI2LHsHNa5B0zSmOISX6FWYAPt5X1rNDOqMGM0FATnh7TBHRohVA==",
       "license": "MIT",
       "dependencies": {
         "@docsearch/react": "^3.5.2",
-        "@docusaurus/core": "3.6.2",
-        "@docusaurus/logger": "3.6.2",
-        "@docusaurus/plugin-content-docs": "3.6.2",
-        "@docusaurus/theme-common": "3.6.2",
-        "@docusaurus/theme-translations": "3.6.2",
-        "@docusaurus/utils": "3.6.2",
-        "@docusaurus/utils-validation": "3.6.2",
+        "@docusaurus/core": "3.6.3",
+        "@docusaurus/logger": "3.6.3",
+        "@docusaurus/plugin-content-docs": "3.6.3",
+        "@docusaurus/theme-common": "3.6.3",
+        "@docusaurus/theme-translations": "3.6.3",
+        "@docusaurus/utils": "3.6.3",
+        "@docusaurus/utils-validation": "3.6.3",
         "algoliasearch": "^4.18.0",
         "algoliasearch-helper": "^3.13.3",
         "clsx": "^2.0.0",
@@ -7202,18 +7202,18 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia/node_modules/@docusaurus/core": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.6.2.tgz",
-      "integrity": "sha512-irMts/mGLZv8dWcy0WUtbY/U6b5qIfHgQd1/kXMyAxUJo99fL0wFSqhMI+tcxjk0HYy427MXerLMqFJj+Arg1w==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.6.3.tgz",
+      "integrity": "sha512-xL7FRY9Jr5DWqB6pEnqgKqcMPJOX5V0pgWXi5lCiih11sUBmcFKM7c3+GyxcVeeWFxyYSDP3grLTWqJoP4P9Vw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/babel": "3.6.2",
-        "@docusaurus/bundler": "3.6.2",
-        "@docusaurus/logger": "3.6.2",
-        "@docusaurus/mdx-loader": "3.6.2",
-        "@docusaurus/utils": "3.6.2",
-        "@docusaurus/utils-common": "3.6.2",
-        "@docusaurus/utils-validation": "3.6.2",
+        "@docusaurus/babel": "3.6.3",
+        "@docusaurus/bundler": "3.6.3",
+        "@docusaurus/logger": "3.6.3",
+        "@docusaurus/mdx-loader": "3.6.3",
+        "@docusaurus/utils": "3.6.3",
+        "@docusaurus/utils-common": "3.6.3",
+        "@docusaurus/utils-validation": "3.6.3",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
@@ -7398,16 +7398,16 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia/node_modules/webpack": {
-      "version": "5.96.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
-      "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
+      "version": "5.97.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
+      "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
-        "@webassemblyjs/ast": "^1.12.1",
-        "@webassemblyjs/wasm-edit": "^1.12.1",
-        "@webassemblyjs/wasm-parser": "^1.12.1",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
         "acorn": "^8.14.0",
         "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
@@ -7458,9 +7458,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.6.2.tgz",
-      "integrity": "sha512-LIWrYoDUsOTKmb0c7IQzawiPUTAaczBs5IOx6srxOWoTHVUMLzJCkl5Y6whfuRrnul8G05qv2vk238bN5Ko62g==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.6.3.tgz",
+      "integrity": "sha512-Gb0regclToVlngSIIwUCtBMQBq48qVUaN1XQNKW4XwlsgUyk0vP01LULdqbem7czSwIeBAFXFoORJ0RPX7ht/w==",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.1.1",
@@ -7471,16 +7471,16 @@
       }
     },
     "node_modules/@docusaurus/tsconfig": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.6.2.tgz",
-      "integrity": "sha512-TWLkyYHBYhIJNcXCEc3D1M9R8UFV4IZ82rGef5U9mE1ZrcgDUlZxYaYdoSuHrPrzPRIl3orjmpscO2FAk2gdZw==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.6.3.tgz",
+      "integrity": "sha512-1pT/rTrRpMV15E4tJH95W5PrjboMn5JkKF+Ys8cTjMegetiXjs0gPFOSDA5hdTlberKQLDO50xPjMJHondLuzA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.6.2.tgz",
-      "integrity": "sha512-117Wsk6xXrWEAsCYCXS3TGJv5tkdIZDcd7T/V0UJvKYmY0gyVPPcEQChy8yTdjbIkbB2q4fa7Jpox72Qv86mqQ==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.6.3.tgz",
+      "integrity": "sha512-xD9oTGDrouWzefkhe9ogB2fDV96/82cRpNGx2HIvI5L87JHNhQVIWimQ/3JIiiX/TEd5S9s+VO6FFguwKNRVow==",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
@@ -7551,16 +7551,16 @@
       }
     },
     "node_modules/@docusaurus/types/node_modules/webpack": {
-      "version": "5.96.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
-      "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
+      "version": "5.97.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
+      "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
-        "@webassemblyjs/ast": "^1.12.1",
-        "@webassemblyjs/wasm-edit": "^1.12.1",
-        "@webassemblyjs/wasm-parser": "^1.12.1",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
         "acorn": "^8.14.0",
         "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
@@ -7597,14 +7597,14 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.6.2.tgz",
-      "integrity": "sha512-oxnpUcFZGE3uPCDoXr8GJriB3VWM9sFjPedFidX3Fsz87l1NZNc1wtbKPfQ7GYFDMYo2IGlAv5+47Me9RkM6lg==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.6.3.tgz",
+      "integrity": "sha512-0R/FR3bKVl4yl8QwbL4TYFfR+OXBRpVUaTJdENapBGR3YMwfM6/JnhGilWQO8AOwPJGtGoDK7ib8+8UF9f3OZQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.6.2",
-        "@docusaurus/types": "3.6.2",
-        "@docusaurus/utils-common": "3.6.2",
+        "@docusaurus/logger": "3.6.3",
+        "@docusaurus/types": "3.6.3",
+        "@docusaurus/utils-common": "3.6.3",
         "@svgr/webpack": "^8.1.0",
         "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
@@ -7629,12 +7629,12 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.6.2.tgz",
-      "integrity": "sha512-dr5wK+OyU2QAWxG7S5siD2bPgS7+ZeqWHfgLNHZ5yalaZf8TbeNNLqydfngukAY56BGZN0NbMkX6jGIr7ZF0sA==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.6.3.tgz",
+      "integrity": "sha512-v4nKDaANLgT3pMBewHYEMAl/ufY0LkXao1QkFWzI5huWFOmNQ2UFzv2BiKeHX5Ownis0/w6cAyoxPhVdDonlSQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.6.2",
+        "@docusaurus/types": "3.6.3",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -7642,14 +7642,14 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.6.2.tgz",
-      "integrity": "sha512-Y3EwblDz72KOcobb5t2zlhHSmrfE8EaHusPJ96Kx2JYtNXL2omqCoOb6FpaXWhES75wvjUpkFLYfiNqAqEov8g==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.6.3.tgz",
+      "integrity": "sha512-bhEGGiN5BE38h21vjqD70Gxg++j+PfYVddDUE5UFvLDup68QOcpD33CLr+2knPorlxRbEaNfz6HQDUMQ3HuqKw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.6.2",
-        "@docusaurus/utils": "3.6.2",
-        "@docusaurus/utils-common": "3.6.2",
+        "@docusaurus/logger": "3.6.3",
+        "@docusaurus/utils": "3.6.3",
+        "@docusaurus/utils-common": "3.6.3",
         "fs-extra": "^11.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
@@ -11636,9 +11636,10 @@
       "dev": true
     },
     "node_modules/@types/prismjs": {
-      "version": "1.26.3",
-      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.3.tgz",
-      "integrity": "sha512-A0D0aTXvjlqJ5ZILMz3rNfDBOx9hHxLZYv2by47Sm/pqW35zzjusrZTryatjN/Rf8Us2gZrJD+KeHbUSTux1Cw=="
+      "version": "1.26.5",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.5.tgz",
+      "integrity": "sha512-AUZTa7hQ2KY5L7AmtSiqxlhWxb4ina0yd8hNbl4TWuqnv/pFP0nDMb3YrfSBf4hJVGLh2YEIBfKaBW/9UEl6IQ==",
+      "license": "MIT"
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.11",
@@ -12094,133 +12095,148 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
     "node_modules/@webassemblyjs/ast": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
-      "integrity": "sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/helper-numbers": "1.11.6",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6"
+        "@webassemblyjs/helper-numbers": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
       }
     },
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
-      "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
-      "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.12.1.tgz",
-      "integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw=="
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
-      "integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/floating-point-hex-parser": "1.11.6",
-        "@webassemblyjs/helper-api-error": "1.11.6",
+        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+        "@webassemblyjs/helper-api-error": "1.13.2",
         "@xtuc/long": "4.2.2"
       }
     },
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
-      "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.12.1.tgz",
-      "integrity": "sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/wasm-gen": "1.12.1"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/wasm-gen": "1.14.1"
       }
     },
     "node_modules/@webassemblyjs/ieee754": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
-      "integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+      "license": "MIT",
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
     },
     "node_modules/@webassemblyjs/leb128": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
-      "integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
     },
     "node_modules/@webassemblyjs/utf8": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
-      "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz",
-      "integrity": "sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/helper-wasm-section": "1.12.1",
-        "@webassemblyjs/wasm-gen": "1.12.1",
-        "@webassemblyjs/wasm-opt": "1.12.1",
-        "@webassemblyjs/wasm-parser": "1.12.1",
-        "@webassemblyjs/wast-printer": "1.12.1"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/helper-wasm-section": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-opt": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1",
+        "@webassemblyjs/wast-printer": "1.14.1"
       }
     },
     "node_modules/@webassemblyjs/wasm-gen": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.12.1.tgz",
-      "integrity": "sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/ieee754": "1.11.6",
-        "@webassemblyjs/leb128": "1.11.6",
-        "@webassemblyjs/utf8": "1.11.6"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
       }
     },
     "node_modules/@webassemblyjs/wasm-opt": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.12.1.tgz",
-      "integrity": "sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/wasm-gen": "1.12.1",
-        "@webassemblyjs/wasm-parser": "1.12.1"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1"
       }
     },
     "node_modules/@webassemblyjs/wasm-parser": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz",
-      "integrity": "sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-api-error": "1.11.6",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/ieee754": "1.11.6",
-        "@webassemblyjs/leb128": "1.11.6",
-        "@webassemblyjs/utf8": "1.11.6"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
       }
     },
     "node_modules/@webassemblyjs/wast-printer": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.12.1.tgz",
-      "integrity": "sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
+        "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
       }
     },
@@ -12271,12 +12287,14 @@
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@yarnpkg/esbuild-plugin-pnp": {
       "version": "3.0.0-rc.15",
@@ -12513,9 +12531,9 @@
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.22.5.tgz",
-      "integrity": "sha512-lWvhdnc+aKOKx8jyA3bsdEgHzm/sglC4cYdMG4xSQyRiPLJVJtH/IVYZG3Hp6PkTEhQqhyVYkeP9z2IlcHJsWw==",
+      "version": "3.22.6",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.22.6.tgz",
+      "integrity": "sha512-F2gSb43QHyvZmvH/2hxIjbk/uFdO2MguQYTFP7J+RowMW1csjIODMobEnpLI8nbLQuzZnGZdIxl5Bpy1k9+CFQ==",
       "license": "MIT",
       "dependencies": {
         "@algolia/events": "^4.0.1"
@@ -14803,9 +14821,9 @@
       }
     },
     "node_modules/css-has-pseudo": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-7.0.1.tgz",
-      "integrity": "sha512-EOcoyJt+OsuKfCADgLT7gADZI5jMzIe/AeI6MeAYKiFBDmNmM7kk46DtSfMj5AohUJisqVzopBpnQTlvbyaBWg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-7.0.2.tgz",
+      "integrity": "sha512-nzol/h+E0bId46Kn2dQH5VElaknX2Sr0hFuB/1EomdC7j+OISt2ZzK7EHX9DZDY53WbIVAR7FYKSO2XnSf07MQ==",
       "funding": [
         {
           "type": "github",
@@ -15018,9 +15036,9 @@
       }
     },
     "node_modules/cssdb": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.2.1.tgz",
-      "integrity": "sha512-KwEPys7lNsC8OjASI8RrmwOYYDcm0JOW9zQhcV83ejYcQkirTEyeAGui8aO2F5PiS6SLpxuTzl6qlMElIdsgIg==",
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.2.3.tgz",
+      "integrity": "sha512-9BDG5XmJrJQQnJ51VFxXCAtpZ5ebDlAREmO8sxMOVU0aSxN/gocbctjIG5LMh3WBUq+xTlb/jw2LoljBEqraTA==",
       "funding": [
         {
           "type": "opencollective",
@@ -22293,9 +22311,9 @@
       }
     },
     "node_modules/lilconfig": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
-      "integrity": "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -25229,9 +25247,9 @@
       }
     },
     "node_modules/node-emoji": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.1.3.tgz",
-      "integrity": "sha512-E2WEOVsgs7O16zsURJ/eH8BqhF029wGpEOnv7Urwdo2wmQanOACwJQh0devF9D9RhoZru0+9JXIS0dBXIAz+lA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
+      "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^4.6.0",
@@ -26125,13 +26143,12 @@
       }
     },
     "node_modules/parse-entities": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.1.tgz",
-      "integrity": "sha512-SWzvYcSJh4d/SGLIOQfZ/CoNv6BTlI6YEQ7Nj82oDVnRpwe/Z/F1EMx42x3JAOwGBlCjeCH0BRJQbQ/opHL17w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0",
-        "character-entities": "^2.0.0",
         "character-entities-legacy": "^3.0.0",
         "character-reference-invalid": "^2.0.0",
         "decode-named-character-reference": "^1.0.0",
@@ -27635,9 +27652,9 @@
       }
     },
     "node_modules/postcss-preset-env": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-10.1.1.tgz",
-      "integrity": "sha512-wqqsnBFD6VIwcHHRbhjTOcOi4qRVlB26RwSr0ordPj7OubRRxdWebv/aLjKLRR8zkZrbxZyuus03nOIgC5elMQ==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-10.1.2.tgz",
+      "integrity": "sha512-OqUBZ9ByVfngWhMNuBEMy52Izj07oIFA6K/EOGBlaSv+P12MiE1+S2cqXtS1VuW82demQ/Tzc7typYk3uHunkA==",
       "funding": [
         {
           "type": "github",
@@ -27685,9 +27702,9 @@
         "autoprefixer": "^10.4.19",
         "browserslist": "^4.23.1",
         "css-blank-pseudo": "^7.0.1",
-        "css-has-pseudo": "^7.0.1",
+        "css-has-pseudo": "^7.0.2",
         "css-prefers-color-scheme": "^10.0.0",
-        "cssdb": "^8.2.1",
+        "cssdb": "^8.2.3",
         "postcss-attribute-case-insensitive": "^7.0.1",
         "postcss-clamp": "^4.1.0",
         "postcss-color-functional-notation": "^7.0.6",
@@ -28023,9 +28040,9 @@
       }
     },
     "node_modules/prism-react-renderer": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-2.4.0.tgz",
-      "integrity": "sha512-327BsVCD/unU4CNLZTWVHyUHKnsqcvj2qbPlQ8MiBE2eq2rgctjigPA1Gp9HLF83kZ20zNN6jgizHJeEsyFYOw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-2.4.1.tgz",
+      "integrity": "sha512-ey8Ls/+Di31eqzUxC46h8MksNuGx/n0AAC8uKpwFau4RPDYLuE3EXTp8N8G2vX2N7UC/+IXeNUnlWBGGcAG+Ig==",
       "license": "MIT",
       "dependencies": {
         "@types/prismjs": "^1.26.0",
@@ -36278,34 +36295,34 @@
     "packages/website": {
       "name": "@maxgraph/docs",
       "dependencies": {
-        "@docusaurus/core": "3.6.2",
-        "@docusaurus/faster": "3.6.2",
-        "@docusaurus/preset-classic": "3.6.2",
+        "@docusaurus/core": "3.6.3",
+        "@docusaurus/faster": "3.6.3",
+        "@docusaurus/preset-classic": "3.6.3",
         "@mdx-js/react": "^3.1.0",
         "clsx": "^2.1.1",
-        "prism-react-renderer": "^2.4.0",
+        "prism-react-renderer": "^2.4.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "3.6.2",
-        "@docusaurus/tsconfig": "3.6.2",
-        "@docusaurus/types": "3.6.2"
+        "@docusaurus/module-type-aliases": "3.6.3",
+        "@docusaurus/tsconfig": "3.6.3",
+        "@docusaurus/types": "3.6.3"
       }
     },
     "packages/website/node_modules/@docusaurus/core": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.6.2.tgz",
-      "integrity": "sha512-irMts/mGLZv8dWcy0WUtbY/U6b5qIfHgQd1/kXMyAxUJo99fL0wFSqhMI+tcxjk0HYy427MXerLMqFJj+Arg1w==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.6.3.tgz",
+      "integrity": "sha512-xL7FRY9Jr5DWqB6pEnqgKqcMPJOX5V0pgWXi5lCiih11sUBmcFKM7c3+GyxcVeeWFxyYSDP3grLTWqJoP4P9Vw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/babel": "3.6.2",
-        "@docusaurus/bundler": "3.6.2",
-        "@docusaurus/logger": "3.6.2",
-        "@docusaurus/mdx-loader": "3.6.2",
-        "@docusaurus/utils": "3.6.2",
-        "@docusaurus/utils-common": "3.6.2",
-        "@docusaurus/utils-validation": "3.6.2",
+        "@docusaurus/babel": "3.6.3",
+        "@docusaurus/bundler": "3.6.3",
+        "@docusaurus/logger": "3.6.3",
+        "@docusaurus/mdx-loader": "3.6.3",
+        "@docusaurus/utils": "3.6.3",
+        "@docusaurus/utils-common": "3.6.3",
+        "@docusaurus/utils-validation": "3.6.3",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -12,19 +12,19 @@
     "extra:copy-gen-resources": "node scripts/copy-generated-resources.mjs"
   },
   "dependencies": {
-    "@docusaurus/core": "3.6.2",
-    "@docusaurus/faster": "3.6.2",
-    "@docusaurus/preset-classic": "3.6.2",
+    "@docusaurus/core": "3.6.3",
+    "@docusaurus/faster": "3.6.3",
+    "@docusaurus/preset-classic": "3.6.3",
     "@mdx-js/react": "^3.1.0",
     "clsx": "^2.1.1",
-    "prism-react-renderer": "^2.4.0",
+    "prism-react-renderer": "^2.4.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.6.2",
-    "@docusaurus/tsconfig": "3.6.2",
-    "@docusaurus/types": "3.6.2"
+    "@docusaurus/module-type-aliases": "3.6.3",
+    "@docusaurus/tsconfig": "3.6.3",
+    "@docusaurus/types": "3.6.3"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
This may also fix an error that occurs with docusaurus 3.6.2

### Notes

The rspack error same sometimes occurs with the previous docusaurus version
```
client (Rspack 1.1.2) compiled successfully
...Panic occurred at runtime.
Message:  Entrypoint should set_runtime_chunk at build_chunk_graph before get_runtime_chunk
Location: crates/rspack_core/src/chunk_group.rs:135
```