### PR TITLE
fix(VertexHandler): do not create label handle for swimlane

### DIFF
--- a/packages/core/src/view/handler/VertexHandler.ts
+++ b/packages/core/src/view/handler/VertexHandler.ts
@@ -273,7 +273,7 @@ class VertexHandler {
         if (
           geo != null &&
           !geo.relative &&
-          //!this.graph.isSwimlane(this.state.cell) &&      disable for now
+          !this.graph.isSwimlane(this.state.cell) &&
           this.graph.isLabelMovable(this.state.cell)
         ) {
           // Marks this as the label handle for getHandleForEvent


### PR DESCRIPTION
This was in place in mxGraph and had been disabled for unknown reasons during the migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated handling of label shape for swimlane cells, improving visual interaction and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->