### PR TITLE
refactor(VertexHandler): simplify management of `style.rotation`

### DIFF
--- a/packages/core/src/view/handler/VertexHandler.ts
+++ b/packages/core/src/view/handler/VertexHandler.ts
@@ -689,9 +689,12 @@ class VertexHandler {
         this.preview = this.createSelectionShape(this.bounds);
 
         if (
-          !(Client.IS_SVG && Number(this.state.style.rotation || '0') !== 0) &&
-          this.state.text != null &&
-          this.state.text.node.parentNode === this.graph.container
+          !(
+            Client.IS_SVG &&
+            (this.state.style.rotation ?? 0) != 0 &&
+            this.state.text != null &&
+            this.state.text.node.parentNode === this.graph.container
+          )
         ) {
           this.preview.dialect = DIALECT.STRICTHTML;
           this.preview.init(this.graph.container);
@@ -1316,7 +1319,7 @@ class VertexHandler {
       if (cell.isVertex() || cell.isEdge()) {
         if (!cell.isEdge()) {
           const style = this.graph.getCurrentCellStyle(cell);
-          const total = (style.rotation || 0) + angle;
+          const total = (style.rotation ?? 0) + angle;
           this.graph.setCellStyles('rotation', total, [cell]);
         }
 


### PR DESCRIPTION
Always use the nullish coalescing (??) operator instead of the logical OR operator, and avoid extra conversion to number
as the rotation property is always a number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of undefined rotation styles to ensure consistent default behavior when rotation is not explicitly set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->