### PR TITLE
feat!: make edge bend points easier to manage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ For more details on the contents of a release, see [the GitHub release page] (ht
 
 _**Note:** Yet to be released breaking changes appear here._
 
+**Breaking Changes**:
+- Some properties have been removed from `EdgeHandler` as it was not possible to correctly change their value.
+They are replaced by global configuration in `EdgeHandlerConfig`:
+  - addEnabled --> addBendOnShiftClickEnabled
+  - removeEnabled --> removeBendOnShiftClickEnabled
+  - virtualBendOpacity
+  - virtualBendsEnabled
+
+
 ## 0.14.0
 
 Release date: `2024-11-27`

--- a/packages/core/src/view/handler/EdgeHandler.ts
+++ b/packages/core/src/view/handler/EdgeHandler.ts
@@ -125,22 +125,6 @@ class EdgeHandler {
   cloneEnabled = true;
 
   /**
-   * Specifies if adding bends by shift-click is enabled.
-   *
-   * **Note**: This experimental feature is not recommended for production use.
-   * @default false
-   */
-  addEnabled = false;
-
-  /**
-   * Specifies if removing bends by shift-click is enabled.
-   *
-   * **Note**: This experimental feature is not recommended for production use.
-   * @default false
-   */
-  removeEnabled = false;
-
-  /**
    * Specifies if removing bends by double click is enabled.
    * @default false
    */
@@ -160,19 +144,6 @@ class EdgeHandler {
   straightRemoveEnabled = false;
 
   /**
-   * Specifies if virtual bends should be added in the center of each segment.
-   * These bends can then be used to add new waypoints.
-   * @default false
-   */
-  virtualBendsEnabled = false;
-
-  /**
-   * Opacity to be used for virtual bends (see {@link virtualBendsEnabled}).
-   * @default 20
-   */
-  virtualBendOpacity = 20;
-
-  /**
    * Specifies if the parent should be highlighted if a child cell is selected.
    * @default false
    */
@@ -180,7 +151,7 @@ class EdgeHandler {
 
   /**
    * Specifies if bends should be added to the graph container.
-   * This is updated in {@link init} based on whether the edge or one of its terminals has an HTML label in the container.
+   * This is updated in {@link constructor} based on whether the edge or one of its terminals has an HTML label in the container.
    */
   preferHtml = false;
 
@@ -333,7 +304,7 @@ class EdgeHandler {
     this.redraw();
 
     // Handles escape keystrokes
-    this.escapeHandler = (sender: Listenable, evt: Event) => {
+    this.escapeHandler = (_sender: Listenable, _evt: Event) => {
       const dirty = this.index != null;
       this.reset();
 
@@ -419,7 +390,7 @@ class EdgeHandler {
    */
   isVirtualBendsEnabled(evt?: Event) {
     return (
-      this.virtualBendsEnabled &&
+      EdgeHandlerConfig.virtualBendsEnabled &&
       (this.state.style.edgeStyle == null ||
         this.state.style.edgeStyle === NONE ||
         this.state.style.noEdgeStyle) &&
@@ -695,6 +666,7 @@ class EdgeHandler {
    * Helper method to initialize the given bend.
    *
    * @param bend {@link Shape} that represents the bend to be initialized.
+   * @param dblClick Optional function to be called on double click.
    */
   initBend(bend: Shape, dblClick?: (evt: MouseEvent) => void) {
     if (this.preferHtml) {
@@ -820,13 +792,20 @@ class EdgeHandler {
       if (b) this.snapPoint = new Point(b.getCenterX(), b.getCenterY());
     }
 
-    if (this.addEnabled && handle === null && this.isAddPointEvent(me.getEvent())) {
+    if (
+      EdgeHandlerConfig.addBendOnShiftClickEnabled &&
+      handle === null &&
+      this.isAddPointEvent(me.getEvent())
+    ) {
       this.addPoint(this.state, me.getEvent());
       me.consume();
     } else if (handle !== null && !me.isConsumed() && this.graph.isEnabled()) {
       const cell = me.getCell();
 
-      if (this.removeEnabled && this.isRemovePointEvent(me.getEvent())) {
+      if (
+        EdgeHandlerConfig.removeBendOnShiftClickEnabled &&
+        this.isRemovePointEvent(me.getEvent())
+      ) {
         this.removePoint(this.state, handle);
       } else if (
         handle !== InternalEvent.LABEL_HANDLE ||
@@ -2000,7 +1979,7 @@ class EdgeHandler {
             b.redraw();
           }
 
-          setOpacity(b.node, this.virtualBendOpacity);
+          setOpacity(b.node, EdgeHandlerConfig.virtualBendOpacity);
           last = pt;
 
           if (this.manageLabelHandle) {

--- a/packages/core/src/view/handler/EdgeSegmentHandler.ts
+++ b/packages/core/src/view/handler/EdgeSegmentHandler.ts
@@ -25,6 +25,7 @@ import ElbowEdgeHandler from './ElbowEdgeHandler';
 import CellState from '../cell/CellState';
 import Cell from '../cell/Cell';
 import InternalMouseEvent from '../event/InternalMouseEvent';
+import { EdgeHandlerConfig } from './config';
 
 class EdgeSegmentHandler extends ElbowEdgeHandler {
   constructor(state: CellState) {
@@ -404,8 +405,8 @@ class EdgeSegmentHandler extends ElbowEdgeHandler {
         }
 
         if (straight) {
-          setOpacity(this.bends[1].node, this.virtualBendOpacity);
-          setOpacity(this.bends[3].node, this.virtualBendOpacity);
+          setOpacity(this.bends[1].node, EdgeHandlerConfig.virtualBendOpacity);
+          setOpacity(this.bends[3].node, EdgeHandlerConfig.virtualBendOpacity);
         }
       }
     }

--- a/packages/core/src/view/handler/config.ts
+++ b/packages/core/src/view/handler/config.ts
@@ -39,6 +39,14 @@ import { shallowCopy } from '../../util/cloneUtils';
  */
 export type EdgeHandlerConfigType = {
   /**
+   * Specifies if adding bends by shift-click is enabled.
+   *
+   * **Note**: This experimental feature is not recommended for production use.
+   * @default false
+   * @since 0.15.0
+   */
+  addBendOnShiftClickEnabled: boolean;
+  /**
    * Defines the color to be used for the connect handle fill color. Use `none` for no color.
    * @default {@link CONNECT_HANDLE_FILLCOLOR}
    */
@@ -49,20 +57,41 @@ export type EdgeHandlerConfigType = {
    */
   handleShape: 'circle' | 'square';
   /**
+   * Specifies if removing bends by shift-click is enabled.
+   *
+   * **Note**: This experimental feature is not recommended for production use.
+   * @default false
+   * @since 0.15.0
+   */
+  removeBendOnShiftClickEnabled: boolean;
+  /**
    * Defines the default color to be used for the selection border of edges. Use `none` for no color.
    * @default {@link EDGE_SELECTION_COLOR}
    */
   selectionColor: string;
+  /**
+   * Defines the default dashed state to be used for the edge selection border.
+   * @default {@link EDGE_SELECTION_DASHED}
+   */
+  selectionDashed: boolean;
   /**
    * Defines the default stroke width to be used for edge selections.
    * @default {@link EDGE_SELECTION_STROKEWIDTH}
    */
   selectionStrokeWidth: number;
   /**
-   * Defines the default dashed state to be used for the edge selection border.
-   * @default {@link EDGE_SELECTION_DASHED}
+   * Opacity to be used for virtual bends (see {@link virtualBendsEnabled}).
+   * @default 20
+   * @since 0.15.0
    */
-  selectionDashed: boolean;
+  virtualBendOpacity: number;
+  /**
+   * Specifies if virtual bends should be added in the center of each segment.
+   * These bends can then be used to add new waypoints.
+   * @default false
+   * @since 0.15.0
+   */
+  virtualBendsEnabled: boolean;
 };
 
 /**
@@ -73,18 +102,26 @@ export type EdgeHandlerConfigType = {
  * @category Configuration
  */
 export const EdgeHandlerConfig: EdgeHandlerConfigType = {
+  addBendOnShiftClickEnabled: false,
+
   connectFillColor: CONNECT_HANDLE_FILLCOLOR,
 
   handleShape: 'square',
 
+  removeBendOnShiftClickEnabled: false,
+
   selectionColor: EDGE_SELECTION_COLOR,
+
+  selectionDashed: EDGE_SELECTION_DASHED,
 
   selectionStrokeWidth: EDGE_SELECTION_STROKEWIDTH,
 
-  selectionDashed: EDGE_SELECTION_DASHED,
+  virtualBendOpacity: 20,
+
+  virtualBendsEnabled: false,
 };
 
-const defaultEdgeHandlerConfig = { ...EdgeHandlerConfig };
+const defaultEdgeHandlerConfig: EdgeHandlerConfigType = { ...EdgeHandlerConfig };
 /**
  * Resets {@link EdgeHandlerConfig} to default values.
  *

--- a/packages/html/stories/CustomHandlesConfiguration.stories.ts
+++ b/packages/html/stories/CustomHandlesConfiguration.stories.ts
@@ -57,6 +57,16 @@ export default {
 
 const Template = ({ label, ...args }: Record<string, string>) => {
   const div = document.createElement('div');
+
+  const divMessage = document.createElement('div');
+  divMessage.innerHTML = `To add a new edge bend, shift-click on the edge where you wish to add it.
+  <br>
+    To remove an existing edge bend, shift-click on it.
+  `;
+  divMessage.style.fontFamily = 'Arial,Helvetica';
+  divMessage.style.marginBottom = '1rem';
+  div.appendChild(divMessage);
+
   const container = createGraphContainer(args);
   div.appendChild(container);
 
@@ -64,11 +74,15 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   if (args.customHandleDefaults) {
     const selectionColor = '#00a8ff';
 
+    EdgeHandlerConfig.addBendOnShiftClickEnabled = true;
     EdgeHandlerConfig.connectFillColor = 'pink';
     EdgeHandlerConfig.handleShape = 'circle';
+    EdgeHandlerConfig.removeBendOnShiftClickEnabled = true;
     EdgeHandlerConfig.selectionColor = selectionColor;
     EdgeHandlerConfig.selectionDashed = false;
     EdgeHandlerConfig.selectionStrokeWidth = 3;
+    EdgeHandlerConfig.virtualBendOpacity = 40;
+    EdgeHandlerConfig.virtualBendsEnabled = true;
 
     HandleConfig.fillColor = '#99ccff';
     HandleConfig.labelFillColor = 'orange';

--- a/packages/website/docs/usage/migrate-from-mxgraph.md
+++ b/packages/website/docs/usage/migrate-from-mxgraph.md
@@ -444,8 +444,8 @@ The following Cell handler classes have been renamed in `maxGraph`:
 - `mxElbowEdgeHandler` to `ElbowEdgeHandler`
 - `mxVertexHandler` to `VertexHandler`
 
-In `mxGraph`, the handlers were configured by updating their properties on the prototype. 
-In `maxGraph`, the handlers are configured with global configuration object. For more details, see the [Global Configuration](./global-configuration.md#general) documentation.
+In `mxGraph`, the handlers were configured by updating their properties on the prototype.
+In `maxGraph`, the handlers are configured with a global configuration object. For more details, see the [Global Configuration](./global-configuration.md#general) documentation.
 
 For example, the `mxVertexHandler` class had a `rotationEnabled` property. 
 This property has been removed in `maxGraph`. Use the `VertexHandlerConfig.rotationEnabled` property instead (since `0.12.0`).

--- a/packages/website/docs/usage/migrate-from-mxgraph.md
+++ b/packages/website/docs/usage/migrate-from-mxgraph.md
@@ -436,13 +436,26 @@ Others were removed:
 - `isVisible(cell)` see [discussion #179](https://github.com/maxGraph/maxGraph/discussions/179#discussioncomment-5389942) for rationale
 - `restoreClone()` (from version 0.11.0)
 
+### Cell handlers
+
+The following Cell handler classes have been renamed in `maxGraph`:
+- `mxEdgeHandler` to `EdgeHandler`
+- `mxEdgeSegmentHandler` to `EdgeSegmentHandler`
+- `mxElbowEdgeHandler` to `ElbowEdgeHandler`
+- `mxVertexHandler` to `VertexHandler`
+
+In `mxGraph`, the handlers were configured by updating their properties on the prototype. 
+In `maxGraph`, the handlers are configured with global configuration object. For more details, see the [Global Configuration](./global-configuration.md#general) documentation.
+
+For example, the `mxVertexHandler` class had a `rotationEnabled` property. 
+This property has been removed in `maxGraph`. Use the `VertexHandlerConfig.rotationEnabled` property instead (since `0.12.0`).
+
 ### Misc
 
 - Codec renaming and output: see [Pull Request #70](https://github.com/maxGraph/maxGraph/pull/70)
 - `mxCellEditor` to `CellEditorHandler`
 - `mxDictionary`&lt;T&gt; to `Dictionary`&lt;K, V&gt;
 - `mxRubberband` to `RubberBandHandler`
-- `mxVertexHandler.rotationEnabled` has been removed. Use `VertexHandlerConfig.rotationEnabled` instead (since `0.12.0`).
 
 ### Event handling
 


### PR DESCRIPTION
Previously in `mxGraph`, this was done by updating the properties on the prototype of the `EdgeHandler` class. This didn't work anymore in `maxGraph`.
It is now possible to configure them back by using new properties available in `EdgeHandlerConfig`

BREAKING CHANGES: the following properties have been removed from `EdgeHandler` and are replaced by global configuration
in `EdgeHandlerConfig`:
  - addEnabled --> addBendOnShiftClickEnabled
  - removeEnabled --> removeBendOnShiftClickEnabled
  - virtualBendOpacity
  - virtualBendsEnabled

### Demo in Storybook

https://github.com/user-attachments/assets/889a1d12-b1bc-405f-952e-b22690021395




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced interactivity with new instructions for adding and removing edge bends.
	- Enabled addition and removal of edge bends via shift-click actions.
	- Modified visual representation settings for bends, including opacity and visibility.

- **Configuration Changes**
	- Introduced new configuration options for edge handling.
	- Added ability to enable/disable adding and removing bends via shift-click.
	- Implemented virtual bend opacity and visibility settings.

- **Documentation**
	- Updated migration guide for transitioning from mxGraph to maxGraph.
	- Provided detailed instructions on class and configuration changes.
	- Added a section on breaking changes related to property removals.

- **Refactoring**
	- Removed direct property management for edge handlers.
	- Centralized configuration management for edge-related functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->