### PR TITLE
refactor(type)!: use explicit parameters in all functions

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -66,7 +66,6 @@ export default tsEslint.config(
       '@typescript-eslint/no-this-alias': 'warn',
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-duplicate-enum-values': 'off', // check the impact of changing enum values if we want to enable this
-      '@typescript-eslint/no-unsafe-function-type': 'off', // will be managed later
       '@typescript-eslint/no-unused-expressions': [
         'error',
         {

--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -62,9 +62,11 @@ import { isI18nEnabled, translate } from '../internal/i18n-utils';
 import { error } from '../gui/guiUtils';
 import type { FitPlugin } from '../view/plugins';
 
-export type EditorActionFunction =
-  | ((editor: Editor, cell: Cell | null) => void)
-  | ((editor: Editor, cell: Cell | null, evt: Event | null) => void);
+export type EditorActionFunction = (
+  editor: Editor,
+  cell: Cell | null,
+  evt?: Event | null
+) => void;
 
 /**
  * Extends {@link EventSource} to implement an application wrapper for a graph that

--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -51,7 +51,7 @@ import type PopupMenuHandler from '../view/plugins/PopupMenuHandler';
 import RubberBandHandler from '../view/plugins/RubberBandHandler';
 import InternalEvent from '../view/event/InternalEvent';
 import InternalMouseEvent from '../view/event/InternalMouseEvent';
-import { CellStateStyle, MouseListenerSet } from '../types';
+import type { CellStateStyle, EditorActionFunction, MouseListenerSet } from '../types';
 import type ConnectionHandler from '../view/plugins/ConnectionHandler';
 import { show } from '../util/printUtils';
 import type PanningHandler from '../view/plugins/PanningHandler';
@@ -61,13 +61,6 @@ import { isNullish } from '../internal/utils';
 import { isI18nEnabled, translate } from '../internal/i18n-utils';
 import { error } from '../gui/guiUtils';
 import type { FitPlugin } from '../view/plugins';
-
-// TODO move to types.ts?
-export type EditorActionFunction = (
-  editor: Editor,
-  cell: Cell | null,
-  evt?: Event | null
-) => void;
 
 /**
  * Extends {@link EventSource} to implement an application wrapper for a graph that

--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -61,6 +61,7 @@ import { isNullish } from '../internal/utils';
 import { isI18nEnabled, translate } from '../internal/i18n-utils';
 import { error } from '../gui/guiUtils';
 import type { FitPlugin } from '../view/plugins';
+import type MaxXmlRequest from '../util/MaxXmlRequest';
 
 /**
  * Extends {@link EventSource} to implement an application wrapper for a graph that
@@ -1925,7 +1926,7 @@ export class Editor extends EventSource {
       data = encodeURIComponent(data);
     }
 
-    post(url, `${this.postParameterName}=${data}`, (req: string) => {
+    post(url, `${this.postParameterName}=${data}`, (req: MaxXmlRequest) => {
       this.fireEvent(new EventObject(InternalEvent.POST, { request: req, url, data }));
     });
   }

--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -605,7 +605,6 @@ export class Editor extends EventSource {
    * cells into the graph. This is assigned from the
    * {@link EditorToolbar} if a vertex-tool is clicked.
    */
-  // TODO more event?
   insertFunction: ((evt: MouseEvent, cell: Cell | null) => void) | null = null;
 
   // =====================================================================================

--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -432,7 +432,7 @@ export class Editor extends EventSource {
     }
   }
 
-  onInit: Function | null = null;
+  onInit: (() => void) | null = null;
   lastSnapshot: number | null = null;
   ignoredChanges: number | null = null;
   swimlaneLayout: any;

--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -63,7 +63,12 @@ import { error } from '../gui/guiUtils';
 import type { FitPlugin } from '../view/plugins';
 
 export type EditorActionFunction =
-  | ((editor: Editor, cell: Cell) => void)
+  //   (
+  //   editor: Editor,
+  //   cell: Cell | null,
+  //   evt?: Event | null
+  // ) => void;
+  | ((editor: Editor, cell: Cell | null) => void)
   | ((editor: Editor, cell: Cell | null, evt: Event | null) => void);
 
 /**
@@ -1036,7 +1041,7 @@ export class Editor extends EventSource {
       editor.graph.getPlugin<FitPlugin>('fit')?.fit();
     });
 
-    this.addAction('showProperties', (editor: Editor, cell: Cell) => {
+    this.addAction('showProperties', (editor: Editor, cell: Cell | null) => {
       editor.showProperties(cell);
     });
 
@@ -1064,26 +1069,26 @@ export class Editor extends EventSource {
       }
     });
 
-    this.addAction('edit', (editor: Editor, cell: Cell) => {
-      if (editor.graph.isEnabled() && editor.graph.isCellEditable(cell)) {
+    this.addAction('edit', (editor: Editor, cell: Cell | null) => {
+      if (editor.graph.isEnabled() && (!cell || editor.graph.isCellEditable(cell))) {
         editor.graph.startEditingAtCell(cell);
       }
     });
 
-    this.addAction('toBack', (editor: Editor, cell: Cell) => {
+    this.addAction('toBack', (editor: Editor, _cell: Cell | null) => {
       if (editor.graph.isEnabled()) {
         editor.graph.orderCells(true);
       }
     });
 
-    this.addAction('toFront', (editor: Editor, cell: Cell) => {
+    this.addAction('toFront', (editor: Editor, _cell: Cell | null) => {
       if (editor.graph.isEnabled()) {
         editor.graph.orderCells(false);
       }
     });
 
-    this.addAction('enterGroup', (editor: Editor, cell: Cell) => {
-      editor.graph.enterGroup(cell);
+    this.addAction('enterGroup', (editor: Editor, cell: Cell | null) => {
+      cell && editor.graph.enterGroup(cell);
     });
 
     this.addAction('exitGroup', (editor: Editor) => {

--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -62,6 +62,7 @@ import { isI18nEnabled, translate } from '../internal/i18n-utils';
 import { error } from '../gui/guiUtils';
 import type { FitPlugin } from '../view/plugins';
 
+// TODO move to types.ts?
 export type EditorActionFunction = (
   editor: Editor,
   cell: Cell | null,

--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -63,11 +63,6 @@ import { error } from '../gui/guiUtils';
 import type { FitPlugin } from '../view/plugins';
 
 export type EditorActionFunction =
-  //   (
-  //   editor: Editor,
-  //   cell: Cell | null,
-  //   evt?: Event | null
-  // ) => void;
   | ((editor: Editor, cell: Cell | null) => void)
   | ((editor: Editor, cell: Cell | null, evt: Event | null) => void);
 

--- a/packages/core/src/editor/EditorPopupMenu.ts
+++ b/packages/core/src/editor/EditorPopupMenu.ts
@@ -263,6 +263,7 @@ export class EditorPopupMenu {
     editor: Editor,
     lab: string,
     icon: string | null = null,
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- unable to identify the function signature for now
     funct: Function | null = null,
     action: string | null = null,
     cell: Cell | null = null,

--- a/packages/core/src/editor/EditorPopupMenu.ts
+++ b/packages/core/src/editor/EditorPopupMenu.ts
@@ -263,8 +263,7 @@ export class EditorPopupMenu {
     editor: Editor,
     lab: string,
     icon: string | null = null,
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- unable to identify the function signature for now
-    funct: Function | null = null,
+    funct: ((editor: Editor, cell: Cell | null, event: MouseEvent) => void) | null = null,
     action: string | null = null,
     cell: Cell | null = null,
     parent: PopupMenuItem | null = null,

--- a/packages/core/src/editor/EditorToolbar.ts
+++ b/packages/core/src/editor/EditorToolbar.ts
@@ -224,7 +224,7 @@ export class EditorToolbar {
     icon: string,
     mode: string,
     pressed: string | null = null,
-    funct: Function | null = null
+    funct: ((editor: Editor) => void) | null = null
   ): any {
     const clickHandler = () => {
       (<Editor>this.editor).setMode(mode);
@@ -256,7 +256,7 @@ export class EditorToolbar {
   addPrototype(
     title: string,
     icon: string,
-    ptype: Function | Cell,
+    ptype: (() => Cell) | Cell,
     pressed: string,
     insert: (
       editor: Editor,
@@ -272,10 +272,7 @@ export class EditorToolbar {
       if (typeof ptype === 'function') {
         return ptype();
       }
-      if (ptype != null) {
-        return (<Editor>this.editor).graph.cloneCell(ptype);
-      }
-      return null;
+      return (<Editor>this.editor).graph.cloneCell(ptype);
     };
 
     // Defines the function for a click event on the graph

--- a/packages/core/src/editor/EditorToolbar.ts
+++ b/packages/core/src/editor/EditorToolbar.ts
@@ -78,6 +78,7 @@ export class EditorToolbar {
   /**
    * Reference to the function used to reset the {@link toolbar}.
    */
+  // TODO can we use EventListenerFunction type here?
   resetHandler: (() => void) | null = null;
 
   /**

--- a/packages/core/src/editor/EditorToolbar.ts
+++ b/packages/core/src/editor/EditorToolbar.ts
@@ -78,7 +78,7 @@ export class EditorToolbar {
   /**
    * Reference to the function used to reset the {@link toolbar}.
    */
-  resetHandler: Function | null = null;
+  resetHandler: (() => void) | null = null;
 
   /**
    * Defines the spacing between existing and new vertices in gridSize units when a new vertex is dropped on an existing cell.

--- a/packages/core/src/editor/EditorToolbar.ts
+++ b/packages/core/src/editor/EditorToolbar.ts
@@ -109,7 +109,7 @@ export class EditorToolbar {
           const funct = evt.getProperty('function');
 
           if (funct != null) {
-            (<Editor>this.editor).insertFunction = () => {
+            this.editor!.insertFunction = () => {
               funct.apply(this, [container]);
               this.toolbar!.resetMode();
             };
@@ -126,11 +126,8 @@ export class EditorToolbar {
         }
       };
 
-      (<Editor>this.editor).graph.addListener(
-        InternalEvent.DOUBLE_CLICK,
-        this.resetHandler
-      );
-      (<Editor>this.editor).addListener(InternalEvent.ESCAPE, this.resetHandler);
+      this.editor!.graph.addListener(InternalEvent.DOUBLE_CLICK, this.resetHandler);
+      this.editor!.addListener(InternalEvent.ESCAPE, this.resetHandler);
     }
   }
 
@@ -146,7 +143,7 @@ export class EditorToolbar {
   addItem(title: string, icon: string, action: string, pressed?: string): any {
     const clickHandler = () => {
       if (action != null && action.length > 0) {
-        (<Editor>this.editor).execute(action);
+        this.editor!.execute(action);
       }
     };
     return (<MaxToolbar>this.toolbar).addItem(title, icon, clickHandler, pressed);
@@ -188,7 +185,7 @@ export class EditorToolbar {
    */
   addActionOption(combo: HTMLSelectElement, title: string, action: string): void {
     const clickHandler = () => {
-      (<Editor>this.editor).execute(action);
+      this.editor!.execute(action);
     };
 
     this.addOption(combo, title, clickHandler);
@@ -227,11 +224,8 @@ export class EditorToolbar {
     funct: ((editor: Editor) => void) | null = null
   ): any {
     const clickHandler = () => {
-      (<Editor>this.editor).setMode(mode);
-
-      if (funct != null) {
-        funct(<Editor>this.editor);
-      }
+      this.editor!.setMode(mode);
+      funct?.(this.editor!);
     };
     return (<MaxToolbar>this.toolbar).addSwitchMode(title, icon, clickHandler, pressed);
   }
@@ -272,7 +266,7 @@ export class EditorToolbar {
       if (typeof ptype === 'function') {
         return ptype();
       }
-      return (<Editor>this.editor).graph.cloneCell(ptype);
+      return this.editor!.graph.cloneCell(ptype);
     };
 
     // Defines the function for a click event on the graph
@@ -362,7 +356,7 @@ export class EditorToolbar {
       ) {
         return graph.splitEdge(target, [vertex], null, pt.x, pt.y);
       }
-      return (<Editor>this.editor).addVertex(target, vertex, pt.x, pt.y);
+      return this.editor!.addVertex(target, vertex, pt.x, pt.y);
     }
     return null;
   }
@@ -398,7 +392,7 @@ export class EditorToolbar {
         const step = this.spacing * graph.gridSize;
         const dist = source.getDirectedEdgeCount(true) * 20;
 
-        if ((<Editor>this.editor).horizontalFlow) {
+        if (this.editor!.horizontalFlow) {
           g.x += (g.width + geo.width) / 2 + step + dist;
         } else {
           g.y += (g.height + geo.height) / 2 + step + dist;
@@ -414,7 +408,7 @@ export class EditorToolbar {
 
         // Creates the edge using the editor instance and calls
         // the second function that fires an add event
-        edge = (<Editor>this.editor).createEdge(source, vertex);
+        edge = this.editor!.createEdge(source, vertex);
 
         if (edge.getGeometry() == null) {
           const edgeGeometry = new Geometry();
@@ -453,7 +447,7 @@ export class EditorToolbar {
       sprite.style.width = `${2 * img.offsetWidth}px`;
       sprite.style.height = `${2 * img.offsetHeight}px`;
 
-      makeDraggable(img, (<Editor>this.editor).graph, dropHandler, sprite);
+      makeDraggable(img, this.editor!.graph, dropHandler, sprite);
       InternalEvent.removeListener(sprite, 'load', loader);
     };
   }
@@ -464,8 +458,8 @@ export class EditorToolbar {
    */
   destroy(): void {
     if (this.resetHandler != null) {
-      (<Editor>this.editor).graph.removeListener(this.resetHandler);
-      (<Editor>this.editor).removeListener(this.resetHandler);
+      this.editor!.graph.removeListener(this.resetHandler);
+      this.editor!.removeListener(this.resetHandler);
       this.resetHandler = null;
     }
 

--- a/packages/core/src/editor/EditorToolbar.ts
+++ b/packages/core/src/editor/EditorToolbar.ts
@@ -146,7 +146,7 @@ export class EditorToolbar {
         this.editor!.execute(action);
       }
     };
-    return (<MaxToolbar>this.toolbar).addItem(title, icon, clickHandler, pressed);
+    return this.toolbar!.addItem(title, icon, clickHandler, pressed);
   }
 
   /**
@@ -156,14 +156,14 @@ export class EditorToolbar {
    */
   addSeparator(icon?: string): void {
     icon = icon || `${Client.imageBasePath}/separator.gif`;
-    (<MaxToolbar>this.toolbar).addSeparator(icon);
+    this.toolbar!.addSeparator(icon);
   }
 
   /**
    * Helper method to invoke {@link MaxToolbar.addCombo} on toolbar and return the resulting DOM node.
    */
   addCombo(): HTMLElement {
-    return (<MaxToolbar>this.toolbar).addCombo();
+    return this.toolbar!.addCombo();
   }
 
   /**
@@ -173,7 +173,7 @@ export class EditorToolbar {
    * @param title String that represents the title of the combo.
    */
   addActionCombo(title: string) {
-    return (<MaxToolbar>this.toolbar).addActionCombo(title);
+    return this.toolbar!.addActionCombo(title);
   }
 
   /**
@@ -203,7 +203,7 @@ export class EditorToolbar {
     title: string,
     value: string | ((evt: any) => void) | null
   ): HTMLElement {
-    return (<MaxToolbar>this.toolbar).addOption(combo, title, value);
+    return this.toolbar!.addOption(combo, title, value);
   }
 
   /**
@@ -227,7 +227,7 @@ export class EditorToolbar {
       this.editor!.setMode(mode);
       funct?.(this.editor!);
     };
-    return (<MaxToolbar>this.toolbar).addSwitchMode(title, icon, clickHandler, pressed);
+    return this.toolbar!.addSwitchMode(title, icon, clickHandler, pressed);
   }
 
   /**
@@ -278,18 +278,11 @@ export class EditorToolbar {
         this.drop(factory(), evt, cell);
       }
 
-      (<MaxToolbar>this.toolbar).resetMode();
+      this.toolbar!.resetMode();
       InternalEvent.consume(evt);
     };
 
-    const img = (<MaxToolbar>this.toolbar).addMode(
-      title,
-      icon,
-      clickHandler,
-      pressed,
-      null,
-      toggle
-    );
+    const img = this.toolbar!.addMode(title, icon, clickHandler, pressed, null, toggle);
 
     // Creates a wrapper function that calls the click handler without the graph argument
     const dropHandler: DropHandler = (

--- a/packages/core/src/editor/EditorToolbar.ts
+++ b/packages/core/src/editor/EditorToolbar.ts
@@ -28,6 +28,7 @@ import type Cell from '../view/cell/Cell';
 import type { AbstractGraph } from '../view/AbstractGraph';
 import EventObject from '../view/event/EventObject';
 import type { DropHandler } from '../view/other/DragSource';
+import { EventListenerFunction } from '../types';
 
 /**
  * Toolbar for the editor.
@@ -50,8 +51,8 @@ import type { DropHandler } from '../view/other/DragSource';
  *
  * ### Codec
  *
- * This class uses the {@link DefaultToolbarCodec} to read configuration
- * data into an existing instance. See {@link DefaultToolbarCodec} for a
+ * This class uses the {@link EditorToolbarCodec} to read configuration
+ * data into an existing instance. See {@link EditorToolbarCodec} for a
  * description of the configuration format.
  *
  * @category Editor
@@ -78,8 +79,7 @@ export class EditorToolbar {
   /**
    * Reference to the function used to reset the {@link toolbar}.
    */
-  // TODO can we use EventListenerFunction type here?
-  resetHandler: (() => void) | null = null;
+  resetHandler: EventListenerFunction | null = null;
 
   /**
    * Defines the spacing between existing and new vertices in gridSize units when a new vertex is dropped on an existing cell.

--- a/packages/core/src/editor/EditorToolbar.ts
+++ b/packages/core/src/editor/EditorToolbar.ts
@@ -102,18 +102,21 @@ export class EditorToolbar {
       this.toolbar = new MaxToolbar(container);
 
       // Installs the insert function in the editor if an item is selected in the toolbar
-      this.toolbar.addListener(InternalEvent.SELECT, () => {
-        const funct = evt.getProperty('function');
+      this.toolbar.addListener(
+        InternalEvent.SELECT,
+        (_sender: EventTarget, evt: EventObject) => {
+          const funct = evt.getProperty('function');
 
-        if (funct != null) {
-          (<Editor>this.editor).insertFunction = () => {
-            funct.apply(this, [container]);
-            (<MaxToolbar>this.toolbar).resetMode();
-          };
-        } else {
-          (<Editor>this.editor).insertFunction = null;
+          if (funct != null) {
+            (<Editor>this.editor).insertFunction = () => {
+              funct.apply(this, [container]);
+              this.toolbar!.resetMode();
+            };
+          } else {
+            this.editor!.insertFunction = null;
+          }
         }
-      });
+      );
 
       // Resets the selected tool after a double click or escape keystroke
       this.resetHandler = () => {

--- a/packages/core/src/editor/EditorToolbar.ts
+++ b/packages/core/src/editor/EditorToolbar.ts
@@ -167,7 +167,7 @@ export class EditorToolbar {
   }
 
   /**
-   * Helper method to invoke <MaxToolbar.addActionCombo> on <toolbar> using
+   * Helper method to invoke {@link MaxToolbar.addActionCombo}> on {@link toolbar} using
    * the given title and return the resulting DOM node.
    *
    * @param title String that represents the title of the combo.
@@ -232,7 +232,7 @@ export class EditorToolbar {
 
   /**
    * Creates an item for inserting a clone of the specified prototype cell into
-   * the <editor>'s graph. The ptype may either be a cell or a function that
+   * the {@link editor}'s graph. The `ptype` may either be a cell or a function that
    * returns a cell.
    *
    * @param title String that represents the title of the item.
@@ -242,8 +242,8 @@ export class EditorToolbar {
    * instances.
    * @param pressed Optional URL of the icon that represents the pressed state.
    * @param insert Optional JavaScript function that handles an insert of the new
-   * cell. This function takes the <Editor>, new cell to be inserted, mouse
-   * event and optional <Cell> under the mouse pointer as arguments.
+   * cell. This function takes the {@link Editor}, new cell to be inserted, mouse
+   * event and optional {@link Cell} under the mouse pointer as arguments.
    * @param toggle Optional boolean that specifies if the item can be toggled.
    * Default is true.
    */
@@ -273,7 +273,7 @@ export class EditorToolbar {
     // after this item has been selected in the toolbar
     const clickHandler = (evt: MouseEvent, cell: Cell | null) => {
       if (typeof insert === 'function') {
-        insert(<Editor>this.editor, factory(), evt, cell);
+        insert(this.editor!, factory(), evt, cell);
       } else {
         this.drop(factory(), evt, cell);
       }
@@ -307,7 +307,7 @@ export class EditorToolbar {
    * @param target - Optional {@link Cell} that represents the drop target.
    */
   drop(vertex: Cell, evt: MouseEvent, target: Cell | null = null): void {
-    const { graph } = <Editor>this.editor;
+    const { graph } = this.editor!;
     const model = graph.getDataModel();
 
     if (
@@ -334,7 +334,7 @@ export class EditorToolbar {
    * @param target - Optional {@link Cell} that represents the parent.
    */
   insert(vertex: Cell, evt: MouseEvent, target: Cell | null = null): any {
-    const { graph } = <Editor>this.editor;
+    const { graph } = this.editor!;
 
     if (graph.canImportCell(vertex)) {
       const x = getClientX(evt);
@@ -358,11 +358,11 @@ export class EditorToolbar {
    * Handles a drop by connecting the given vertex to the given source cell.
    *
    * @param vertex - {@link Cell} to be inserted.
-   * @param evt - Mouse event that represents the drop.
+   * @param _evt - Mouse event that represents the drop.
    * @param source - Optional {@link Cell} that represents the source terminal.
    */
-  connect(vertex: Cell, evt: MouseEvent, source: Cell | null = null): void {
-    const { graph } = <Editor>this.editor;
+  connect(vertex: Cell, _evt: MouseEvent, source: Cell | null = null): void {
+    const { graph } = this.editor!;
     const model = graph.getDataModel();
 
     if (
@@ -374,8 +374,8 @@ export class EditorToolbar {
 
       model.beginUpdate();
       try {
-        const geo = <Geometry>source.getGeometry();
-        const g = (<Geometry>vertex.getGeometry()).clone();
+        const geo = source.getGeometry()!;
+        const g = vertex.getGeometry()!.clone();
 
         // Moves the vertex away from the drop target that will
         // be used as the source for the new connection
@@ -428,7 +428,7 @@ export class EditorToolbar {
    */
   installDropHandler(img: HTMLElement, dropHandler: DropHandler): void {
     const sprite = document.createElement('img');
-    sprite.setAttribute('src', <string>img.getAttribute('src'));
+    sprite.setAttribute('src', img.getAttribute('src')!);
 
     // Handles delayed loading of the images
     const loader = (evt: InternalEvent) => {

--- a/packages/core/src/editor/EditorToolbar.ts
+++ b/packages/core/src/editor/EditorToolbar.ts
@@ -101,23 +101,19 @@ export class EditorToolbar {
     if (container != null) {
       this.toolbar = new MaxToolbar(container);
 
-      // Installs the insert function in the editor if an item is
-      // selected in the toolbar
-      this.toolbar.addListener(
-        InternalEvent.SELECT,
-        (sender: Element, evt: EventObject) => {
-          const funct = evt.getProperty('function');
+      // Installs the insert function in the editor if an item is selected in the toolbar
+      this.toolbar.addListener(InternalEvent.SELECT, () => {
+        const funct = evt.getProperty('function');
 
-          if (funct != null) {
-            (<Editor>this.editor).insertFunction = () => {
-              funct.apply(this, [container]);
-              (<MaxToolbar>this.toolbar).resetMode();
-            };
-          } else {
-            (<Editor>this.editor).insertFunction = null;
-          }
+        if (funct != null) {
+          (<Editor>this.editor).insertFunction = () => {
+            funct.apply(this, [container]);
+            (<MaxToolbar>this.toolbar).resetMode();
+          };
+        } else {
+          (<Editor>this.editor).insertFunction = null;
         }
-      );
+      });
 
       // Resets the selected tool after a double click or escape keystroke
       this.resetHandler = () => {

--- a/packages/core/src/editor/EditorToolbar.ts
+++ b/packages/core/src/editor/EditorToolbar.ts
@@ -431,7 +431,7 @@ export class EditorToolbar {
     sprite.setAttribute('src', img.getAttribute('src')!);
 
     // Handles delayed loading of the images
-    const loader = (evt: InternalEvent) => {
+    const loader = (_evt: InternalEvent) => {
       // Preview uses the image node with double size. Later this can be
       // changed to use a separate preview and guides, but for this the
       // dropHandler must use the additional x- and y-arguments and the

--- a/packages/core/src/gui/MaxForm.ts
+++ b/packages/core/src/gui/MaxForm.ts
@@ -58,7 +58,7 @@ class MaxForm {
    * Helper method to add an OK and Cancel button using the respective
    * functions.
    */
-  addButtons(okFunct: Function, cancelFunct: Function): void {
+  addButtons(okFunct: () => void, cancelFunct: () => void): void {
     const tr = document.createElement('tr');
     let td = document.createElement('td');
     tr.appendChild(td);

--- a/packages/core/src/gui/MaxLog.ts
+++ b/packages/core/src/gui/MaxLog.ts
@@ -173,7 +173,7 @@ class MaxLog {
       ) {
         const elt = MaxLog.window.getElement();
 
-        const resizeHandler = (_sender: EventTarget, _eventObject: EventObject) => {
+        const resizeHandler = () => {
           (<HTMLTextAreaElement>MaxLog.textarea).style.height = `${Math.max(
             0,
             elt.offsetHeight - 70

--- a/packages/core/src/gui/MaxLog.ts
+++ b/packages/core/src/gui/MaxLog.ts
@@ -26,6 +26,7 @@ import { getElapseMillisecondsMessage } from '../internal/time-utils';
 import { VERSION } from '../util/Constants';
 import { GlobalConfig } from '../util/config';
 import { popup } from './guiUtils';
+import EventObject from '../view/event/EventObject';
 
 const copyTextToClipboard = (text: string): void => {
   navigator.clipboard.writeText(text).then(
@@ -98,16 +99,16 @@ class MaxLog {
       table.appendChild(tbody);
 
       // Adds various debugging buttons
-      MaxLog.addButton('Info', function (evt: MouseEvent) {
+      MaxLog.addButton('Info', function () {
         MaxLog.info();
       });
 
-      MaxLog.addButton('DOM', function (evt: MouseEvent) {
+      MaxLog.addButton('DOM', function () {
         const content = getInnerHtml(document.body);
         MaxLog.debug(content);
       });
 
-      MaxLog.addButton('Trace', function (evt: MouseEvent) {
+      MaxLog.addButton('Trace', function () {
         MaxLog.TRACE = !MaxLog.TRACE;
 
         if (MaxLog.TRACE) {
@@ -117,7 +118,7 @@ class MaxLog {
         }
       });
 
-      MaxLog.addButton('Copy', function (evt: MouseEvent) {
+      MaxLog.addButton('Copy', function () {
         try {
           copyTextToClipboard((<HTMLTextAreaElement>MaxLog.textarea).value);
         } catch (err) {
@@ -125,7 +126,7 @@ class MaxLog {
         }
       });
 
-      MaxLog.addButton('Show', function (evt: MouseEvent) {
+      MaxLog.addButton('Show', function () {
         try {
           popup((<HTMLTextAreaElement>MaxLog.textarea).value);
         } catch (err) {
@@ -133,7 +134,7 @@ class MaxLog {
         }
       });
 
-      MaxLog.addButton('Clear', function (evt: MouseEvent) {
+      MaxLog.addButton('Clear', function () {
         (<HTMLTextAreaElement>MaxLog.textarea).value = '';
       });
 
@@ -172,7 +173,7 @@ class MaxLog {
       ) {
         const elt = MaxLog.window.getElement();
 
-        const resizeHandler = (sender: any, evt: MouseEvent) => {
+        const resizeHandler = (_sender: EventTarget, _eventObject: EventObject) => {
           (<HTMLTextAreaElement>MaxLog.textarea).style.height = `${Math.max(
             0,
             elt.offsetHeight - 70

--- a/packages/core/src/gui/MaxLog.ts
+++ b/packages/core/src/gui/MaxLog.ts
@@ -26,7 +26,6 @@ import { getElapseMillisecondsMessage } from '../internal/time-utils';
 import { VERSION } from '../util/Constants';
 import { GlobalConfig } from '../util/config';
 import { popup } from './guiUtils';
-import EventObject from '../view/event/EventObject';
 
 const copyTextToClipboard = (text: string): void => {
   navigator.clipboard.writeText(text).then(

--- a/packages/core/src/gui/MaxToolbar.ts
+++ b/packages/core/src/gui/MaxToolbar.ts
@@ -340,7 +340,7 @@ class MaxToolbar extends EventSource {
   /**
    * Adds a new item to the toolbar. The selection is typically reset after
    * the item has been consumed, for example by adding a new vertex to the
-   * graph. The reset is not carried out if the item is double clicked.
+   * graph. The reset is not carried out if the item is double-clicked.
    *
    * The function argument uses the following signature: funct(evt, cell) where
    * evt is the native mouse event and cell is the cell under the mouse.

--- a/packages/core/src/gui/MaxToolbar.ts
+++ b/packages/core/src/gui/MaxToolbar.ts
@@ -55,7 +55,7 @@ class MaxToolbar extends EventSource {
   currentImg: HTMLImageElementWithProps | HTMLButtonElement | null = null;
   selectedMode: HTMLImageElementWithProps | null = null;
   defaultMode: HTMLImageElementWithProps | HTMLButtonElement | null = null;
-  defaultFunction: Function | null = null;
+  defaultFunction: ((evt: MouseEvent, cell: Cell | null) => void) | null = null;
 
   /**
    * Reference to the DOM nodes that contains the toolbar.
@@ -348,7 +348,7 @@ class MaxToolbar extends EventSource {
   addMode(
     title: string | null = null,
     icon: string | null = null,
-    funct: Function,
+    funct: (evt: MouseEvent, cell: Cell | null) => void,
     pressedIcon: string,
     style: string | null = null,
     toggle = false
@@ -396,7 +396,10 @@ class MaxToolbar extends EventSource {
    * DOM node as selected. This function fires a select event with the given
    * function as a parameter.
    */
-  selectMode(domNode: HTMLImageElement, funct: Function | null = null): void {
+  selectMode(
+    domNode: HTMLImageElement,
+    funct: ((evt: MouseEvent, cell: Cell | null) => void) | null = null
+  ): void {
     if (this.selectedMode != domNode) {
       if (this.selectedMode != null) {
         const tmp = this.selectedMode.altIcon;

--- a/packages/core/src/i18n/Translations.ts
+++ b/packages/core/src/i18n/Translations.ts
@@ -189,7 +189,7 @@ export default class Translations {
   static add = (
     basename: string | null = null,
     lan: string | null = null,
-    callback: Function | null = null
+    callback: (() => void) | null = null
   ): void => {
     lan ??= TranslationsConfig.getLanguage()?.toLowerCase() ?? NONE;
 
@@ -373,7 +373,7 @@ export default class Translations {
    *
    * @param callback Callback function for asynchronous loading.
    */
-  static loadResources = (callback: Function): void => {
+  static loadResources = (callback: () => void): void => {
     Translations.add(`${Client.basePath}/resources/editor`, null, () => {
       Translations.add(`${Client.basePath}/resources/graph`, null, callback);
     });

--- a/packages/core/src/i18n/Translations.ts
+++ b/packages/core/src/i18n/Translations.ts
@@ -405,7 +405,7 @@ export class TranslationsAsI18n implements I18nProvider {
   addResource(
     basename?: string | null,
     language?: string | null,
-    callback?: Function | null
+    callback?: (() => void) | null
   ): void {
     Translations.add(basename, language, callback);
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -31,6 +31,7 @@ import type GraphDataModel from './view/GraphDataModel';
 import type { Stylesheet } from './view/style/Stylesheet';
 import type GraphSelectionModel from './view/GraphSelectionModel';
 import type GraphView from './view/GraphView';
+import EventObject from './view/event/EventObject';
 
 export type FilterFunction = (cell: Cell) => boolean;
 
@@ -1616,3 +1617,8 @@ export interface EdgeMarkerRegistryInterface extends Registry<MarkerFactoryFunct
     filled: boolean
   ): MarkerFunction | null;
 }
+
+export type EventListenerFunction = (
+  sender: EventTarget, // TODO why not EventSource? or both objects?
+  eventObject: EventObject
+) => void;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -31,7 +31,8 @@ import type GraphDataModel from './view/GraphDataModel';
 import type { Stylesheet } from './view/style/Stylesheet';
 import type GraphSelectionModel from './view/GraphSelectionModel';
 import type GraphView from './view/GraphView';
-import EventObject from './view/event/EventObject';
+import type EventObject from './view/event/EventObject';
+import type Editor from './editor/Editor';
 
 export type FilterFunction = (cell: Cell) => boolean;
 
@@ -1621,4 +1622,10 @@ export interface EdgeMarkerRegistryInterface extends Registry<MarkerFactoryFunct
 export type EventListenerFunction = (
   sender: EventTarget, // TODO why not EventSource? Listenable? or both objects?
   eventObject: EventObject
+) => void;
+
+export type EditorActionFunction = (
+  editor: Editor,
+  cell: Cell | null,
+  evt?: Event | null
 ) => void;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1430,7 +1430,7 @@ export interface I18nProvider {
   addResource(
     basename?: string | null,
     language?: string | null,
-    callback?: Function | null
+    callback?: (() => void) | null
   ): void;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1619,6 +1619,7 @@ export interface EdgeMarkerRegistryInterface extends Registry<MarkerFactoryFunct
   ): MarkerFunction | null;
 }
 
+// TODO rename to EventListener?
 export type EventListenerFunction = (
   sender: EventTarget, // TODO why not EventSource? Listenable? or both objects?
   eventObject: EventObject

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1619,6 +1619,6 @@ export interface EdgeMarkerRegistryInterface extends Registry<MarkerFactoryFunct
 }
 
 export type EventListenerFunction = (
-  sender: EventTarget, // TODO why not EventSource? or both objects?
+  sender: EventTarget, // TODO why not EventSource? Listenable? or both objects?
   eventObject: EventObject
 ) => void;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1625,6 +1625,7 @@ export type EventListenerFunction = (
   eventObject: EventObject
 ) => void;
 
+// TODO rename to EditorAction?
 export type EditorActionFunction = (
   editor: Editor,
   cell: Cell | null,

--- a/packages/core/src/util/MaxXmlRequest.ts
+++ b/packages/core/src/util/MaxXmlRequest.ts
@@ -250,9 +250,12 @@ export default class MaxXmlRequest {
    * @param ontimeout Optional function to execute on timeout.
    */
   send(
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- require a generic function type
     onload: Function | null = null,
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- require a generic function type
     onerror: Function | null = null,
     timeout: number | null = null,
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- require a generic function type
     ontimeout: Function | null = null
   ): void {
     this.request = this.create();

--- a/packages/core/src/util/MaxXmlRequest.ts
+++ b/packages/core/src/util/MaxXmlRequest.ts
@@ -149,7 +149,7 @@ export default class MaxXmlRequest {
   /**
    * Holds the inner, browser-specific request object.
    */
-  request: any = null;
+  request: XMLHttpRequest = null!;
 
   /**
    * Specifies if request values should be decoded as URIs before setting the
@@ -251,11 +251,11 @@ export default class MaxXmlRequest {
    */
   send(
     onload: ((sender: MaxXmlRequest) => void) | null = null,
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- require a generic function type
-    onerror: Function | null = null,
+    onerror: ((this: XMLHttpRequest, ev: ProgressEvent) => any) | null = null,
     timeout: number | null = null,
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- require a generic function type
-    ontimeout: Function | null = null
+    ontimeout:
+      | ((this: XMLHttpRequest, ev: ProgressEvent<EventTarget>) => any)
+      | null = null
   ): void {
     this.request = this.create();
 
@@ -273,7 +273,7 @@ export default class MaxXmlRequest {
       this.setRequestHeaders(this.request, this.params);
 
       if (window.XMLHttpRequest && this.withCredentials) {
-        this.request.withCredentials = 'true';
+        this.request.withCredentials = true;
       }
 
       if (window.XMLHttpRequest && timeout != null && ontimeout != null) {

--- a/packages/core/src/util/MaxXmlRequest.ts
+++ b/packages/core/src/util/MaxXmlRequest.ts
@@ -250,8 +250,7 @@ export default class MaxXmlRequest {
    * @param ontimeout Optional function to execute on timeout.
    */
   send(
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- require a generic function type
-    onload: Function | null = null,
+    onload: ((sender: MaxXmlRequest) => void) | null = null,
     // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- require a generic function type
     onerror: Function | null = null,
     timeout: number | null = null,

--- a/packages/core/src/util/cellArrayUtils.ts
+++ b/packages/core/src/util/cellArrayUtils.ts
@@ -1,24 +1,6 @@
 import Cell from '../view/cell/Cell';
 import Dictionary from './Dictionary';
 import ObjectIdentity from './ObjectIdentity';
-import type { FilterFunction } from '../types';
-
-// TODO review this function that seems to have been moved in the main branch!
-/**
- * Returns the cells from the given array where the given filter function
- * returns true.
- */
-export const filterCells = (filter: FilterFunction) => (cells: Cell[]) => {
-  const result = [] as Cell[];
-
-  for (let i = 0; i < cells.length; i += 1) {
-    if (filter(cells[i])) {
-      result.push(cells[i]);
-    }
-  }
-
-  return result;
-};
 
 /**
  * Returns all opposite vertices terminal for the given edges, only returning sources and/or targets as specified.

--- a/packages/core/src/util/cellArrayUtils.ts
+++ b/packages/core/src/util/cellArrayUtils.ts
@@ -1,6 +1,23 @@
 import Cell from '../view/cell/Cell';
 import Dictionary from './Dictionary';
 import ObjectIdentity from './ObjectIdentity';
+import type { FilterFunction } from '../types';
+
+/**
+ * Returns the cells from the given array where the given filter function
+ * returns true.
+ */
+export const filterCells = (filter: Function) => (cells: Cell[]) => {
+  const result = [] as Cell[];
+
+  for (let i = 0; i < cells.length; i += 1) {
+    if (filter(cells[i])) {
+      result.push(cells[i]);
+    }
+  }
+
+  return result;
+};
 
 /**
  * Returns all opposite vertices terminal for the given edges, only returning sources and/or targets as specified.

--- a/packages/core/src/util/cellArrayUtils.ts
+++ b/packages/core/src/util/cellArrayUtils.ts
@@ -3,11 +3,12 @@ import Dictionary from './Dictionary';
 import ObjectIdentity from './ObjectIdentity';
 import type { FilterFunction } from '../types';
 
+// TODO review this function that seems to have been moved in the main branch!
 /**
  * Returns the cells from the given array where the given filter function
  * returns true.
  */
-export const filterCells = (filter: Function) => (cells: Cell[]) => {
+export const filterCells = (filter: FilterFunction) => (cells: Cell[]) => {
   const result = [] as Cell[];
 
   for (let i = 0; i < cells.length; i += 1) {

--- a/packages/core/src/util/gestureUtils.ts
+++ b/packages/core/src/util/gestureUtils.ts
@@ -86,7 +86,7 @@ import type Cell from '../view/cell/Cell';
  */
 export const makeDraggable = (
   element: Element,
-  graphF: AbstractGraph | ((evt: MouseEvent) => Graph),
+  graphF: AbstractGraph | ((evt: MouseEvent) => AbstractGraph),
   funct: DropHandler,
   dragElement: Element | null = null,
   dx: number | null = null,

--- a/packages/core/src/util/gestureUtils.ts
+++ b/packages/core/src/util/gestureUtils.ts
@@ -86,7 +86,7 @@ import type Cell from '../view/cell/Cell';
  */
 export const makeDraggable = (
   element: Element,
-  graphF: AbstractGraph | Function,
+  graphF: AbstractGraph | ((evt: MouseEvent) => Graph),
   funct: DropHandler,
   dragElement: Element | null = null,
   dx: number | null = null,

--- a/packages/core/src/util/requestUtils.ts
+++ b/packages/core/src/util/requestUtils.ts
@@ -180,7 +180,8 @@ export const getAll = (
 export const post = (
   url: string,
   params: string | null = null,
-  onload: Function,
+  onload: (sender: MaxXmlRequest) => void,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- require a generic function type
   onerror: Function | null = null
 ) => {
   return new MaxXmlRequest(url, params).send(onload, onerror);

--- a/packages/core/src/util/requestUtils.ts
+++ b/packages/core/src/util/requestUtils.ts
@@ -79,9 +79,11 @@ export const load = (url: string): MaxXmlRequest => {
 export const get = (
   url: string,
   onload: ((sender: MaxXmlRequest) => void) | null = null,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- require a generic function type
   onerror: Function | null = null,
   binary = false,
   timeout: number | null = null,
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- require a generic function type
   ontimeout: Function | null = null,
   headers: { [key: string]: string } | null = null
 ) => {

--- a/packages/core/src/util/requestUtils.ts
+++ b/packages/core/src/util/requestUtils.ts
@@ -78,7 +78,7 @@ export const load = (url: string): MaxXmlRequest => {
  */
 export const get = (
   url: string,
-  onload: Function | null = null,
+  onload: ((sender: MaxXmlRequest) => void) | null = null,
   onerror: Function | null = null,
   binary = false,
   timeout: number | null = null,

--- a/packages/core/src/util/requestUtils.ts
+++ b/packages/core/src/util/requestUtils.ts
@@ -79,12 +79,10 @@ export const load = (url: string): MaxXmlRequest => {
 export const get = (
   url: string,
   onload: ((sender: MaxXmlRequest) => void) | null = null,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- require a generic function type
-  onerror: Function | null = null,
+  onerror: ((this: XMLHttpRequest, ev: ProgressEvent) => any) | null = null,
   binary = false,
   timeout: number | null = null,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- require a generic function type
-  ontimeout: Function | null = null,
+  ontimeout: ((this: XMLHttpRequest, ev: ProgressEvent) => any) | null = null,
   headers: { [key: string]: string } | null = null
 ) => {
   const req = new MaxXmlRequest(url, null, 'GET');
@@ -183,8 +181,7 @@ export const post = (
   url: string,
   params: string | null = null,
   onload: (sender: MaxXmlRequest) => void,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- require a generic function type
-  onerror: Function | null = null
+  onerror: ((this: XMLHttpRequest, ev: ProgressEvent) => any) | null = null
 ) => {
   return new MaxXmlRequest(url, params).send(onload, onerror);
 };

--- a/packages/core/src/util/treeTraversal.ts
+++ b/packages/core/src/util/treeTraversal.ts
@@ -119,7 +119,7 @@ export function findTreeRoots(
 export function traverse(
   vertex: Cell | null = null,
   directed = true,
-  func: Function | null = null,
+  func: ((vertex: Cell, edge: Cell | null) => boolean) | null = null,
   edge: Cell | null = null,
   visited: Dictionary<Cell, boolean> | null = null,
   inverse = false

--- a/packages/core/src/view/AbstractGraph.ts
+++ b/packages/core/src/view/AbstractGraph.ts
@@ -60,6 +60,7 @@ import ImageBundle from './image/ImageBundle';
 import { applyGraphMixins } from './mixins/_graph-mixins-apply';
 import { isNullish } from '../internal/utils';
 import { isI18nEnabled } from '../internal/i18n-utils';
+import AbstractCanvas2D from './canvas/AbstractCanvas2D';
 
 /**
  * Extends {@link EventSource} to implement a graph component for the browser. This is the entry point class of the package.
@@ -84,7 +85,9 @@ export abstract class AbstractGraph extends EventSource {
   destroyed = false;
 
   graphModelChangeListener: EventListenerFunction | null = null;
-  paintBackground: Function | null = null;
+  paintBackground:
+    | ((c: AbstractCanvas2D, x: number, y: number, w: number, h: number) => void)
+    | null = null;
   isConstrainedMoving = false;
 
   // ===================================================================================================================

--- a/packages/core/src/view/AbstractGraph.ts
+++ b/packages/core/src/view/AbstractGraph.ts
@@ -18,7 +18,8 @@ limitations under the License.
 
 import Image from './image/ImageBox';
 import EventObject from './event/EventObject';
-import EventSource, { EventListenerFunction } from './event/EventSource';
+import type { EventListenerFunction } from './event/EventSource';
+import EventSource from './event/EventSource';
 import InternalEvent from './event/InternalEvent';
 import Rectangle from './geometry/Rectangle';
 import Client from '../Client';

--- a/packages/core/src/view/AbstractGraph.ts
+++ b/packages/core/src/view/AbstractGraph.ts
@@ -18,7 +18,7 @@ limitations under the License.
 
 import Image from './image/ImageBox';
 import EventObject from './event/EventObject';
-import EventSource from './event/EventSource';
+import EventSource, { EventListenerFunction } from './event/EventSource';
 import InternalEvent from './event/InternalEvent';
 import Rectangle from './geometry/Rectangle';
 import Client from '../Client';
@@ -83,7 +83,7 @@ export abstract class AbstractGraph extends EventSource {
 
   destroyed = false;
 
-  graphModelChangeListener: Function | null = null;
+  graphModelChangeListener: EventListenerFunction | null = null;
   paintBackground: Function | null = null;
   isConstrainedMoving = false;
 

--- a/packages/core/src/view/AbstractGraph.ts
+++ b/packages/core/src/view/AbstractGraph.ts
@@ -468,7 +468,7 @@ export abstract class AbstractGraph extends EventSource {
     this.initializeCollaborators(options);
 
     // Adds a graph model listener to update the view
-    this.graphModelChangeListener = (_sender: any, evt: EventObject) => {
+    this.graphModelChangeListener = (_sender, evt) => {
       this.graphModelChanged(evt.getProperty('edit').changes);
     };
     this.getDataModel().addListener(InternalEvent.CHANGE, this.graphModelChangeListener);

--- a/packages/core/src/view/AbstractGraph.ts
+++ b/packages/core/src/view/AbstractGraph.ts
@@ -18,7 +18,6 @@ limitations under the License.
 
 import Image from './image/ImageBox';
 import EventObject from './event/EventObject';
-import type { EventListenerFunction } from './event/EventSource';
 import EventSource from './event/EventSource';
 import InternalEvent from './event/InternalEvent';
 import Rectangle from './geometry/Rectangle';
@@ -49,6 +48,7 @@ import ElbowEdgeHandler from './handler/ElbowEdgeHandler';
 import type {
   DialectValue,
   EdgeStyleFunction,
+  EventListenerFunction,
   GraphCollaboratorsOptions,
   GraphFoldingOptions,
   GraphOptions,

--- a/packages/core/src/view/Graph.ts
+++ b/packages/core/src/view/Graph.ts
@@ -30,7 +30,6 @@ import {
   registerDefaultPerimeters,
 } from './style/register';
 import { getDefaultPlugins } from './plugins';
-import type AbstractCanvas2D from './canvas/AbstractCanvas2D';
 
 /**
  * An implementation of {@link AbstractGraph} that automatically loads some default built-ins (plugins, style elements).

--- a/packages/core/src/view/Graph.ts
+++ b/packages/core/src/view/Graph.ts
@@ -30,6 +30,7 @@ import {
   registerDefaultPerimeters,
 } from './style/register';
 import { getDefaultPlugins } from './plugins';
+import type AbstractCanvas2D from './canvas/AbstractCanvas2D';
 
 /**
  * An implementation of {@link AbstractGraph} that automatically loads some default built-ins (plugins, style elements).

--- a/packages/core/src/view/animate/Effects.ts
+++ b/packages/core/src/view/animate/Effects.ts
@@ -57,7 +57,7 @@ class Effects {
   static animateChanges(
     graph: AbstractGraph,
     changes: UndoableChange[],
-    done?: Function
+    done?: () => void
   ): void {
     const maxStep = 10;
     let step = 0;

--- a/packages/core/src/view/cell/CellHighlight.ts
+++ b/packages/core/src/view/cell/CellHighlight.ts
@@ -47,7 +47,7 @@ class CellHighlight {
 
   opacity = 100;
 
-  repaintHandler: Function;
+  repaintHandler: () => void;
 
   shape: Shape | null = null;
 

--- a/packages/core/src/view/cell/CellHighlight.ts
+++ b/packages/core/src/view/cell/CellHighlight.ts
@@ -76,9 +76,8 @@ class CellHighlight {
 
   /**
    * Holds the handler that automatically invokes reset if the highlight should be hidden.
-   * @default null
    */
-  resetHandler: Function;
+  resetHandler: () => void;
 
   constructor(
     graph: AbstractGraph,

--- a/packages/core/src/view/cell/CellStatePreview.ts
+++ b/packages/core/src/view/cell/CellStatePreview.ts
@@ -88,11 +88,7 @@ class CellStatePreview {
     return delta.point;
   }
 
-  /**
-   *
-   * @param {Function} visitor
-   */
-  show(visitor: Function | null = null): void {
+  show(visitor: ((state: CellState) => void) | null = null): void {
     this.deltas.visit((key: string, delta: any) => {
       this.translateState(delta.state, delta.point.x, delta.point.y);
     });
@@ -133,18 +129,11 @@ class CellStatePreview {
     }
   }
 
-  /**
-   *
-   * @param {CellState} state
-   * @param {number} dx
-   * @param {number} dy
-   * @param {Function} visitor
-   */
   revalidateState(
     state: CellState,
     dx: number,
     dy: number,
-    visitor: Function | null = null
+    visitor: ((state: CellState) => void) | null = null
   ): void {
     // Updates the edge terminal points and restores the
     // (relative) positions of any (relative) children

--- a/packages/core/src/view/cell/TemporaryCellStates.ts
+++ b/packages/core/src/view/cell/TemporaryCellStates.ts
@@ -52,8 +52,8 @@ class TemporaryCellStates {
     view: GraphView,
     scale = 1,
     cells: Cell[],
-    isCellVisibleFn: Function | null = null,
-    getLinkForCellState: Function | null = null
+    isCellVisibleFn: ((cell: Cell) => boolean) | null = null,
+    getLinkForCellState: ((state: CellState) => string | null) | null = null
   ) {
     this.view = view;
 
@@ -104,9 +104,7 @@ class TemporaryCellStates {
     // Validates the vertices and edges without adding them to
     // the model so that the original cells are not modified
     for (const cell of cells) {
-      const bounds = view.getBoundingBox(
-        view.validateCellState(<Cell>view.validateCell(<Cell>cell))
-      );
+      const bounds = view.getBoundingBox(view.validateCellState(view.validateCell(cell)));
       if (bbox == null) {
         bbox = bounds;
       } else {

--- a/packages/core/src/view/event/EventSource.ts
+++ b/packages/core/src/view/event/EventSource.ts
@@ -23,7 +23,10 @@ type EventListenerObject = {
   name: string;
 };
 
-type EventListenerFunction = (sender: string, eventObject: EventObject) => void;
+export type EventListenerFunction = (
+  sender: EventTarget,
+  eventObject: EventObject
+) => void;
 
 /**
  * Base class for objects that dispatch named events.
@@ -135,8 +138,7 @@ class EventSource {
    * ```
    *
    * @param evt {@link EventObject} that represents the event.
-   * @param sender Optional sender to be passed to the listener. Default value is
-   * the return value of <getEventSource>.
+   * @param sender Optional sender to be passed to the listener. Default value is the returned value of {@link getEventSource}.
    */
   fireEvent(evt: EventObject, sender: EventTarget | null = null) {
     if (this.isEventsEnabled()) {

--- a/packages/core/src/view/event/EventSource.ts
+++ b/packages/core/src/view/event/EventSource.ts
@@ -137,13 +137,13 @@ class EventSource {
    * fireEvent(new mxEventObject("eventName", key1, val1, .., keyN, valN))
    * ```
    *
-   * @param evt {@link EventObject} that represents the event.
+   * @param eventObject {@link EventObject} that represents the event.
    * @param sender Optional sender to be passed to the listener. Default value is the returned value of {@link getEventSource}.
    */
-  fireEvent(evt: EventObject, sender: EventTarget | null = null) {
+  fireEvent(eventObject: EventObject, sender: EventTarget | null = null) {
     if (this.isEventsEnabled()) {
-      if (!evt) {
-        evt = new EventObject('');
+      if (!eventObject) {
+        eventObject = new EventObject('');
       }
 
       if (!sender) {
@@ -155,8 +155,8 @@ class EventSource {
       }
 
       for (const eventListener of this.eventListeners) {
-        if (eventListener.name === null || eventListener.name === evt.getName()) {
-          eventListener.funct.apply(this, [sender, evt]);
+        if (eventListener.name === null || eventListener.name === eventObject.getName()) {
+          eventListener.funct.apply(this, [sender, eventObject]);
         }
       }
     }

--- a/packages/core/src/view/event/EventSource.ts
+++ b/packages/core/src/view/event/EventSource.ts
@@ -134,7 +134,7 @@ class EventSource {
    * Example:
    *
    * ```javascript
-   * fireEvent(new mxEventObject("eventName", key1, val1, .., keyN, valN))
+   * fireEvent(new EventObject("eventName", key1, val1, .., keyN, valN))
    * ```
    *
    * @param eventObject {@link EventObject} that represents the event.

--- a/packages/core/src/view/event/EventSource.ts
+++ b/packages/core/src/view/event/EventSource.ts
@@ -19,10 +19,11 @@ limitations under the License.
 import EventObject from './EventObject';
 
 type EventListenerObject = {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- require a generic function type
-  funct: Function;
+  funct: EventListenerFunction;
   name: string;
 };
+
+type EventListenerFunction = (sender: string, eventObject: EventObject) => void;
 
 /**
  * Base class for objects that dispatch named events.
@@ -52,66 +53,65 @@ class EventSource {
   }
 
   /**
-   * Holds the event names and associated listeners in an array. The array
-   * contains the event name followed by the respective listener for each
-   * registered listener.
+   * Holds the event names and associated listeners in an array.
+   * The array  contains the event name followed by the respective listener for each registered listener.
    */
   eventListeners: EventListenerObject[] = [];
 
   /**
-   * Specifies if events can be fired. Default is true.
+   * Specifies if events can be fired.
+   * @default true
    */
   eventsEnabled = true;
 
   /**
-   * Optional source for events. Default is null.
+   * Optional source for events.
+   * @default null
    */
   eventSource: EventTarget | null = null;
 
   /**
-   * Returns <eventsEnabled>.
+   * Returns {@link eventsEnabled}.
    */
   isEventsEnabled() {
     return this.eventsEnabled;
   }
 
   /**
-   * Sets <eventsEnabled>.
+   * Sets {@link eventsEnabled}.
    */
   setEventsEnabled(value: boolean) {
     this.eventsEnabled = value;
   }
 
   /**
-   * Returns <eventSource>.
+   * Returns {@link eventSource}.
    */
   getEventSource() {
     return this.eventSource;
   }
 
   /**
-   * Sets <eventSource>.
+   * Sets {@link eventSource}.
    */
   setEventSource(value: EventTarget | null) {
     this.eventSource = value;
   }
 
   /**
-   * Binds the specified function to the given event name. If no event name
-   * is given, then the listener is registered for all events.
+   * Binds the specified function to the given event name.
+   * If no event name is given, then the listener is registered for all events.
    *
    * The parameters of the listener are the sender and an {@link EventObject}.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- require a generic function type
-  addListener(name: string, funct: Function) {
+  addListener(name: string, funct: EventListenerFunction) {
     this.eventListeners.push({ name, funct });
   }
 
   /**
    * Removes all occurrences of the given listener from {@link eventListeners}.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- require a generic function type
-  removeListener(funct: Function) {
+  removeListener(funct: EventListenerFunction) {
     let i = 0;
 
     while (i < this.eventListeners.length) {
@@ -126,7 +126,7 @@ class EventSource {
   /**
    * Dispatches the given event to the listeners which are registered for
    * the event. The sender argument is optional. The current execution scope
-   * ("this") is used for the listener invocation (see {@link Utils#bind}).
+   * ("this") is used for the listener invocation (see {@link utils.bind}).
    *
    * Example:
    *

--- a/packages/core/src/view/event/EventSource.ts
+++ b/packages/core/src/view/event/EventSource.ts
@@ -19,6 +19,7 @@ limitations under the License.
 import EventObject from './EventObject';
 
 type EventListenerObject = {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- require a generic function type
   funct: Function;
   name: string;
 };
@@ -101,6 +102,7 @@ class EventSource {
    *
    * The parameters of the listener are the sender and an {@link EventObject}.
    */
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- require a generic function type
   addListener(name: string, funct: Function) {
     this.eventListeners.push({ name, funct });
   }
@@ -108,6 +110,7 @@ class EventSource {
   /**
    * Removes all occurrences of the given listener from {@link eventListeners}.
    */
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- require a generic function type
   removeListener(funct: Function) {
     let i = 0;
 

--- a/packages/core/src/view/event/EventSource.ts
+++ b/packages/core/src/view/event/EventSource.ts
@@ -24,7 +24,7 @@ type EventListenerObject = {
 };
 
 export type EventListenerFunction = (
-  sender: EventTarget, // TODO why not EventSource?
+  sender: EventTarget, // TODO why not EventSource? or both objects?
   eventObject: EventObject
 ) => void;
 
@@ -150,6 +150,7 @@ class EventSource {
         sender = this.getEventSource();
       }
       if (!sender) {
+        // TODO check mxgraph implementation, this is not extending EventTarget
         sender = <EventTarget>(<unknown>this);
       }
 

--- a/packages/core/src/view/event/EventSource.ts
+++ b/packages/core/src/view/event/EventSource.ts
@@ -106,7 +106,7 @@ class EventSource {
   }
 
   /**
-   * Removes all occurrences of the given listener from <eventListeners>.
+   * Removes all occurrences of the given listener from {@link eventListeners}.
    */
   removeListener(funct: Function) {
     let i = 0;

--- a/packages/core/src/view/event/EventSource.ts
+++ b/packages/core/src/view/event/EventSource.ts
@@ -24,7 +24,7 @@ type EventListenerObject = {
 };
 
 export type EventListenerFunction = (
-  sender: EventTarget,
+  sender: EventTarget, // TODO why not EventSource?
   eventObject: EventObject
 ) => void;
 

--- a/packages/core/src/view/event/EventSource.ts
+++ b/packages/core/src/view/event/EventSource.ts
@@ -17,16 +17,12 @@ limitations under the License.
 */
 
 import EventObject from './EventObject';
+import { EventListenerFunction } from '../../types';
 
 type EventListenerObject = {
   funct: EventListenerFunction;
   name: string;
 };
-
-export type EventListenerFunction = (
-  sender: EventTarget, // TODO why not EventSource? or both objects?
-  eventObject: EventObject
-) => void;
 
 /**
  * Base class for objects that dispatch named events.

--- a/packages/core/src/view/handler/EdgeHandler.ts
+++ b/packages/core/src/view/handler/EdgeHandler.ts
@@ -62,6 +62,7 @@ import EventSource from '../event/EventSource';
 import type SelectionHandler from '../plugins/SelectionHandler';
 import { equalPoints } from '../../util/arrayUtils';
 import { EdgeHandlerConfig, HandleConfig } from './config';
+import EventObject from '../event/EventObject';
 
 /**
  * Graph event handler that reconnects edges, modifies control points and the edge label location.
@@ -193,7 +194,7 @@ class EdgeHandler implements MouseListenerSet {
    */
   manageLabelHandle = false;
 
-  escapeHandler: (sender: Listenable, evt: Event) => void;
+  escapeHandler: (sender: Listenable, eventObject: EventObject) => void;
 
   currentPoint: Point | null = null;
 
@@ -300,7 +301,7 @@ class EdgeHandler implements MouseListenerSet {
     this.redraw();
 
     // Handles escape keystrokes
-    this.escapeHandler = (_sender: Listenable, _evt: Event) => {
+    this.escapeHandler = () => {
       const dirty = this.index != null;
       this.reset();
 

--- a/packages/core/src/view/handler/EdgeHandler.ts
+++ b/packages/core/src/view/handler/EdgeHandler.ts
@@ -194,6 +194,7 @@ class EdgeHandler implements MouseListenerSet {
    */
   manageLabelHandle = false;
 
+  // TODO use EventListenerFunction type instead
   escapeHandler: (sender: Listenable, eventObject: EventObject) => void;
 
   currentPoint: Point | null = null;

--- a/packages/core/src/view/handler/EdgeHandler.ts
+++ b/packages/core/src/view/handler/EdgeHandler.ts
@@ -54,7 +54,12 @@ import {
 import type { AbstractGraph } from '../AbstractGraph';
 import CellState from '../cell/CellState';
 import Shape from '../shape/Shape';
-import type { CellHandle, ColorValue, Listenable, MouseListenerSet } from '../../types';
+import type {
+  CellHandle,
+  ColorValue,
+  EventListenerFunction,
+  MouseListenerSet,
+} from '../../types';
 import InternalMouseEvent from '../event/InternalMouseEvent';
 import Cell from '../cell/Cell';
 import ImageBox from '../image/ImageBox';
@@ -62,7 +67,6 @@ import EventSource from '../event/EventSource';
 import type SelectionHandler from '../plugins/SelectionHandler';
 import { equalPoints } from '../../util/arrayUtils';
 import { EdgeHandlerConfig, HandleConfig } from './config';
-import EventObject from '../event/EventObject';
 
 /**
  * Graph event handler that reconnects edges, modifies control points and the edge label location.
@@ -194,8 +198,7 @@ class EdgeHandler implements MouseListenerSet {
    */
   manageLabelHandle = false;
 
-  // TODO use EventListenerFunction type instead
-  escapeHandler: (sender: Listenable, eventObject: EventObject) => void;
+  escapeHandler: EventListenerFunction;
 
   currentPoint: Point | null = null;
 

--- a/packages/core/src/view/handler/KeyHandler.ts
+++ b/packages/core/src/view/handler/KeyHandler.ts
@@ -108,7 +108,7 @@ class KeyHandler {
   /**
    * Maps from keycodes to functions for non-pressed control keys.
    */
-  normalKeys: { [key: number]: Function } = {};
+  normalKeys: { [key: number]: () => void } = {};
 
   /**
    * Maps from keycodes to functions for pressed shift keys.
@@ -154,7 +154,7 @@ class KeyHandler {
    * @param code Integer that specifies the keycode.
    * @param funct JavaScript function that takes the key event as an argument.
    */
-  bindKey(code: number, funct: Function) {
+  bindKey(code: number, funct: () => void) {
     this.normalKeys[code] = funct;
   }
 
@@ -165,7 +165,7 @@ class KeyHandler {
    * @param code Integer that specifies the keycode.
    * @param funct JavaScript function that takes the key event as an argument.
    */
-  bindShiftKey(code: number, funct: Function) {
+  bindShiftKey(code: number, funct: () => void) {
     this.shiftKeys[code] = funct;
   }
 
@@ -206,7 +206,7 @@ class KeyHandler {
    *
    * @param evt Key event whose associated function should be returned.
    */
-  getFunction(evt: KeyboardEvent) {
+  getFunction(evt: KeyboardEvent): () => void {
     if (evt != null && !isAltDown(evt)) {
       if (this.isControlDown(evt)) {
         if (isShiftDown(evt)) {

--- a/packages/core/src/view/handler/KeyHandler.ts
+++ b/packages/core/src/view/handler/KeyHandler.ts
@@ -108,22 +108,22 @@ class KeyHandler {
   /**
    * Maps from keycodes to functions for non-pressed control keys.
    */
-  normalKeys: { [key: number]: () => void } = {};
+  normalKeys: { [key: number]: (evt: KeyboardEvent) => void } = {};
 
   /**
    * Maps from keycodes to functions for pressed shift keys.
    */
-  shiftKeys: { [key: number]: Function } = {};
+  shiftKeys: { [key: number]: (evt: KeyboardEvent) => void } = {};
 
   /**
    * Maps from keycodes to functions for pressed control keys.
    */
-  controlKeys: { [key: number]: Function } = {};
+  controlKeys: { [key: number]: (evt: KeyboardEvent) => void } = {};
 
   /**
    * Maps from keycodes to functions for pressed control and shift keys.
    */
-  controlShiftKeys: { [key: number]: Function } = {};
+  controlShiftKeys: { [key: number]: (evt: KeyboardEvent) => void } = {};
 
   /**
    * Specifies if events are handled. Default is true.
@@ -154,7 +154,7 @@ class KeyHandler {
    * @param code Integer that specifies the keycode.
    * @param funct JavaScript function that takes the key event as an argument.
    */
-  bindKey(code: number, funct: () => void) {
+  bindKey(code: number, funct: (evt: KeyboardEvent) => void) {
     this.normalKeys[code] = funct;
   }
 
@@ -165,7 +165,7 @@ class KeyHandler {
    * @param code Integer that specifies the keycode.
    * @param funct JavaScript function that takes the key event as an argument.
    */
-  bindShiftKey(code: number, funct: () => void) {
+  bindShiftKey(code: number, funct: (evt: KeyboardEvent) => void) {
     this.shiftKeys[code] = funct;
   }
 
@@ -176,7 +176,7 @@ class KeyHandler {
    * @param code Integer that specifies the keycode.
    * @param funct JavaScript function that takes the key event as an argument.
    */
-  bindControlKey(code: number, funct: Function) {
+  bindControlKey(code: number, funct: (evt: KeyboardEvent) => void) {
     this.controlKeys[code] = funct;
   }
 
@@ -187,7 +187,7 @@ class KeyHandler {
    * @param code Integer that specifies the keycode.
    * @param funct JavaScript function that takes the key event as an argument.
    */
-  bindControlShiftKey(code: number, funct: Function) {
+  bindControlShiftKey(code: number, funct: (evt: KeyboardEvent) => void) {
     this.controlShiftKeys[code] = funct;
   }
 
@@ -206,7 +206,7 @@ class KeyHandler {
    *
    * @param evt Key event whose associated function should be returned.
    */
-  getFunction(evt: KeyboardEvent): () => void {
+  getFunction(evt: KeyboardEvent): ((evt: KeyboardEvent) => void) | null {
     if (evt != null && !isAltDown(evt)) {
       if (this.isControlDown(evt)) {
         if (isShiftDown(evt)) {

--- a/packages/core/src/view/handler/VertexHandler.ts
+++ b/packages/core/src/view/handler/VertexHandler.ts
@@ -47,6 +47,7 @@ import { HandleConfig, VertexHandlerConfig } from './config';
  * Some elements of this handler and its subclasses can be configured using {@link EdgeHandlerConfig}.
  */
 class VertexHandler implements MouseListenerSet {
+  // TODO use EventListenerFunction type instead
   escapeHandler: (sender: Listenable, evt: Event) => void;
   selectionBounds: Rectangle;
   bounds: Rectangle;
@@ -319,7 +320,7 @@ class VertexHandler implements MouseListenerSet {
     }
 
     // Handles escape keystrokes
-    this.escapeHandler = (_sender: Listenable, _evt: Event) => {
+    this.escapeHandler = () => {
       if (this.livePreview && this.index != null) {
         // Redraws the live preview
         this.state.view.graph.cellRenderer.redraw(this.state, true);

--- a/packages/core/src/view/handler/VertexHandler.ts
+++ b/packages/core/src/view/handler/VertexHandler.ts
@@ -30,11 +30,11 @@ import type { AbstractGraph } from '../AbstractGraph';
 import CellState from '../cell/CellState';
 import Image from '../image/ImageBox';
 import type Cell from '../cell/Cell';
-import type { CellHandle, Listenable, MouseListenerSet } from '../../types';
+import type { CellHandle, EventListenerFunction, MouseListenerSet } from '../../types';
 import Shape from '../shape/Shape';
 import InternalMouseEvent from '../event/InternalMouseEvent';
 import EdgeHandler from './EdgeHandler';
-import EventSource from '../event/EventSource';
+import type EventSource from '../event/EventSource';
 import type SelectionHandler from '../plugins/SelectionHandler';
 import type SelectionCellsHandler from '../plugins/SelectionCellsHandler';
 import { HandleConfig, VertexHandlerConfig } from './config';
@@ -47,8 +47,7 @@ import { HandleConfig, VertexHandlerConfig } from './config';
  * Some elements of this handler and its subclasses can be configured using {@link EdgeHandlerConfig}.
  */
 class VertexHandler implements MouseListenerSet {
-  // TODO use EventListenerFunction type instead
-  escapeHandler: (sender: Listenable, evt: Event) => void;
+  escapeHandler: EventListenerFunction;
   selectionBounds: Rectangle;
   bounds: Rectangle;
   selectionBorder: RectangleShape;

--- a/packages/core/src/view/layout/SwimlaneManager.ts
+++ b/packages/core/src/view/layout/SwimlaneManager.ts
@@ -20,7 +20,6 @@ import EventSource from '../event/EventSource';
 import InternalEvent from '../event/InternalEvent';
 import Rectangle from '../geometry/Rectangle';
 import type { AbstractGraph } from '../AbstractGraph';
-import type EventObject from '../event/EventObject';
 import type Cell from '../cell/Cell';
 import type { EventListenerFunction } from '../../types';
 
@@ -45,13 +44,13 @@ class SwimlaneManager extends EventSource {
     this.addEnabled = addEnabled;
     this.resizeEnabled = resizeEnabled;
 
-    this.addHandler = (_sender: EventTarget, evt: EventObject) => {
+    this.addHandler = (_sender, evt) => {
       if (this.isEnabled() && this.isAddEnabled()) {
         this.cellsAdded(evt.getProperty('cells'));
       }
     };
 
-    this.resizeHandler = (_sender: EventTarget, evt: EventObject) => {
+    this.resizeHandler = (_sender, evt) => {
       if (this.isEnabled() && this.isResizeEnabled()) {
         this.cellsResized(evt.getProperty('cells'));
       }

--- a/packages/core/src/view/layout/SwimlaneManager.ts
+++ b/packages/core/src/view/layout/SwimlaneManager.ts
@@ -20,8 +20,9 @@ import EventSource from '../event/EventSource';
 import InternalEvent from '../event/InternalEvent';
 import Rectangle from '../geometry/Rectangle';
 import type { AbstractGraph } from '../AbstractGraph';
-import EventObject from '../event/EventObject';
+import type EventObject from '../event/EventObject';
 import type Cell from '../cell/Cell';
+import type { EventListenerFunction } from '../../types';
 
 /**
  * Manager for swimlanes and nested swimlanes that sets the size of newly added
@@ -44,13 +45,13 @@ class SwimlaneManager extends EventSource {
     this.addEnabled = addEnabled;
     this.resizeEnabled = resizeEnabled;
 
-    this.addHandler = (_sender: EventSource, evt: EventObject) => {
+    this.addHandler = (_sender: EventTarget, evt: EventObject) => {
       if (this.isEnabled() && this.isAddEnabled()) {
         this.cellsAdded(evt.getProperty('cells'));
       }
     };
 
-    this.resizeHandler = (_sender: EventSource, evt: EventObject) => {
+    this.resizeHandler = (_sender: EventTarget, evt: EventObject) => {
       if (this.isEnabled() && this.isResizeEnabled()) {
         this.cellsResized(evt.getProperty('cells'));
       }
@@ -92,14 +93,12 @@ class SwimlaneManager extends EventSource {
   /**
    * Holds the function that handles the move event.
    */
-  // TODO use EventListenerFunction type instead
-  addHandler: (sender: EventSource, evt: EventObject) => void;
+  addHandler: EventListenerFunction;
 
   /**
    * Holds the function that handles the move event.
    */
-  // TODO use EventListenerFunction type instead
-  resizeHandler: (sender: EventSource, evt: EventObject) => void;
+  resizeHandler: EventListenerFunction;
 
   /**
    * Returns true if events are handled. This implementation

--- a/packages/core/src/view/layout/SwimlaneManager.ts
+++ b/packages/core/src/view/layout/SwimlaneManager.ts
@@ -44,13 +44,13 @@ class SwimlaneManager extends EventSource {
     this.addEnabled = addEnabled;
     this.resizeEnabled = resizeEnabled;
 
-    this.addHandler = (sender: EventSource, evt: EventObject) => {
+    this.addHandler = (_sender: EventSource, evt: EventObject) => {
       if (this.isEnabled() && this.isAddEnabled()) {
         this.cellsAdded(evt.getProperty('cells'));
       }
     };
 
-    this.resizeHandler = (sender: EventSource, evt: EventObject) => {
+    this.resizeHandler = (_sender: EventSource, evt: EventObject) => {
       if (this.isEnabled() && this.isResizeEnabled()) {
         this.cellsResized(evt.getProperty('cells'));
       }
@@ -92,11 +92,13 @@ class SwimlaneManager extends EventSource {
   /**
    * Holds the function that handles the move event.
    */
+  // TODO use EventListenerFunction type instead
   addHandler: (sender: EventSource, evt: EventObject) => void;
 
   /**
    * Holds the function that handles the move event.
    */
+  // TODO use EventListenerFunction type instead
   resizeHandler: (sender: EventSource, evt: EventObject) => void;
 
   /**

--- a/packages/core/src/view/layout/hierarchical/GraphHierarchyModel.ts
+++ b/packages/core/src/view/layout/hierarchical/GraphHierarchyModel.ts
@@ -413,12 +413,15 @@ class GraphHierarchyModel {
 
     this.visit(
       (
-        parent: GraphHierarchyNode,
-        node: GraphHierarchyNode,
-        edge: GraphHierarchyNode,
+        parent: GraphHierarchyNode | null,
+        node: GraphHierarchyNode | null,
+        edge: GraphHierarchyEdge | null,
         layer: number,
         seen: number
       ) => {
+        if (!node) {
+          return;
+        }
         if (seen == 0 && node.maxRank < 0 && node.minRank < 0) {
           rankList[node.temp[0]].push(node);
           node.maxRank = node.temp[0];
@@ -455,14 +458,20 @@ class GraphHierarchyModel {
   }
 
   /**
-   * A depth first search through the internal heirarchy model.
+   * A depth first search through the internal hierarchy model.
    *
    * @param visitor The visitor function pattern to be called for each node.
    * @param trackAncestors Whether or not the search is to keep track all nodes
    * directly above this one in the search path.
    */
   visit(
-    visitor: Function,
+    visitor: (
+      parent: GraphHierarchyNode | null,
+      node: GraphHierarchyNode | null,
+      edge: GraphHierarchyEdge | null,
+      layer: number,
+      seen: number
+    ) => void,
     dfsRoots: GraphHierarchyNode[] | null,
     trackAncestors: boolean,
     seenNodes: { [key: string]: GraphHierarchyNode } | null = null
@@ -518,7 +527,13 @@ class GraphHierarchyModel {
     parent: GraphHierarchyNode | null,
     root: GraphHierarchyNode | null,
     connectingEdge: GraphHierarchyEdge | null,
-    visitor: Function,
+    visitor: (
+      parent: GraphHierarchyNode | null,
+      node: GraphHierarchyNode | null,
+      edge: GraphHierarchyEdge | null,
+      layer: number,
+      seen: number
+    ) => void,
     seen: { [key: string]: GraphHierarchyNode | null },
     layer: number
   ): void {
@@ -567,7 +582,13 @@ class GraphHierarchyModel {
     parent: GraphHierarchyNode | null,
     root: GraphHierarchyNode,
     connectingEdge: GraphHierarchyEdge | null,
-    visitor: Function,
+    visitor: (
+      parent: GraphHierarchyNode | null,
+      node: GraphHierarchyNode | null,
+      edge: GraphHierarchyEdge | null,
+      layer: number,
+      seen: number
+    ) => void,
     seen: { [key: string]: GraphHierarchyNode },
     ancestors: any,
     childHash: string | number,

--- a/packages/core/src/view/layout/hierarchical/GraphHierarchyModel.ts
+++ b/packages/core/src/view/layout/hierarchical/GraphHierarchyModel.ts
@@ -414,14 +414,11 @@ class GraphHierarchyModel {
     this.visit(
       (
         parent: GraphHierarchyNode | null,
-        node: GraphHierarchyNode | null,
+        node: GraphHierarchyNode,
         edge: GraphHierarchyEdge | null,
         layer: number,
         seen: number
       ) => {
-        if (!node) {
-          return;
-        }
         if (seen == 0 && node.maxRank < 0 && node.minRank < 0) {
           rankList[node.temp[0]].push(node);
           node.maxRank = node.temp[0];

--- a/packages/core/src/view/layout/hierarchical/GraphHierarchyModel.ts
+++ b/packages/core/src/view/layout/hierarchical/GraphHierarchyModel.ts
@@ -467,7 +467,7 @@ class GraphHierarchyModel {
   visit(
     visitor: (
       parent: GraphHierarchyNode | null,
-      node: GraphHierarchyNode | null,
+      node: GraphHierarchyNode,
       edge: GraphHierarchyEdge | null,
       layer: number,
       seen: number
@@ -529,7 +529,7 @@ class GraphHierarchyModel {
     connectingEdge: GraphHierarchyEdge | null,
     visitor: (
       parent: GraphHierarchyNode | null,
-      node: GraphHierarchyNode | null,
+      node: GraphHierarchyNode,
       edge: GraphHierarchyEdge | null,
       layer: number,
       seen: number
@@ -584,7 +584,7 @@ class GraphHierarchyModel {
     connectingEdge: GraphHierarchyEdge | null,
     visitor: (
       parent: GraphHierarchyNode | null,
-      node: GraphHierarchyNode | null,
+      node: GraphHierarchyNode,
       edge: GraphHierarchyEdge | null,
       layer: number,
       seen: number

--- a/packages/core/src/view/layout/hierarchical/GraphHierarchyModel.ts
+++ b/packages/core/src/view/layout/hierarchical/GraphHierarchyModel.ts
@@ -577,7 +577,7 @@ class GraphHierarchyModel {
    */
   extendedDfs(
     parent: GraphHierarchyNode | null,
-    root: GraphHierarchyNode,
+    root: GraphHierarchyNode | null,
     connectingEdge: GraphHierarchyEdge | null,
     visitor: (
       parent: GraphHierarchyNode | null,

--- a/packages/core/src/view/layout/hierarchical/MinimumCycleRemover.ts
+++ b/packages/core/src/view/layout/hierarchical/MinimumCycleRemover.ts
@@ -111,8 +111,8 @@ class MinimumCycleRemover extends HierarchicalLayoutStage {
         parent: GraphHierarchyNode | null,
         node: GraphHierarchyNode,
         connectingEdge: GraphHierarchyEdge | null,
-        layer: any,
-        seen: any
+        layer: number,
+        seen: number
       ) => {
         // Check if the cell is in it's own ancestor list, if so
         // invert the connecting edge and reverse the target/source

--- a/packages/core/src/view/layout/hierarchical/MinimumCycleRemover.ts
+++ b/packages/core/src/view/layout/hierarchical/MinimumCycleRemover.ts
@@ -75,16 +75,16 @@ class MinimumCycleRemover extends HierarchicalLayoutStage {
 
     model.visit(
       (
-        parent: GraphHierarchyNode,
+        parent: GraphHierarchyNode | null,
         node: GraphHierarchyNode,
-        connectingEdge: GraphHierarchyEdge,
-        layer: any,
-        seen: any
+        connectingEdge: GraphHierarchyEdge | null,
+        layer: number,
+        seen: number
       ) => {
         // Check if the cell is in it's own ancestor list, if so
         // invert the connecting edge and reverse the target/source
         // relationship to that edge in the parent and the cell
-        if (node.isAncestor(parent)) {
+        if (parent && connectingEdge && node.isAncestor(parent)) {
           connectingEdge.invert();
           remove(connectingEdge, parent.connectsAsSource);
           parent.connectsAsTarget.push(connectingEdge);
@@ -108,16 +108,16 @@ class MinimumCycleRemover extends HierarchicalLayoutStage {
     // Pick a random cell and dfs from it
     model.visit(
       (
-        parent: GraphHierarchyNode,
+        parent: GraphHierarchyNode | null,
         node: GraphHierarchyNode,
-        connectingEdge: GraphHierarchyEdge,
+        connectingEdge: GraphHierarchyEdge | null,
         layer: any,
         seen: any
       ) => {
         // Check if the cell is in it's own ancestor list, if so
         // invert the connecting edge and reverse the target/source
         // relationship to that edge in the parent and the cell
-        if (node.isAncestor(parent)) {
+        if (parent && connectingEdge && node.isAncestor(parent)) {
           connectingEdge.invert();
           remove(connectingEdge, parent.connectsAsSource);
           node.connectsAsSource.push(connectingEdge);

--- a/packages/core/src/view/layout/hierarchical/SwimlaneModel.ts
+++ b/packages/core/src/view/layout/hierarchical/SwimlaneModel.ts
@@ -558,7 +558,13 @@ class SwimlaneModel {
    * directly above this one in the search path.
    */
   visit(
-    visitor: Function,
+    visitor: (
+      parent: Cell | null,
+      root: GraphHierarchyNode,
+      connectingEdge: Cell | null,
+      layer: number,
+      seen: number
+    ) => void,
     dfsRoots: GraphHierarchyNode[] | null,
     trackAncestors: boolean,
     seenNodes: { [key: string]: Cell } | null
@@ -614,7 +620,13 @@ class SwimlaneModel {
     parent: Cell | null,
     root: GraphHierarchyNode,
     connectingEdge: Cell | null,
-    visitor: Function,
+    visitor: (
+      parent: Cell | null,
+      root: GraphHierarchyNode,
+      connectingEdge: Cell | null,
+      layer: number,
+      seen: number
+    ) => void,
     seen: { [key: string]: Cell },
     layer: number
   ) {
@@ -663,7 +675,13 @@ class SwimlaneModel {
     parent: GraphHierarchyNode | null,
     root: GraphHierarchyNode,
     connectingEdge: Cell | null,
-    visitor: Function,
+    visitor: (
+      parent: Cell | null,
+      root: GraphHierarchyNode,
+      connectingEdge: Cell | null,
+      layer: number,
+      seen: number
+    ) => void,
     seen: { [key: string]: Cell },
     ancestors: any,
     childHash: string | number,

--- a/packages/core/src/view/layout/hierarchical/SwimlaneModel.ts
+++ b/packages/core/src/view/layout/hierarchical/SwimlaneModel.ts
@@ -23,6 +23,7 @@ import Dictionary from '../../../util/Dictionary';
 import Cell from '../../cell/Cell';
 import { clone } from '../../../util/cloneUtils';
 import SwimlaneLayout from '../SwimlaneLayout';
+import GraphAbstractHierarchyCell from '../datatypes/GraphAbstractHierarchyCell';
 
 /**
  * Internal model of a hierarchical graph. This model stores nodes and edges
@@ -137,7 +138,7 @@ class SwimlaneModel {
   /**
    * Mapping from rank number to actual rank
    */
-  ranks: GraphHierarchyNode[][] = [];
+  ranks: GraphAbstractHierarchyCell[][] = [];
 
   /**
    * Store of roots of this hierarchy model, these are real graph cells, not
@@ -483,7 +484,7 @@ class SwimlaneModel {
    * to create dummy nodes for edges that cross layers.
    */
   fixRanks(): void {
-    const rankList: GraphHierarchyNode[][] = [];
+    const rankList: GraphAbstractHierarchyCell[][] = [];
     this.ranks = [];
 
     for (let i = 0; i < this.maxRank + 1; i += 1) {
@@ -509,9 +510,9 @@ class SwimlaneModel {
 
     this.visit(
       (
-        parent: GraphHierarchyNode,
+        parent: GraphHierarchyNode | null,
         node: GraphHierarchyNode,
-        edge: GraphHierarchyNode,
+        edge: GraphHierarchyEdge | null,
         layer: number,
         seen: number
       ) => {
@@ -559,9 +560,9 @@ class SwimlaneModel {
    */
   visit(
     visitor: (
-      parent: Cell | null,
+      parent: GraphHierarchyNode | null,
       root: GraphHierarchyNode,
-      connectingEdge: Cell | null,
+      connectingEdge: GraphHierarchyEdge | null,
       layer: number,
       seen: number
     ) => void,
@@ -617,13 +618,13 @@ class SwimlaneModel {
    * @param layer the layer on the dfs tree ( not the same as the model ranks )
    */
   dfs(
-    parent: Cell | null,
+    parent: GraphHierarchyNode | null,
     root: GraphHierarchyNode,
-    connectingEdge: Cell | null,
+    connectingEdge: GraphHierarchyEdge | null,
     visitor: (
-      parent: Cell | null,
+      parent: GraphHierarchyNode | null,
       root: GraphHierarchyNode,
-      connectingEdge: Cell | null,
+      connectingEdge: GraphHierarchyEdge | null,
       layer: number,
       seen: number
     ) => void,
@@ -674,11 +675,11 @@ class SwimlaneModel {
   extendedDfs(
     parent: GraphHierarchyNode | null,
     root: GraphHierarchyNode,
-    connectingEdge: Cell | null,
+    connectingEdge: GraphHierarchyEdge | null,
     visitor: (
-      parent: Cell | null,
+      parent: GraphHierarchyNode | null,
       root: GraphHierarchyNode,
-      connectingEdge: Cell | null,
+      connectingEdge: GraphHierarchyEdge | null,
       layer: number,
       seen: number
     ) => void,

--- a/packages/core/src/view/layout/hierarchical/SwimlaneModel.ts
+++ b/packages/core/src/view/layout/hierarchical/SwimlaneModel.ts
@@ -18,12 +18,12 @@ limitations under the License.
 
 import GraphHierarchyNode from '../datatypes/GraphHierarchyNode';
 import GraphHierarchyEdge from '../datatypes/GraphHierarchyEdge';
+import GraphAbstractHierarchyCell from '../datatypes/GraphAbstractHierarchyCell';
 import CellPath from '../../cell/CellPath';
 import Dictionary from '../../../util/Dictionary';
 import Cell from '../../cell/Cell';
 import { clone } from '../../../util/cloneUtils';
 import SwimlaneLayout from '../SwimlaneLayout';
-import GraphAbstractHierarchyCell from '../datatypes/GraphAbstractHierarchyCell';
 
 /**
  * Internal model of a hierarchical graph. This model stores nodes and edges

--- a/packages/core/src/view/layout/hierarchical/SwimlaneOrdering.ts
+++ b/packages/core/src/view/layout/hierarchical/SwimlaneOrdering.ts
@@ -95,7 +95,7 @@ class SwimlaneOrdering extends HierarchicalLayoutStage {
           <number>parent.swimlaneIndex < <number>node.swimlaneIndex &&
           connectingEdge.source === node;
 
-        if (isAncestor && connectingEdge != null) {
+        if (isAncestor && connectingEdge) {
           connectingEdge.invert();
           remove(connectingEdge, parent.connectsAsSource);
           node.connectsAsSource.push(connectingEdge);

--- a/packages/core/src/view/layout/hierarchical/SwimlaneOrdering.ts
+++ b/packages/core/src/view/layout/hierarchical/SwimlaneOrdering.ts
@@ -72,11 +72,11 @@ class SwimlaneOrdering extends HierarchicalLayoutStage {
 
     model.visit(
       (
-        parent: GraphHierarchyNode,
+        parent: GraphHierarchyNode | null,
         node: GraphHierarchyNode,
-        connectingEdge: GraphHierarchyEdge,
-        layer: any,
-        seen: any
+        connectingEdge: GraphHierarchyEdge | null,
+        layer: number,
+        seen: number
       ) => {
         // Check if the cell is in it's own ancestor list, if so
         // invert the connecting edge and reverse the target/source
@@ -95,7 +95,7 @@ class SwimlaneOrdering extends HierarchicalLayoutStage {
           <number>parent.swimlaneIndex < <number>node.swimlaneIndex &&
           connectingEdge.source === node;
 
-        if (isAncestor) {
+        if (isAncestor && connectingEdge != null) {
           connectingEdge.invert();
           remove(connectingEdge, parent.connectsAsSource);
           node.connectsAsSource.push(connectingEdge);

--- a/packages/core/src/view/layout/types.ts
+++ b/packages/core/src/view/layout/types.ts
@@ -24,7 +24,7 @@ import type GraphHierarchyNode from './datatypes/GraphHierarchyNode';
 export interface GraphLayoutTraverseArgs {
   vertex: Cell | null;
   directed: boolean | null;
-  func: Function | null;
+  func: ((vertex: Cell, edge: Cell | null) => void) | null;
   edge: Cell | null;
   visited: Dictionary<Cell, boolean> | null;
 }

--- a/packages/core/src/view/mixins/CellsMixin.type.ts
+++ b/packages/core/src/view/mixins/CellsMixin.type.ts
@@ -653,7 +653,7 @@ declare module '../AbstractGraph' {
      *
      * @param x X-coordinate of the location to be checked.
      * @param y Y-coordinate of the location to be checked.
-     * @param parent {@link mxCell} that should be used as the root of the recursion. Default is current root of the view or the root of the model.
+     * @param parent {@link Cell} that should be used as the root of the recursion. Default is current root of the view or the root of the model.
      * @param vertices Optional boolean indicating if vertices should be returned. Default is `true`.
      * @param edges Optional boolean indicating if edges should be returned. Default is `true`.
      * @param ignoreFn Optional function that returns true if cell should be ignored. The function is passed the cell state and the x and y parameter. Default is `null`.
@@ -664,7 +664,7 @@ declare module '../AbstractGraph' {
       parent?: Cell | null,
       vertices?: boolean | null,
       edges?: boolean | null,
-      ignoreFn?: Function | null
+      ignoreFn?: ((state: CellState, x: number, y: number) => boolean) | null
     ) => Cell | null;
 
     /**
@@ -677,7 +677,7 @@ declare module '../AbstractGraph' {
      * @param y Y-coordinate of the rectangle.
      * @param width Width of the rectangle.
      * @param height Height of the rectangle.
-     * @param parent {@link mxCell} that should be used as the root of the recursion. Default is current root of the view or the root of the model.
+     * @param parent {@link Cell} that should be used as the root of the recursion. Default is current root of the view or the root of the model.
      * @param result Optional array to store the result in. Default is an empty Array.
      * @param intersection Default is `null`.
      * @param ignoreFn Default is `null`.
@@ -691,7 +691,7 @@ declare module '../AbstractGraph' {
       parent?: Cell | null,
       result?: Cell[],
       intersection?: Rectangle | null,
-      ignoreFn?: Function | null,
+      ignoreFn?: ((state: CellState) => boolean) | null,
       includeDescendants?: boolean
     ) => Cell[];
 

--- a/packages/core/src/view/mixins/OverlaysMixin.ts
+++ b/packages/core/src/view/mixins/OverlaysMixin.ts
@@ -17,7 +17,6 @@ limitations under the License.
 import CellOverlay from '../cell/CellOverlay';
 import EventObject from '../event/EventObject';
 import InternalEvent from '../event/InternalEvent';
-import type InternalMouseEvent from '../event/InternalMouseEvent';
 import type { AbstractGraph } from '../AbstractGraph';
 
 type PartialGraph = Pick<

--- a/packages/core/src/view/mixins/OverlaysMixin.ts
+++ b/packages/core/src/view/mixins/OverlaysMixin.ts
@@ -138,14 +138,11 @@ export const OverlaysMixin: PartialType = {
 
       // Adds a handler for single mouseclicks to select the cell
       if (isSelect) {
-        overlay.addListener(
-          InternalEvent.CLICK,
-          (sender: any, evt: InternalMouseEvent) => {
-            if (this.isEnabled()) {
-              this.setSelectionCell(cell);
-            }
+        overlay.addListener(InternalEvent.CLICK, () => {
+          if (this.isEnabled()) {
+            this.setSelectionCell(cell);
           }
-        );
+        });
       }
 
       // Sets and returns the overlay in the graph

--- a/packages/core/src/view/mixins/SelectionMixin.type.ts
+++ b/packages/core/src/view/mixins/SelectionMixin.type.ts
@@ -216,7 +216,10 @@ declare module '../AbstractGraph' {
      * @param changes
      * @param ignoreFn Optional function that takes a change and returns true if the change should be ignored.
      */
-    getSelectionCellsForChanges: (changes: any[], ignoreFn?: Function | null) => Cell[];
+    getSelectionCellsForChanges: (
+      changes: any[],
+      ignoreFn?: (change: any) => void | null
+    ) => Cell[];
 
     /**
      * Removes selection cells that are not in the model from the selection.

--- a/packages/core/src/view/mixins/SelectionMixin.type.ts
+++ b/packages/core/src/view/mixins/SelectionMixin.type.ts
@@ -218,7 +218,7 @@ declare module '../AbstractGraph' {
      */
     getSelectionCellsForChanges: (
       changes: any[],
-      ignoreFn?: (change: any) => void | null
+      ignoreFn?: ((change: any) => void) | null
     ) => Cell[];
 
     /**

--- a/packages/core/src/view/mixins/SelectionMixin.type.ts
+++ b/packages/core/src/view/mixins/SelectionMixin.type.ts
@@ -218,7 +218,7 @@ declare module '../AbstractGraph' {
      */
     getSelectionCellsForChanges: (
       changes: any[],
-      ignoreFn?: ((change: any) => void) | null
+      ignoreFn?: ((change: any) => boolean) | null
     ) => Cell[];
 
     /**

--- a/packages/core/src/view/other/AutoSaveManager.ts
+++ b/packages/core/src/view/other/AutoSaveManager.ts
@@ -92,7 +92,7 @@ class AutoSaveManager extends EventSource {
   /**
    * Holds the function that handles graph model changes.
    */
-  changeHandler: Function;
+  changeHandler: (sender: any, evt: any) => void;
 
   /**
    * Returns true if events are handled. This implementation
@@ -103,10 +103,9 @@ class AutoSaveManager extends EventSource {
   }
 
   /**
-   * Enables or disables event handling. This implementation
-   * updates <enabled>.
+   * Enables or disables event handling. This implementation updates {@link enabled}.
    *
-   * @param enabled - Boolean that specifies the new enabled state.
+   * @param value - Boolean that specifies the new enabled state.
    */
   setEnabled(value: boolean): void {
     this.enabled = value;

--- a/packages/core/src/view/other/DragSource.ts
+++ b/packages/core/src/view/other/DragSource.ts
@@ -93,7 +93,7 @@ class DragSource {
    */
   dropHandler: DropHandler;
 
-  eventConsumer: (sender: EventSource, evt: EventObject) => void;
+  eventConsumer: (sender: EventSource, eventObject: EventObject) => void;
 
   /**
    * {@link Point} that specifies the offset of the {@link dragElement}. Default is null.

--- a/packages/core/src/view/other/DragSource.ts
+++ b/packages/core/src/view/other/DragSource.ts
@@ -72,7 +72,7 @@ class DragSource {
       InternalEvent.consume(evt);
     });
 
-    this.eventConsumer = (sender: EventSource, evt: EventObject) => {
+    this.eventConsumer = (_sender: EventSource, evt: EventObject) => {
       const evtName = evt.getProperty('eventName');
       const me = evt.getProperty('event');
 

--- a/packages/core/src/view/other/DragSource.ts
+++ b/packages/core/src/view/other/DragSource.ts
@@ -233,9 +233,9 @@ class DragSource {
 
   /**
    * Returns the graph for the given mouse event. This implementation returns
-   * null.
+   * `null`.
    */
-  getGraphForEvent(evt: MouseEvent) {
+  getGraphForEvent(evt: MouseEvent): Graph | null {
     return null;
   }
 

--- a/packages/core/src/view/other/DragSource.ts
+++ b/packages/core/src/view/other/DragSource.ts
@@ -235,7 +235,7 @@ class DragSource {
    * Returns the graph for the given mouse event. This implementation returns
    * `null`.
    */
-  getGraphForEvent(evt: MouseEvent): Graph | null {
+  getGraphForEvent(evt: MouseEvent): AbstractGraph | null {
     return null;
   }
 

--- a/packages/core/src/view/other/DragSource.ts
+++ b/packages/core/src/view/other/DragSource.ts
@@ -93,6 +93,7 @@ class DragSource {
    */
   dropHandler: DropHandler;
 
+  // TODO use EventListenerFunction type instead
   eventConsumer: (sender: EventSource, eventObject: EventObject) => void;
 
   /**

--- a/packages/core/src/view/other/DragSource.ts
+++ b/packages/core/src/view/other/DragSource.ts
@@ -38,11 +38,10 @@ import {
   isPenEvent,
   isTouchEvent,
 } from '../../util/EventUtils';
-import EventSource from '../event/EventSource';
-import EventObject from '../event/EventObject';
 import type { AbstractGraph } from '../AbstractGraph';
 import type Cell from '../cell/Cell';
 import type SelectionHandler from '../plugins/SelectionHandler';
+import type { EventListenerFunction } from '../../types';
 
 export type DropHandler = (
   graph: AbstractGraph,
@@ -72,7 +71,7 @@ class DragSource {
       InternalEvent.consume(evt);
     });
 
-    this.eventConsumer = (_sender: EventSource, evt: EventObject) => {
+    this.eventConsumer = (_sender, evt) => {
       const evtName = evt.getProperty('eventName');
       const me = evt.getProperty('event');
 
@@ -93,8 +92,7 @@ class DragSource {
    */
   dropHandler: DropHandler;
 
-  // TODO use EventListenerFunction type instead
-  eventConsumer: (sender: EventSource, eventObject: EventObject) => void;
+  eventConsumer: EventListenerFunction;
 
   /**
    * {@link Point} that specifies the offset of the {@link dragElement}. Default is null.

--- a/packages/core/src/view/other/Outline.ts
+++ b/packages/core/src/view/other/Outline.ts
@@ -36,7 +36,7 @@ import EventObject from '../event/EventObject';
 import { getSource, isMouseEvent } from '../../util/EventUtils';
 import EventSource from '../event/EventSource';
 import { hasScrollbars } from '../../util/styleUtils';
-import type { Listenable, MouseListenerSet } from '../../types';
+import type { EventListenerFunction, Listenable, MouseListenerSet } from '../../types';
 import { getDefaultPlugins } from '../plugins';
 
 /**
@@ -101,7 +101,7 @@ class Outline implements MouseListenerSet {
     this.outline.labelsVisible = this.labelsVisible;
     this.outline.setEnabled(false);
 
-    this.updateHandler = (sender: any, evt: EventObject) => {
+    this.updateHandler = () => {
       if (!this.suspended && !this.active) {
         this.update();
       }
@@ -123,7 +123,7 @@ class Outline implements MouseListenerSet {
     // @ts-ignore because sender and evt don't seem used
     InternalEvent.addListener(this.source.container, 'scroll', this.updateHandler);
 
-    this.panHandler = (sender: any, evt: EventObject) => {
+    this.panHandler = (sender: EventTarget, evt: EventObject) => {
       if (this.updateOnPan) {
         this.updateHandler?.(sender, evt);
       }
@@ -131,7 +131,7 @@ class Outline implements MouseListenerSet {
     this.source.addListener(InternalEvent.PAN, this.panHandler);
 
     // Refreshes the graph in the outline after a refresh of the main graph
-    this.refreshHandler = (sender: any) => {
+    this.refreshHandler = () => {
       const outline = this.outline;
       outline?.setStylesheet(this.source.getStylesheet());
       outline?.refresh();
@@ -199,11 +199,11 @@ class Outline implements MouseListenerSet {
 
   selectionBorder: RectangleShape | null = null;
 
-  updateHandler: ((sender: any, evt: EventObject) => void) | null = null;
+  updateHandler: EventListenerFunction | null = null;
 
-  refreshHandler: ((sender: any, evt: EventObject) => void) | null = null;
+  refreshHandler: EventListenerFunction | null = null;
 
-  panHandler: ((sender: any, evt: EventObject) => void) | null = null;
+  panHandler: EventListenerFunction | null = null;
 
   active: boolean | null = null;
 

--- a/packages/core/src/view/other/Outline.ts
+++ b/packages/core/src/view/other/Outline.ts
@@ -32,7 +32,6 @@ import { BaseGraph } from '../BaseGraph';
 import ImageShape from '../shape/node/ImageShape';
 import InternalEvent from '../event/InternalEvent';
 import Image from '../image/ImageBox';
-import EventObject from '../event/EventObject';
 import { getSource, isMouseEvent } from '../../util/EventUtils';
 import EventSource from '../event/EventSource';
 import { hasScrollbars } from '../../util/styleUtils';
@@ -123,7 +122,7 @@ class Outline implements MouseListenerSet {
     // @ts-ignore because sender and evt don't seem used
     InternalEvent.addListener(this.source.container, 'scroll', this.updateHandler);
 
-    this.panHandler = (sender: EventTarget, evt: EventObject) => {
+    this.panHandler = (sender, evt) => {
       if (this.updateOnPan) {
         this.updateHandler?.(sender, evt);
       }

--- a/packages/core/src/view/other/Outline.ts
+++ b/packages/core/src/view/other/Outline.ts
@@ -125,7 +125,7 @@ class Outline implements MouseListenerSet {
 
     this.panHandler = (sender: any, evt: EventObject) => {
       if (this.updateOnPan) {
-        (<Function>this.updateHandler)(sender, evt);
+        this.updateHandler?.(sender, evt);
       }
     };
     this.source.addListener(InternalEvent.PAN, this.panHandler);

--- a/packages/core/src/view/plugins/CellEditorHandler.ts
+++ b/packages/core/src/view/plugins/CellEditorHandler.ts
@@ -44,7 +44,7 @@ import {
   isMetaDown,
   isShiftDown,
 } from '../../util/EventUtils';
-import EventSource from '../event/EventSource';
+import EventSource, { EventListenerFunction } from '../event/EventSource';
 import { matchBinaryMask } from '../../internal/utils';
 import type { AbstractGraph } from '../AbstractGraph';
 import type { AlignValue, GraphPlugin } from '../../types';
@@ -159,7 +159,7 @@ class CellEditorHandler implements GraphPlugin {
     };
 
     // Handling of deleted cells while editing
-    this.changeHandler = (_sender: EventSource) => {
+    this.changeHandler = () => {
       if (this.editingCell && !this.graph.getView().getState(this.editingCell, false)) {
         this.stopEditing(true);
       }
@@ -171,7 +171,7 @@ class CellEditorHandler implements GraphPlugin {
   }
 
   // TODO: Document me!
-  changeHandler: (sender: EventSource) => void;
+  changeHandler: EventListenerFunction;
 
   zoomHandler: () => void;
 

--- a/packages/core/src/view/plugins/CellEditorHandler.ts
+++ b/packages/core/src/view/plugins/CellEditorHandler.ts
@@ -44,7 +44,6 @@ import {
   isMetaDown,
   isShiftDown,
 } from '../../util/EventUtils';
-import EventSource from '../event/EventSource';
 import { matchBinaryMask } from '../../internal/utils';
 import type { AbstractGraph } from '../AbstractGraph';
 import type { AlignValue, EventListenerFunction, GraphPlugin } from '../../types';

--- a/packages/core/src/view/plugins/CellEditorHandler.ts
+++ b/packages/core/src/view/plugins/CellEditorHandler.ts
@@ -44,10 +44,10 @@ import {
   isMetaDown,
   isShiftDown,
 } from '../../util/EventUtils';
-import EventSource, { EventListenerFunction } from '../event/EventSource';
+import EventSource from '../event/EventSource';
 import { matchBinaryMask } from '../../internal/utils';
 import type { AbstractGraph } from '../AbstractGraph';
-import type { AlignValue, GraphPlugin } from '../../types';
+import type { AlignValue, EventListenerFunction, GraphPlugin } from '../../types';
 import type TooltipHandler from './TooltipHandler';
 
 /**

--- a/packages/core/src/view/plugins/PanningHandler.ts
+++ b/packages/core/src/view/plugins/PanningHandler.ts
@@ -221,7 +221,9 @@ class PanningHandler extends EventSource implements GraphPlugin, MouseListenerSe
 
   active = false;
 
+  // TODO use EventListenerFunction type instead
   forcePanningHandler: (sender: EventSource, evt: EventObject) => void;
+  // TODO use EventListenerFunction type instead
   gestureHandler: (sender: EventSource, evt: EventObject) => void;
 
   mouseUpListener: MouseEventListener;

--- a/packages/core/src/view/plugins/PanningHandler.ts
+++ b/packages/core/src/view/plugins/PanningHandler.ts
@@ -31,7 +31,12 @@ import {
 import PanningManager from '../other/PanningManager';
 import InternalMouseEvent from '../event/InternalMouseEvent';
 
-import type { GraphPlugin, MouseEventListener, MouseListenerSet } from '../../types';
+import type {
+  EventListenerFunction,
+  GraphPlugin,
+  MouseEventListener,
+  MouseListenerSet,
+} from '../../types';
 import type { AbstractGraph } from '../AbstractGraph';
 
 /**
@@ -76,9 +81,9 @@ class PanningHandler extends EventSource implements GraphPlugin, MouseListenerSe
     this.graph.addMouseListener(this);
 
     // Handles force panning event
-    this.forcePanningHandler = (_sender: EventSource, eo: EventObject) => {
-      const evtName = eo.getProperty('eventName');
-      const me = eo.getProperty('event');
+    this.forcePanningHandler = (_sender, eventObject) => {
+      const evtName = eventObject.getProperty('eventName');
+      const me = eventObject.getProperty('event');
 
       if (evtName === InternalEvent.MOUSE_DOWN && this.isForcePanningEvent(me)) {
         this.start(me);
@@ -91,9 +96,9 @@ class PanningHandler extends EventSource implements GraphPlugin, MouseListenerSe
     this.graph.addListener(InternalEvent.FIRE_MOUSE_EVENT, this.forcePanningHandler);
 
     // Handles pinch gestures
-    this.gestureHandler = (_sender: EventSource, eo: EventObject) => {
+    this.gestureHandler = (_sender, eventObject) => {
       if (this.isPinchEnabled()) {
-        const evt = eo.getProperty('event');
+        const evt = eventObject.getProperty('event');
 
         if (!isConsumed(evt) && evt.type === 'gesturestart') {
           this.initialScale = this.graph.view.scale;
@@ -221,10 +226,8 @@ class PanningHandler extends EventSource implements GraphPlugin, MouseListenerSe
 
   active = false;
 
-  // TODO use EventListenerFunction type instead
-  forcePanningHandler: (sender: EventSource, evt: EventObject) => void;
-  // TODO use EventListenerFunction type instead
-  gestureHandler: (sender: EventSource, evt: EventObject) => void;
+  forcePanningHandler: EventListenerFunction;
+  gestureHandler: EventListenerFunction;
 
   mouseUpListener: MouseEventListener;
 

--- a/packages/core/src/view/plugins/PopupMenuHandler.ts
+++ b/packages/core/src/view/plugins/PopupMenuHandler.ts
@@ -44,7 +44,7 @@ class PopupMenuHandler extends MaxPopupMenu implements GraphPlugin, MouseListene
     this.graph.addMouseListener(this);
 
     // Does not show menu if any touch gestures take place after the trigger
-    this.gestureHandler = (sender: EventSource, eo: EventObject) => {
+    this.gestureHandler = (_sender: EventSource, _eventObject: EventObject) => {
       this.inTolerance = false;
     };
 
@@ -53,7 +53,7 @@ class PopupMenuHandler extends MaxPopupMenu implements GraphPlugin, MouseListene
     this.init();
   }
 
-  gestureHandler: (sender: EventSource, eo: EventObject) => void;
+  gestureHandler: (sender: EventSource, eventObject: EventObject) => void;
 
   inTolerance = false;
   popupTrigger = false;

--- a/packages/core/src/view/plugins/PopupMenuHandler.ts
+++ b/packages/core/src/view/plugins/PopupMenuHandler.ts
@@ -22,10 +22,9 @@ import { getScrollOrigin } from '../../util/styleUtils';
 import { getMainEvent, isMultiTouchEvent } from '../../util/EventUtils';
 import type { AbstractGraph } from '../AbstractGraph';
 import InternalMouseEvent from '../event/InternalMouseEvent';
-import type { GraphPlugin, MouseListenerSet } from '../../types';
+import type { EventListenerFunction, GraphPlugin, MouseListenerSet } from '../../types';
 import type TooltipHandler from './TooltipHandler';
-import EventSource from '../event/EventSource';
-import EventObject from '../event/EventObject';
+import type EventSource from '../event/EventSource';
 
 /**
  * Event handler that creates popupmenus.
@@ -44,7 +43,7 @@ class PopupMenuHandler extends MaxPopupMenu implements GraphPlugin, MouseListene
     this.graph.addMouseListener(this);
 
     // Does not show menu if any touch gestures take place after the trigger
-    this.gestureHandler = (_sender: EventSource, _eventObject: EventObject) => {
+    this.gestureHandler = (_sender, _eventObject) => {
       this.inTolerance = false;
     };
 
@@ -53,8 +52,7 @@ class PopupMenuHandler extends MaxPopupMenu implements GraphPlugin, MouseListene
     this.init();
   }
 
-  // TODO use EventListenerFunction type instead
-  gestureHandler: (sender: EventSource, eventObject: EventObject) => void;
+  gestureHandler: EventListenerFunction;
 
   inTolerance = false;
   popupTrigger = false;

--- a/packages/core/src/view/plugins/PopupMenuHandler.ts
+++ b/packages/core/src/view/plugins/PopupMenuHandler.ts
@@ -53,6 +53,7 @@ class PopupMenuHandler extends MaxPopupMenu implements GraphPlugin, MouseListene
     this.init();
   }
 
+  // TODO use EventListenerFunction type instead
   gestureHandler: (sender: EventSource, eventObject: EventObject) => void;
 
   inTolerance = false;

--- a/packages/core/src/view/plugins/RubberBandHandler.ts
+++ b/packages/core/src/view/plugins/RubberBandHandler.ts
@@ -32,7 +32,6 @@ import { isAltDown, isMultiTouchEvent } from '../../util/EventUtils';
 import { clearSelection } from '../../util/domUtils';
 import type { AbstractGraph } from '../AbstractGraph';
 import type { EventListenerFunction, GraphPlugin, MouseListenerSet } from '../../types';
-import type EventObject from '../event/EventObject';
 import type EventSource from '../event/EventSource';
 
 /**
@@ -65,7 +64,7 @@ class RubberBandHandler implements GraphPlugin, MouseListenerSet {
     this.graph.addMouseListener(this);
 
     // Handles force rubberband event
-    this.forceRubberbandHandler = (_sender: EventTarget, evt: EventObject) => {
+    this.forceRubberbandHandler = (_sender, evt) => {
       const evtName = evt.getProperty('eventName');
       const me = evt.getProperty('event');
 

--- a/packages/core/src/view/plugins/RubberBandHandler.ts
+++ b/packages/core/src/view/plugins/RubberBandHandler.ts
@@ -89,7 +89,7 @@ class RubberBandHandler implements GraphPlugin, MouseListenerSet {
     this.graph.addListener(InternalEvent.PAN, this.panHandler);
 
     // Does not show menu if any touch gestures take place after the trigger
-    this.gestureHandler = (sender: EventSource, eo: EventObject) => {
+    this.gestureHandler = () => {
       if (this.first) {
         this.reset();
       }
@@ -98,8 +98,10 @@ class RubberBandHandler implements GraphPlugin, MouseListenerSet {
     this.graph.addListener(InternalEvent.GESTURE, this.gestureHandler);
   }
 
+  // TODO use EventListenerFunction type instead
   forceRubberbandHandler: (sender: EventSource, evt: EventObject) => void;
   panHandler: () => void;
+  // TODO use EventListenerFunction type instead
   gestureHandler: (sender: EventSource, eo: EventObject) => void;
   graph: AbstractGraph;
   first: Point | null = null;

--- a/packages/core/src/view/plugins/RubberBandHandler.ts
+++ b/packages/core/src/view/plugins/RubberBandHandler.ts
@@ -31,9 +31,9 @@ import Rectangle from '../geometry/Rectangle';
 import { isAltDown, isMultiTouchEvent } from '../../util/EventUtils';
 import { clearSelection } from '../../util/domUtils';
 import type { AbstractGraph } from '../AbstractGraph';
-import type { GraphPlugin, MouseListenerSet } from '../../types';
-import EventObject from '../event/EventObject';
-import EventSource from '../event/EventSource';
+import type { EventListenerFunction, GraphPlugin, MouseListenerSet } from '../../types';
+import type EventObject from '../event/EventObject';
+import type EventSource from '../event/EventSource';
 
 /**
  * Event handler that selects rectangular regions.
@@ -65,7 +65,7 @@ class RubberBandHandler implements GraphPlugin, MouseListenerSet {
     this.graph.addMouseListener(this);
 
     // Handles force rubberband event
-    this.forceRubberbandHandler = (sender: EventSource, evt: EventObject) => {
+    this.forceRubberbandHandler = (_sender: EventTarget, evt: EventObject) => {
       const evtName = evt.getProperty('eventName');
       const me = evt.getProperty('event');
 
@@ -98,11 +98,9 @@ class RubberBandHandler implements GraphPlugin, MouseListenerSet {
     this.graph.addListener(InternalEvent.GESTURE, this.gestureHandler);
   }
 
-  // TODO use EventListenerFunction type instead
-  forceRubberbandHandler: (sender: EventSource, evt: EventObject) => void;
+  forceRubberbandHandler: EventListenerFunction;
   panHandler: () => void;
-  // TODO use EventListenerFunction type instead
-  gestureHandler: (sender: EventSource, eo: EventObject) => void;
+  gestureHandler: EventListenerFunction;
   graph: AbstractGraph;
   first: Point | null = null;
   destroyed = false;

--- a/packages/core/src/view/plugins/RubberBandHandler.ts
+++ b/packages/core/src/view/plugins/RubberBandHandler.ts
@@ -98,9 +98,9 @@ class RubberBandHandler implements GraphPlugin, MouseListenerSet {
     this.graph.addListener(InternalEvent.GESTURE, this.gestureHandler);
   }
 
-  forceRubberbandHandler: Function;
-  panHandler: Function;
-  gestureHandler: Function;
+  forceRubberbandHandler: (sender: EventSource, evt: EventObject) => void;
+  panHandler: () => void;
+  gestureHandler: (sender: EventSource, eo: EventObject) => void;
   graph: AbstractGraph;
   first: Point | null = null;
   destroyed = false;

--- a/packages/core/src/view/plugins/SelectionCellsHandler.ts
+++ b/packages/core/src/view/plugins/SelectionCellsHandler.ts
@@ -24,7 +24,7 @@ import { sortCells } from '../../util/styleUtils';
 import type { AbstractGraph } from '../AbstractGraph';
 import Cell from '../cell/Cell';
 import CellState from '../cell/CellState';
-import type { GraphPlugin, MouseListenerSet } from '../../types';
+import type { EventListenerFunction, GraphPlugin, MouseListenerSet } from '../../types';
 import type EdgeHandler from '../handler/EdgeHandler';
 import type VertexHandler from '../handler/VertexHandler';
 import InternalMouseEvent from '../event/InternalMouseEvent';
@@ -88,8 +88,7 @@ class SelectionCellsHandler extends EventSource implements GraphPlugin, MouseLis
   /**
    * Keeps a reference to an event listener for later removal.
    */
-  // TODO use EventListenerFunction type instead
-  refreshHandler: (sender: EventSource, evt: EventObject) => void;
+  refreshHandler: EventListenerFunction;
 
   /**
    * Defines the maximum number of handlers to paint individually. Default is 100.

--- a/packages/core/src/view/plugins/SelectionCellsHandler.ts
+++ b/packages/core/src/view/plugins/SelectionCellsHandler.ts
@@ -58,7 +58,7 @@ class SelectionCellsHandler extends EventSource implements GraphPlugin, MouseLis
     this.handlers = new Dictionary();
     this.graph.addMouseListener(this);
 
-    this.refreshHandler = (sender: EventSource, evt: EventObject) => {
+    this.refreshHandler = () => {
       if (this.isEnabled()) {
         this.refresh();
       }
@@ -88,6 +88,7 @@ class SelectionCellsHandler extends EventSource implements GraphPlugin, MouseLis
   /**
    * Keeps a reference to an event listener for later removal.
    */
+  // TODO use EventListenerFunction type instead
   refreshHandler: (sender: EventSource, evt: EventObject) => void;
 
   /**

--- a/packages/core/src/view/plugins/SelectionHandler.ts
+++ b/packages/core/src/view/plugins/SelectionHandler.ts
@@ -46,11 +46,15 @@ import Cell from '../cell/Cell';
 import type PopupMenuHandler from './PopupMenuHandler';
 import EventSource from '../event/EventSource';
 import CellState from '../cell/CellState';
-import EventObject from '../event/EventObject';
 import type ConnectionHandler from './ConnectionHandler';
 import { EdgeHandlerConfig, VertexHandlerConfig } from '../handler/config';
 import type CellEditorHandler from './CellEditorHandler';
-import type { ColorValue, GraphPlugin, MouseListenerSet } from '../../types';
+import type {
+  ColorValue,
+  EventListenerFunction,
+  GraphPlugin,
+  MouseListenerSet,
+} from '../../types';
 
 /**
  * Graph event handler that handles selection.
@@ -170,20 +174,19 @@ class SelectionHandler implements GraphPlugin, MouseListenerSet {
   graph: AbstractGraph;
 
   panHandler: () => void;
-  // TODO use EventListenerFunction type instead
-  escapeHandler: (sender: EventSource, evt: EventObject) => void;
-  // TODO use EventListenerFunction type instead
-  refreshHandler: (sender: EventSource, evt: EventObject) => void;
+  escapeHandler: EventListenerFunction;
+  refreshHandler: EventListenerFunction;
   keyHandler: (e: KeyboardEvent) => void;
   refreshThread: number | null = null;
 
   /**
-   * Defines the maximum number of cells to paint subhandles
-   * for. Default is 50 for Firefox and 20 for IE. Set this
-   * to 0 if you want an unlimited number of handles to be
-   * displayed. This is only recommended if the number of
-   * cells in the graph is limited to a small number, eg.
-   * 500.
+   * Defines the maximum number of cells to paint sub-handles for.
+   *
+   * Set this to 0 if you want an unlimited number of handles to be displayed.
+   *
+   * This is only recommended if the number of cells in the graph is limited to a small number, e.g. 500.
+   *
+   * @default 50
    */
   maxCells = 50;
 

--- a/packages/core/src/view/plugins/SelectionHandler.ts
+++ b/packages/core/src/view/plugins/SelectionHandler.ts
@@ -85,14 +85,14 @@ class SelectionHandler implements GraphPlugin, MouseListenerSet {
     this.graph.addListener(InternalEvent.PAN, this.panHandler);
 
     // Handles escape keystrokes
-    this.escapeHandler = (sender, evt) => {
+    this.escapeHandler = () => {
       this.reset();
     };
 
     this.graph.addListener(InternalEvent.ESCAPE, this.escapeHandler);
 
     // Updates the preview box for remote changes
-    this.refreshHandler = (sender, evt) => {
+    this.refreshHandler = () => {
       // Merges multiple pending calls
       if (this.refreshThread) {
         window.clearTimeout(this.refreshThread);
@@ -170,7 +170,9 @@ class SelectionHandler implements GraphPlugin, MouseListenerSet {
   graph: AbstractGraph;
 
   panHandler: () => void;
+  // TODO use EventListenerFunction type instead
   escapeHandler: (sender: EventSource, evt: EventObject) => void;
+  // TODO use EventListenerFunction type instead
   refreshHandler: (sender: EventSource, evt: EventObject) => void;
   keyHandler: (e: KeyboardEvent) => void;
   refreshThread: number | null = null;

--- a/packages/html/stories/AutoLayout.stories.ts
+++ b/packages/html/stories/AutoLayout.stories.ts
@@ -184,40 +184,37 @@ const Template = ({ label, ...args }: Record<string, string>) => {
     overlay.cursor = 'hand';
 
     // Installs a handler for clicks on the overlay
-    overlay.addListener(
-      InternalEvent.CLICK,
-      (_name: string, _funct: (sender: EventTarget, evt: EventObject) => void) => {
-        graph.clearSelection();
+    overlay.addListener(InternalEvent.CLICK, () => {
+      graph.clearSelection();
 
-        let vertex: Cell;
-        executeLayout(
-          () => {
-            const geo = cell.getGeometry();
-            vertex = graph.insertVertex({
-              parent,
-              value: 'World!',
-              position: [geo!.x, geo!.y],
-              size: [80, 30],
-            });
-            addOverlay(vertex);
-            graph.view.refresh();
-            graph.insertEdge({
-              parent,
-              source: cell,
-              target: vertex,
-            });
-          },
-          () => {
-            graph.scrollCellToVisible(vertex);
-          }
-        );
-      }
-    );
+      let vertex: Cell;
+      executeLayout(
+        () => {
+          const geo = cell.getGeometry();
+          vertex = graph.insertVertex({
+            parent,
+            value: 'World!',
+            position: [geo!.x, geo!.y],
+            size: [80, 30],
+          });
+          addOverlay(vertex);
+          graph.view.refresh();
+          graph.insertEdge({
+            parent,
+            source: cell,
+            target: vertex,
+          });
+        },
+        () => {
+          graph.scrollCellToVisible(vertex);
+        }
+      );
+    });
 
     // Special CMS event, automatically connect the new vertex to its predecessor
-    overlay.addListener('pointerdown', (_sender: EventTarget, eo: EventObject) => {
-      const evt2 = eo.getProperty('event');
-      const state = eo.getProperty('state');
+    overlay.addListener('pointerdown', (_sender, eventObject) => {
+      const evt2 = eventObject.getProperty('event');
+      const state = eventObject.getProperty('state');
 
       const popupMenuHandler = graph.getPlugin<PopupMenuHandler>('PopupMenuHandler')!;
       popupMenuHandler.hideMenu();

--- a/packages/html/stories/DynamicLoading.stories.ts
+++ b/packages/html/stories/DynamicLoading.stories.ts
@@ -17,7 +17,6 @@ limitations under the License.
 
 import {
   Effects,
-  EventObject,
   Graph,
   GraphDataModel,
   InternalEvent,
@@ -54,8 +53,8 @@ const Template = ({ label, ...args }: Record<string, any>) => {
   graph.setEnabled(false);
 
   // Handles clicks on cells
-  graph.addListener(InternalEvent.CLICK, function (_sender: any, evt: EventObject) {
-    const cell = evt.getProperty('cell');
+  graph.addListener(InternalEvent.CLICK, function (_sender, eventObject) {
+    const cell = eventObject.getProperty('cell');
 
     if (cell != null) {
       load(graph, cell);
@@ -78,12 +77,10 @@ const Template = ({ label, ...args }: Record<string, any>) => {
   const cell = graph.insertVertex(parent, '0-0', '0-0', cx - 20, cy - 15, 60, 40);
 
   // Animates the changes in the graph model
-  graph
-    .getDataModel()
-    .addListener(InternalEvent.CHANGE, function (_sender: any, evt: EventObject) {
-      const { changes } = evt.getProperty('edit');
-      Effects.animateChanges(graph, changes);
-    });
+  graph.getDataModel().addListener(InternalEvent.CHANGE, function (_sender, eventObject) {
+    const { changes } = eventObject.getProperty('edit');
+    Effects.animateChanges(graph, changes);
+  });
 
   // Loads the links for the given cell into the given graph
   // by requesting the respective data in the server-side

--- a/packages/html/stories/DynamicToolbar.stories.ts
+++ b/packages/html/stories/DynamicToolbar.stories.ts
@@ -169,7 +169,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
     const img: InternalHTMLImageElementWithProps = toolbar.addMode(
       null,
       image,
-      (evt: MouseEvent, cell: Cell) => {
+      (evt: MouseEvent, cell: Cell | null) => {
         const pt = graph.getPointForEvent(evt);
         dropHandler(graph, evt, cell, pt.x, pt.y);
       },

--- a/packages/html/stories/Manhattan.stories.ts
+++ b/packages/html/stories/Manhattan.stories.ts
@@ -16,7 +16,6 @@ limitations under the License.
 */
 
 import {
-  EventObject,
   Graph,
   InternalEvent,
   ManhattanConnectorConfig,
@@ -48,7 +47,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   graph.getPlugin<SelectionHandler>('SelectionHandler')!.guidesEnabled = true;
 
   // Hack to rerender edge on any node move
-  graph.model.addListener(InternalEvent.CHANGE, (_sender: unknown, evt: EventObject) => {
+  graph.model.addListener(InternalEvent.CHANGE, (_sender, evt) => {
     const changes = evt.getProperty('changes');
     const hasMoveEdits = changes?.some(
       // checks for the existence of the geometry and previous properties which are characteristic of GeometryChange in the model

--- a/packages/html/stories/Manhattan.stories.ts
+++ b/packages/html/stories/Manhattan.stories.ts
@@ -47,8 +47,8 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   graph.getPlugin<SelectionHandler>('SelectionHandler')!.guidesEnabled = true;
 
   // Hack to rerender edge on any node move
-  graph.model.addListener(InternalEvent.CHANGE, (_sender, evt) => {
-    const changes = evt.getProperty('changes');
+  graph.model.addListener(InternalEvent.CHANGE, (_sender, eventObject) => {
+    const changes = eventObject.getProperty('changes');
     const hasMoveEdits = changes?.some(
       // checks for the existence of the geometry and previous properties which are characteristic of GeometryChange in the model
       (c: any) => typeof c.geometry !== 'undefined' && typeof c.previous !== 'undefined'

--- a/packages/html/stories/Overlays.stories.ts
+++ b/packages/html/stories/Overlays.stories.ts
@@ -22,7 +22,6 @@ import {
   type CellState,
   CellTracker,
   EllipseShape,
-  type EventObject,
   Graph,
   ImageBox,
   InternalEvent,
@@ -123,8 +122,8 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   }
 
   // Installs a handler for click events in the graph that toggles the overlay for the respective cell
-  graph.addListener(InternalEvent.CLICK, (_sender: EventTarget, evt: EventObject) => {
-    const cell = evt.getProperty('cell');
+  graph.addListener(InternalEvent.CLICK, (_sender, eventObject) => {
+    const cell = eventObject.getProperty('cell');
 
     if (cell) {
       const overlays = graph.getCellOverlays(cell);
@@ -138,12 +137,9 @@ const Template = ({ label, ...args }: Record<string, string>) => {
         );
 
         // Installs a handler for clicks on the overlay
-        overlay.addListener(
-          InternalEvent.CLICK,
-          (_sender: EventTarget, _evt: EventObject) => {
-            window.alert('Overlay clicked');
-          }
-        );
+        overlay.addListener(InternalEvent.CLICK, (_sender, _eventObject) => {
+          window.alert('Overlay clicked');
+        });
 
         // Sets the overlay for the cell in the graph
         graph.addCellOverlay(cell, overlay);
@@ -155,14 +151,11 @@ const Template = ({ label, ...args }: Record<string, string>) => {
 
   // Installs a handler for double click events in the graph
   // that shows an alert box
-  graph.addListener(
-    InternalEvent.DOUBLE_CLICK,
-    (_sender: EventTarget, evt: EventObject) => {
-      const cell = evt.getProperty('cell');
-      alert(`Double-click: ${cell != null ? 'Cell' : 'Graph'}`);
-      evt.consume();
-    }
-  );
+  graph.addListener(InternalEvent.DOUBLE_CLICK, (_sender, eventObject) => {
+    const cell = eventObject.getProperty('cell');
+    alert(`Double-click: ${cell != null ? 'Cell' : 'Graph'}`);
+    eventObject.consume();
+  });
 
   // Gets the default parent for inserting new cells. This is normally the first child of the root (i.e. layer 0).
   const parent = graph.getDefaultParent();

--- a/packages/html/stories/SwimLanes.stories.ts
+++ b/packages/html/stories/SwimLanes.stories.ts
@@ -17,6 +17,7 @@ limitations under the License.
 
 import {
   type ConnectionHandler,
+  type EventListenerFunction,
   ImageBox,
   Perimeter,
   Point,
@@ -28,7 +29,6 @@ import {
   Graph,
   type Cell,
   type EdgeParameters,
-  type EventObject,
   type SelectionHandler,
   type VertexParameters,
   Client,
@@ -231,8 +231,8 @@ const Template = ({ label, ...args }: Record<string, string>) => {
     };
 
     // Keeps widths on collapse/expand
-    const foldingHandler = function (_sender: any, evt: EventObject) {
-      const cells = evt.getProperty('cells');
+    const foldingHandler: EventListenerFunction = function (_sender, eventObject) {
+      const cells = eventObject.getProperty('cells');
 
       for (let i = 0; i < cells.length; i++) {
         const geo = cells[i].getGeometry();

--- a/packages/html/stories/Toolbar.stories.ts
+++ b/packages/html/stories/Toolbar.stories.ts
@@ -175,9 +175,8 @@ const Template = ({ label, ...args }: { [p: string]: any }) => {
       const cells = graph.getSelectionCells();
       const bounds = graph.getView().getBounds(cells);
 
-      // Function that is executed when the image is dropped on
-      // the graph. The cell argument points to the cell under
-      // the mousepointer if there is one.
+      // Function that is executed when the image is dropped on the graph.
+      // The cell argument points to the cell under the mouse-pointer if there is one.
       const funct = (graph: AbstractGraph, _evt: MouseEvent, cell: Cell | null) => {
         graph.stopEditing(false);
 
@@ -205,9 +204,8 @@ const Template = ({ label, ...args }: { [p: string]: any }) => {
     image: string,
     title?: string
   ) {
-    // Function that is executed when the image is dropped on
-    // the graph. The cell argument points to the cell under
-    // the mousepointer if there is one.
+    // Function that is executed when the image is dropped on the graph.
+    // The cell argument points to the cell under the mouse-pointer if there is one.
     const funct = (graph: AbstractGraph, evt: MouseEvent, cell: Cell | null) => {
       graph.stopEditing(false);
 

--- a/packages/html/stories/Toolbar.stories.ts
+++ b/packages/html/stories/Toolbar.stories.ts
@@ -59,7 +59,7 @@ export default {
   },
 };
 
-const Template = ({ label, ...args }: { [p: string]: any }) => {
+const Template = ({ label, ...args }: Record<string, string>) => {
   configureImagesBasePath();
   const div = document.createElement('div');
   div.style.display = 'flex';
@@ -169,6 +169,10 @@ const Template = ({ label, ...args }: { [p: string]: any }) => {
   addEdge('images/entity.gif', 50, 50, {});
   addToolbarLine();
 
+  const selectFunction: (evt: MouseEvent, cell: Cell | null) => void = () => {
+    // do nothing
+  };
+
   const button = DomHelpers.button('Create toolbar entry from selection', (evt) => {
     if (!graph.isSelectionEmpty()) {
       // Creates a copy of the selection array to preserve its state
@@ -188,7 +192,7 @@ const Template = ({ label, ...args }: { [p: string]: any }) => {
       };
 
       // Creates the image which is used as the drag icon (preview)
-      const img = toolbar.addMode(null, 'images/outline.gif', funct, '');
+      const img = toolbar.addMode(null, 'images/outline.gif', selectFunction, '');
       gestureUtils.makeDraggable(img, graph, funct);
     }
   });
@@ -230,7 +234,7 @@ const Template = ({ label, ...args }: { [p: string]: any }) => {
     };
 
     // Creates the image which is used as the drag icon (preview)
-    const img = toolbar.addMode(title, image, funct, '');
+    const img = toolbar.addMode(title, image, selectFunction, '');
     gestureUtils.makeDraggable(img, graph, funct);
   }
 


### PR DESCRIPTION
**DISCLAIMER: this is a work in progress and subject to force push**

This mainly implies using specific signature for functions instead of using the generic "Function" type.

BREAKING CHANGES: **TODO**

### Tasks
This PR initially tried to bump all eslint plugins and to fix all eslint errors/warnings. As this was a too large task, it has been split:

- [x] extract all eslint plugins bump in a dedicated PR, except the bump of ts-eslint #628
- [x] bump ts-eslint in a dedicated PR excluding rules that enforce explicit function parameter (forbid usage of the Function type) #744
- [x] rebase on main and drop commits related to the former eslint plugins bump
- [ ] in this PR, convert Function type to explicit function types including exact parameters
- [ ] split this PR which is too large