### PR TITLE
docs: fix link to getting-started page

### DIFF
--- a/packages/website/docs/demo-and-examples.md
+++ b/packages/website/docs/demo-and-examples.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Demos and Examples
 [//]: # (extract of <rootdir>/README.md)
-For more comprehensive examples than the [“Getting started” example](./manual/getting-started.md), this page provides a list of demos and examples to help you understand how to use `maxGraph` and integrate it into your projects.
+For more comprehensive examples than the [“Getting started” example](./manual/getting-started.mdx), this page provides a list of demos and examples to help you understand how to use `maxGraph` and integrate it into your projects.
 
 Note that they are based on `maxGraph` features, which require the use of [CSS and images](./usage/css-and-images.md) provided in the npm package.
 


### PR DESCRIPTION
The page is now using MDX and the link in the "demos and examples" page hasn't been updated.

## Notes

#598 hasn't been updated to use the latest contents of the main branch, so the error hasn't been detected prior merging 😢 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated file reference for "Getting started" example from `.md` to `.mdx` extension

<!-- end of auto-generated comment: release notes by coderabbit.ai -->