### PR TITLE
fix: ensure that codecs for base JS elements are registered

### DIFF
--- a/packages/core/src/serialization/register.ts
+++ b/packages/core/src/serialization/register.ts
@@ -42,6 +42,16 @@ import StyleChange from '../view/undoable_changes/StyleChange';
 import ValueChange from '../view/undoable_changes/ValueChange';
 import VisibleChange from '../view/undoable_changes/VisibleChange';
 
+let isBaseCodecsRegistered = false;
+const registerBaseCodecs = (force = false) => {
+  if (!isBaseCodecsRegistered || force) {
+    CodecRegistry.register(new ObjectCodec({})); // Object
+    CodecRegistry.register(new ObjectCodec([])); // Array
+
+    isBaseCodecsRegistered = true;
+  }
+};
+
 const registerGenericChangeCodecs = () => {
   const __dummy: any = undefined;
   CodecRegistry.register(
@@ -88,8 +98,7 @@ export const registerModelCodecs = (force = false) => {
     // Codecs are currently only registered automatically during encode/export
     CodecRegistry.register(createObjectCodec(new Geometry(), 'Geometry'));
     CodecRegistry.register(createObjectCodec(new Point(), 'Point'));
-    CodecRegistry.register(new ObjectCodec({})); // Object
-    CodecRegistry.register(new ObjectCodec([])); // Array
+    registerBaseCodecs(force);
 
     // mxGraph support
     CodecRegistry.addAlias('mxGraphModel', 'GraphDataModel');
@@ -136,6 +145,8 @@ let isEditorCodecsRegistered = false;
  */
 export const registerEditorCodecs = (force = false) => {
   if (!isEditorCodecsRegistered || force) {
+    registerBaseCodecs(force);
+
     CodecRegistry.register(new EditorCodec());
     CodecRegistry.register(new EditorKeyHandlerCodec());
     CodecRegistry.register(new EditorPopupMenuCodec());


### PR DESCRIPTION
Previously, codecs for Object and Array weren't registered when calling `registerEditorCodecs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved codec registration process by centralizing base codec registration logic
	- Added a mechanism to prevent redundant codec registrations
	- Simplified codec initialization in model and editor registration functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->