### PR TITLE
docs: add links to specific examples and demos in various pages

### DIFF
--- a/packages/website/docs/usage/css-and-images.md
+++ b/packages/website/docs/usage/css-and-images.md
@@ -33,6 +33,11 @@ import '@maxgraph/core/css/common.css';
 import './custom.css'
 ```
 
+:::tip
+You can see this technique in action in the [TypeScript example](https://github.com/maxGraph/maxGraph/blob/main/packages/ts-example/src/main.ts) provided in the `maxGraph` repository.
+:::
+
+
 ## Images
 
 The `@maxgraph/core` npm package includes images that are required by some features.

--- a/packages/website/docs/usage/perimeters.md
+++ b/packages/website/docs/usage/perimeters.md
@@ -26,6 +26,12 @@ It is taken from the Storybook demo.
 
 ![Perimeters Example](./assets/perimeters.png)
 
+:::note
+The image above has been produced using the Storybook demo:
+- live demo: [PerimeterVariousImplementations](https://maxgraph.github.io/maxGraph/?path=/story/perimeters--perimeter-various-implementations)
+- source code: [PerimeterVariousImplementations.stories.ts](https://github.com/maxGraph/maxGraph/blob/main/packages/html/stories/PerimeterVariousImplementations.stories.ts)
+:::
+
 
 ## How to Use a Specific Perimeter
 
@@ -99,3 +105,9 @@ Or it can be used for all vertices in the `Graph` as follows:
 const style = graph.getStylesheet().getDefaultVertexStyle();
 style.perimeter = CustomPerimeter;
 ```
+
+## Example of custom behavior
+
+It is possible to create a perimeter that places the edge on the bounds of the label of a vertex. See the Storybook demo:
+- live demo: [PerimeterOnLabelBounds](https://maxgraph.github.io/maxGraph/demo/?path=/story/labels-perimeteronlabelbounds--default)
+- source code: [PerimeterOnLabelBounds.stories.ts](https://github.com/maxGraph/maxGraph/blob/main/packages/html/stories/PerimeterOnLabelBounds.stories.ts)


### PR DESCRIPTION
The purpose is to better guide readers to examples of code that actually uses the concept explained in the documentation.

This is done for now in the "css and images" and "perimeters" pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the CSS and images documentation with a new tip for viewing a TypeScript example.
	- Enhanced the perimeters documentation with additional information, examples, and links to live demos and source code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->