### PR TITLE
docs: add a page to highlight demo and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,9 @@ Documentation to be migrated:
 ## Examples
 <!-- copied into packages/website/docs/demo-and-examples.md -->
 
-For more complete examples than the “Getting started” example, please see :
+For more comprehensive examples than the “Getting started” example, here is a list of demos and examples to help you understand how to use `maxGraph` and integrate it into your projects.
+
+Note that they are based on `maxGraph` features, which require the use of [CSS and images](./usage/css-and-images.md) provided in the npm package.
 
 - the [storybook stories](packages/html/stories) which demonstrates various features of maxGraph.
   - The stories are currently written in `JavaScript` and will be progressively migrated to `TypeScript`.
@@ -150,8 +152,6 @@ For more complete examples than the “Getting started” example, please see :
 - the [js-example-without-defaults](packages/js-example-without-defaults) project/application that demonstrates how to not use defaults plugins and style defaults (shapes, perimeters, ...). It is a vanilla JavaScript application built by [Webpack](https://webpack.js.org/).
 - the [maxgraph-integration-examples](https://github.com/maxGraph/maxgraph-integration-examples) repository which shows how to integrate `maxGraph` with different frameworks and build tools.
 
-
-Notice that some elements produced by `maxGraph` require [CSS and images](packages/website/docs/usage/css-and-images.md) provided in the npm package.
 <!-- END OF 'copied into packages/website/docs/demo-and-examples.md' -->
 
 

--- a/README.md
+++ b/README.md
@@ -137,12 +137,13 @@ Documentation to be migrated:
 
 
 ## Examples
+<!-- copied into packages/website/docs/demo-and-examples.md -->
 
-For more complete examples than getting started,, please have a look at:
+For more complete examples than the “Getting started” example, please have a look at:
 
 - the [storybook stories](packages/html/stories) which demonstrates various features of maxGraph.
   - The stories are currently written in `JavaScript` and will be progressively migrated to `TypeScript`.
-  - A live instance is available on the [maxGraph webiste](https://maxgraph.github.io/maxGraph/demo).
+  - A live instance is available on the [maxGraph website](https://maxgraph.github.io/maxGraph/demo).
 - the [ts-example](packages/ts-example) project/application that demonstrates how to define and use custom `Shapes` with `maxGraph`. It is a vanilla TypeScript application built by [Vite](https://vitejs.dev/).
 - the [ts-example-without-defaults](packages/ts-example-without-defaults) project/application that demonstrates how to not use defaults plugins and style defaults (shapes, perimeters, ...). It is a vanilla TypeScript application built by [Vite](https://vitejs.dev/).
 - the [js-example](packages/js-example) project/application that demonstrates how import and export the `maxGraph` model with XML data. It is a vanilla JavaScript application built by [Webapck](https://webpack.js.org/).
@@ -151,6 +152,7 @@ For more complete examples than getting started,, please have a look at:
 
 
 Notice that some elements produced by `maxGraph` require to use [CSS and images](packages/website/docs/usage/css-and-images.md) provided in the npm package.
+<!-- END OF 'copied into packages/website/docs/demo-and-examples.md' -->
 
 
 ## <a id="migrate-from-mxgraph"></a> Migrating from mxGraph

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Documentation to be migrated:
 
 For more comprehensive examples than the “Getting started” example, here is a list of demos and examples to help you understand how to use `maxGraph` and integrate it into your projects.
 
-Note that they are based on `maxGraph` features, which require the use of [CSS and images](./usage/css-and-images.md) provided in the npm package.
+Note that they are based on `maxGraph` features, which require the use of [CSS and images](packages/website/docs/usage/css-and-images.md) provided in the npm package.
 
 - the [storybook stories](packages/html/stories) which demonstrates various features of maxGraph.
   - The stories are currently written in `JavaScript` and will be progressively migrated to `TypeScript`.

--- a/README.md
+++ b/README.md
@@ -139,19 +139,19 @@ Documentation to be migrated:
 ## Examples
 <!-- copied into packages/website/docs/demo-and-examples.md -->
 
-For more complete examples than the “Getting started” example, please have a look at:
+For more complete examples than the “Getting started” example, please see :
 
 - the [storybook stories](packages/html/stories) which demonstrates various features of maxGraph.
   - The stories are currently written in `JavaScript` and will be progressively migrated to `TypeScript`.
   - A live instance is available on the [maxGraph website](https://maxgraph.github.io/maxGraph/demo).
 - the [ts-example](packages/ts-example) project/application that demonstrates how to define and use custom `Shapes` with `maxGraph`. It is a vanilla TypeScript application built by [Vite](https://vitejs.dev/).
 - the [ts-example-without-defaults](packages/ts-example-without-defaults) project/application that demonstrates how to not use defaults plugins and style defaults (shapes, perimeters, ...). It is a vanilla TypeScript application built by [Vite](https://vitejs.dev/).
-- the [js-example](packages/js-example) project/application that demonstrates how import and export the `maxGraph` model with XML data. It is a vanilla JavaScript application built by [Webapck](https://webpack.js.org/).
-- the [js-example-without-defaults](packages/js-example-without-defaults) project/application that demonstrates how to not use defaults plugins and style defaults (shapes, perimeters, ...). It is a vanilla JavaScript application built by [Webapck](https://webpack.js.org/).
-- the https://github.com/maxGraph/maxgraph-integration-examples repository which shows how to integrate `maxGraph` with different frameworks and build tools.
+- the [js-example](packages/js-example) project/application that demonstrates how to import and export the `maxGraph` model with XML data. It is a vanilla JavaScript application built by [Webpack](https://webpack.js.org/).
+- the [js-example-without-defaults](packages/js-example-without-defaults) project/application that demonstrates how to not use defaults plugins and style defaults (shapes, perimeters, ...). It is a vanilla JavaScript application built by [Webpack](https://webpack.js.org/).
+- the [maxgraph-integration-examples](https://github.com/maxGraph/maxgraph-integration-examples) repository which shows how to integrate `maxGraph` with different frameworks and build tools.
 
 
-Notice that some elements produced by `maxGraph` require to use [CSS and images](packages/website/docs/usage/css-and-images.md) provided in the npm package.
+Notice that some elements produced by `maxGraph` require [CSS and images](packages/website/docs/usage/css-and-images.md) provided in the npm package.
 <!-- END OF 'copied into packages/website/docs/demo-and-examples.md' -->
 
 

--- a/packages/website/docs/demo-and-examples.md
+++ b/packages/website/docs/demo-and-examples.md
@@ -4,18 +4,25 @@ sidebar_position: 2
 
 # Demos and Examples
 [//]: # (extract of <rootdir>/README.md)
-For more complete examples than the [“Getting started” example](./manual/getting-started.md), please see:
+For more comprehensive examples than the [“Getting started” example](./manual/getting-started.md), this page provides a list of demos and examples to help you understand how to use `maxGraph` and integrate it into your projects.
 
-- the [storybook stories](https://github.com/maxGraph/maxGraph/tree/main/packages/html/stories) which demonstrates various features of maxGraph.
+Note that they are based on `maxGraph` features, which require the use of [CSS and images](./usage/css-and-images.md) provided in the npm package.
+
+
+## Interactive Demos
+- the [storybook stories](https://github.com/maxGraph/maxGraph/tree/main/packages/html/stories) demonstrates various features of maxGraph.
   - The stories are currently written in `JavaScript` and will be progressively migrated to `TypeScript`.
   - A live instance is available on the [maxGraph website](https://maxgraph.github.io/maxGraph/demo).
-- the [ts-example](https://github.com/maxGraph/maxGraph/tree/main/packages/ts-example) project/application that demonstrates how to define and use custom `Shapes` with `maxGraph`. It is a vanilla TypeScript application built by [Vite](https://vitejs.dev/).
-- the [ts-example-without-defaults](https://github.com/maxGraph/maxGraph/tree/main/packages/ts-example-without-defaults) project/application that demonstrates how to not use defaults plugins and style defaults (shapes, perimeters, ...). It is a vanilla TypeScript application built by [Vite](https://vitejs.dev/).
-- the [js-example](https://github.com/maxGraph/maxGraph/tree/main/packages/js-example) project/application that demonstrates how to import and export the `maxGraph` model with XML data. It is a vanilla JavaScript application built by [Webpack](https://webpack.js.org/).
-- the [js-example-without-defaults](https://github.com/maxGraph/maxGraph/tree/main/packages/js-example-without-defaults) project/application that demonstrates how to not use defaults plugins and style defaults (shapes, perimeters, ...). It is a vanilla JavaScript application built by [Webpack](https://webpack.js.org/).
+
+## TypeScript Examples
+- the [ts-example](https://github.com/maxGraph/maxGraph/tree/main/packages/ts-example) project/application demonstrates how to define and use custom `Shapes` with `maxGraph`. It is a vanilla TypeScript application built by [Vite](https://vitejs.dev/).
+- the [ts-example-without-defaults](https://github.com/maxGraph/maxGraph/tree/main/packages/ts-example-without-defaults) project/application demonstrates how to not use defaults plugins and style defaults (shapes, perimeters, ...). It is a vanilla TypeScript application built by [Vite](https://vitejs.dev/).
+
+## JavaScript Examples
+- the [js-example](https://github.com/maxGraph/maxGraph/tree/main/packages/js-example) project/application demonstrates how to import and export the `maxGraph` model with XML data. It is a vanilla JavaScript application built by [Webpack](https://webpack.js.org/).
+- the [js-example-without-defaults](https://github.com/maxGraph/maxGraph/tree/main/packages/js-example-without-defaults) project/application demonstrates how to not use defaults plugins and style defaults (shapes, perimeters, ...). It is a vanilla JavaScript application built by [Webpack](https://webpack.js.org/).
+
+## Framework Integration and Bundlers
 - the [maxgraph-integration-examples](https://github.com/maxGraph/maxgraph-integration-examples) repository which shows how to integrate `maxGraph` with different frameworks and build tools.
-
-
-Notice that some elements produced by `maxGraph` require [CSS and images](./usage/css-and-images.md) provided in the npm package.
 
 [//]: # (END OF 'extract of <rootdir>/README.md')

--- a/packages/website/docs/demo-and-examples.md
+++ b/packages/website/docs/demo-and-examples.md
@@ -3,17 +3,19 @@ sidebar_position: 2
 ---
 
 # Demos and Examples
-
-For more complete examples than the [“Getting started” example](./manual/getting-started.md), please have a look at:
+[//]: # (extract of <rootdir>/README.md)
+For more complete examples than the [“Getting started” example](./manual/getting-started.md), please see:
 
 - the [storybook stories](https://github.com/maxGraph/maxGraph/tree/main/packages/html/stories) which demonstrates various features of maxGraph.
-    - The stories are currently written in `JavaScript` and will be progressively migrated to `TypeScript`.
-    - A live instance is available on the [maxGraph website](https://maxgraph.github.io/maxGraph/demo).
+  - The stories are currently written in `JavaScript` and will be progressively migrated to `TypeScript`.
+  - A live instance is available on the [maxGraph website](https://maxgraph.github.io/maxGraph/demo).
 - the [ts-example](https://github.com/maxGraph/maxGraph/tree/main/packages/ts-example) project/application that demonstrates how to define and use custom `Shapes` with `maxGraph`. It is a vanilla TypeScript application built by [Vite](https://vitejs.dev/).
 - the [ts-example-without-defaults](https://github.com/maxGraph/maxGraph/tree/main/packages/ts-example-without-defaults) project/application that demonstrates how to not use defaults plugins and style defaults (shapes, perimeters, ...). It is a vanilla TypeScript application built by [Vite](https://vitejs.dev/).
-- the [js-example](https://github.com/maxGraph/maxGraph/tree/main/packages/js-example) project/application that demonstrates how import and export the `maxGraph` model with XML data. It is a vanilla JavaScript application built by [Webapck](https://webpack.js.org/).
-- the [js-example-without-defaults](https://github.com/maxGraph/maxGraph/tree/main/packages/js-example-without-defaults) project/application that demonstrates how to not use defaults plugins and style defaults (shapes, perimeters, ...). It is a vanilla JavaScript application built by [Webapck](https://webpack.js.org/).
-- the https://github.com/maxGraph/maxgraph-integration-examples repository which shows how to integrate `maxGraph` with different frameworks and build tools.
+- the [js-example](https://github.com/maxGraph/maxGraph/tree/main/packages/js-example) project/application that demonstrates how to import and export the `maxGraph` model with XML data. It is a vanilla JavaScript application built by [Webpack](https://webpack.js.org/).
+- the [js-example-without-defaults](https://github.com/maxGraph/maxGraph/tree/main/packages/js-example-without-defaults) project/application that demonstrates how to not use defaults plugins and style defaults (shapes, perimeters, ...). It is a vanilla JavaScript application built by [Webpack](https://webpack.js.org/).
+- the [maxgraph-integration-examples](https://github.com/maxGraph/maxgraph-integration-examples) repository which shows how to integrate `maxGraph` with different frameworks and build tools.
 
 
-Notice that some elements produced by `maxGraph` require to use [CSS and images](./usage/css-and-images.md) provided in the npm package.
+Notice that some elements produced by `maxGraph` require [CSS and images](./usage/css-and-images.md) provided in the npm package.
+
+[//]: # (END OF 'extract of <rootdir>/README.md')

--- a/packages/website/docs/demo-and-examples.md
+++ b/packages/website/docs/demo-and-examples.md
@@ -1,0 +1,19 @@
+---
+sidebar_position: 2
+---
+
+# Demos and Examples
+
+For more complete examples than the [“Getting started” example](./manual/getting-started.md), please have a look at:
+
+- the [storybook stories](https://github.com/maxGraph/maxGraph/tree/main/packages/html/stories) which demonstrates various features of maxGraph.
+    - The stories are currently written in `JavaScript` and will be progressively migrated to `TypeScript`.
+    - A live instance is available on the [maxGraph website](https://maxgraph.github.io/maxGraph/demo).
+- the [ts-example](https://github.com/maxGraph/maxGraph/tree/main/packages/ts-example) project/application that demonstrates how to define and use custom `Shapes` with `maxGraph`. It is a vanilla TypeScript application built by [Vite](https://vitejs.dev/).
+- the [ts-example-without-defaults](https://github.com/maxGraph/maxGraph/tree/main/packages/ts-example-without-defaults) project/application that demonstrates how to not use defaults plugins and style defaults (shapes, perimeters, ...). It is a vanilla TypeScript application built by [Vite](https://vitejs.dev/).
+- the [js-example](https://github.com/maxGraph/maxGraph/tree/main/packages/js-example) project/application that demonstrates how import and export the `maxGraph` model with XML data. It is a vanilla JavaScript application built by [Webapck](https://webpack.js.org/).
+- the [js-example-without-defaults](https://github.com/maxGraph/maxGraph/tree/main/packages/js-example-without-defaults) project/application that demonstrates how to not use defaults plugins and style defaults (shapes, perimeters, ...). It is a vanilla JavaScript application built by [Webapck](https://webpack.js.org/).
+- the https://github.com/maxGraph/maxgraph-integration-examples repository which shows how to integrate `maxGraph` with different frameworks and build tools.
+
+
+Notice that some elements produced by `maxGraph` require to use [CSS and images](./usage/css-and-images.md) provided in the npm package.

--- a/packages/website/docs/development/_category_.json
+++ b/packages/website/docs/development/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Development",
-  "position": 3,
+  "position": 13,
   "link": {
     "type": "generated-index",
     "description": "Everything you need to know when you are developing maxGraph."

--- a/packages/website/docs/known-issues.md
+++ b/packages/website/docs/known-issues.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 20
 ---
 
 # Known Issues

--- a/packages/website/docs/manual/_category_.json
+++ b/packages/website/docs/manual/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Manual",
-  "position": 1,
+  "position": 11,
   "link": {
     "type": "generated-index",
     "description": "An introduction to the concepts used in maxGraph."

--- a/packages/website/docs/usage/_category_.json
+++ b/packages/website/docs/usage/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Usage",
-  "position": 2,
+  "position": 12,
   "link": {
     "type": "generated-index",
     "description": "Everything you need to know to use specific features of maxGraph."


### PR DESCRIPTION
The content of the new page is an extract of the main README file.
In the the main README file, also fix a few typos, enhance readability and structure.

### Screenshots

initial proposal | final
---- | ----
![image](https://github.com/user-attachments/assets/22d451e8-96d4-4c79-8d21-233395845165) | ![image](https://github.com/user-attachments/assets/ca438f49-cde3-444f-88cb-25111a6fde88)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new documentation file for demos and examples related to the `maxGraph` library.

- **Bug Fixes**
	- Corrected typographical errors in the `README.md` file for improved clarity.

- **Documentation**
	- Enhanced readability and structure of the `README.md`.
	- Expanded examples section to include integration notes and requirements.
	- Updated the content of the demo-and-examples documentation for better organization and clarity.

- **Chores**
	- Adjusted the sidebar positions in various documentation files for better navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->