### PR TITLE
docs: update references to GraphDataModel

### DIFF
--- a/packages/core/src/serialization/CodecRegistry.ts
+++ b/packages/core/src/serialization/CodecRegistry.ts
@@ -26,7 +26,7 @@ import ObjectCodec from './ObjectCodec';
  * 1. Define a default codec with a new instance of the object to be handled.
  *
  *     ```javascript
- *     const codec = new ObjectCodec(new Transactions());
+ *     const codec = new ObjectCodec(new GraphDataModel());
  *     ```
  *
  * 2. Define the functions required for encoding and decoding objects.

--- a/packages/core/src/util/Constants.ts
+++ b/packages/core/src/util/Constants.ts
@@ -52,8 +52,7 @@ export enum DIALECT {
 }
 
 /**
- * Name of the field to be used to store the object ID. Default is
- * <code>mxObjectId</code>.
+ * Name of the field to be used to store the object ID.
  */
 export const IDENTITY_FIELD_NAME = 'mxObjectId';
 

--- a/packages/core/src/util/ObjectIdentity.ts
+++ b/packages/core/src/util/ObjectIdentity.ts
@@ -31,8 +31,8 @@ import { getFunctionName } from './StringUtils';
  */
 class ObjectIdentity {
   /**
-   * Name of the field to be used to store the object ID. Default is
-   * <code>mxObjectId</code>.
+   * Name of the field to be used to store the object ID.
+   * @default {@IDENTITY_FIELD_NAME}
    */
   static FIELD_NAME = IDENTITY_FIELD_NAME;
 

--- a/packages/core/src/util/styleUtils.ts
+++ b/packages/core/src/util/styleUtils.ts
@@ -319,7 +319,7 @@ export const convertPoint = (container: HTMLElement, x: number, y: number) => {
  * Assigns the value for the given key in the styles of the given cells, or
  * removes the key from the styles if the value is null.
  *
- * @param model <Transactions> to execute the transaction in.
+ * @param model {@link GraphDataModel} to execute the transaction in.
  * @param cells Array of {@link Cell}s to be updated.
  * @param key Key of the style to be changed.
  * @param value New value for the given key.
@@ -361,7 +361,7 @@ export const setCellStyles = (
  *       constants.FONT.BOLD);
  * ```
  *
- * @param model <Transactions> that contains the cells.
+ * @param model {@link GraphDataModel} that contains the cells.
  * @param cells Array of {@link Cell}s to change the style for.
  * @param key Key of the style to be changed.
  * @param flag Integer for the bit to be changed.

--- a/packages/core/src/view/event/EventSource.ts
+++ b/packages/core/src/view/event/EventSource.ts
@@ -35,13 +35,14 @@ type EventListenerObject = {
  * ```
  *
  * Known Subclasses:
+ * - {@link CellOverlay}
+ * - {@link Editor}
+ * - {@link Graph}
+ * - {@link GraphDataModel}
+ * - {@link GraphView}
+ * - {@link MaxToolbar}
+ * - {@link MaxWindow}
  *
- * <Transactions>, {@link Graph}, {@link GraphView}, <Editor>, <CellOverlay>,
- * <MaxToolbar>, <MaxWindow>
- *
- * Constructor: mxEventSource
- *
- * Constructs a new event source.
  */
 class EventSource {
   constructor(eventSource: EventTarget | null = null) {

--- a/packages/core/src/view/handler/ConnectionHandler.ts
+++ b/packages/core/src/view/handler/ConnectionHandler.ts
@@ -175,7 +175,7 @@ type FactoryMethod = (
  * of the inserted edge. To print the source, target or any optional ports IDs that the
  * edge is connected to, the following code can be used. To get more details about the
  * actual connection point, {@link Graph.getConnectionConstraint} can be used. To resolve
- * the port IDs, use <Transactions.getCell>.
+ * the port IDs, use {@link GraphDataModel.getCell}.
  *
  * ```javascript
  * graph.getPlugin('ConnectionHandler')?.addListener(mxEvent.CONNECT, (sender, evt) => {

--- a/packages/core/src/view/image/ImageBox.ts
+++ b/packages/core/src/view/image/ImageBox.ts
@@ -18,10 +18,6 @@ limitations under the License.
 
 /**
  * Encapsulates the URL, width and height of an image.
- *
- * Constructor: mxImage
- *
- * Constructs a new image.
  */
 class ImageBox {
   constructor(src: string, width: number, height: number) {

--- a/packages/core/src/view/undoable_changes/ChildChange.ts
+++ b/packages/core/src/view/undoable_changes/ChildChange.ts
@@ -47,10 +47,7 @@ export class ChildChange implements UndoableChange {
   }
 
   /**
-   * Changes the parent of {@link child}` using
-   * <Transactions.parentForCellChanged> and
-   * removes or restores the cell's
-   * connections.
+   * Changes the parent of {@link child} using {@link GraphDataModel.parentForCellChanged} and removes or restores the cell's connections.
    */
   execute() {
     let tmp = this.child.getParent();

--- a/packages/core/src/view/undoable_changes/CollapseChange.ts
+++ b/packages/core/src/view/undoable_changes/CollapseChange.ts
@@ -41,8 +41,7 @@ class CollapseChange implements UndoableChange {
   }
 
   /**
-   * Changes the collapsed state of {@link cell}` to {@link previous}` using
-   * <Transactions.collapsedStateForCellChanged>.
+   * Changes the collapsed state of {@link cell} to {@link previous} using {@link GraphDataModel.collapsedStateForCellChanged}.
    */
   execute() {
     this.collapsed = this.previous;

--- a/packages/core/src/view/undoable_changes/GeometryChange.ts
+++ b/packages/core/src/view/undoable_changes/GeometryChange.ts
@@ -42,8 +42,7 @@ class GeometryChange implements UndoableChange {
   }
 
   /**
-   * Changes the geometry of {@link cell}` ro {@link previous}` using
-   * <Transactions.geometryForCellChanged>.
+   * Changes the geometry of {@link cell} to {@link previous} using{@link GraphDataModel.geometryForCellChanged}.
    */
   execute() {
     this.geometry = this.previous;

--- a/packages/core/src/view/undoable_changes/RootChange.ts
+++ b/packages/core/src/view/undoable_changes/RootChange.ts
@@ -41,8 +41,7 @@ export class RootChange implements UndoableChange {
   }
 
   /**
-   * Carries out a change of the root using
-   * <Transactions.rootChanged>.
+   * Carries out a change of the root using {@link GraphDataModel.rootChanged}.
    */
   execute() {
     this.root = this.previous;

--- a/packages/core/src/view/undoable_changes/StyleChange.ts
+++ b/packages/core/src/view/undoable_changes/StyleChange.ts
@@ -38,8 +38,7 @@ class StyleChange implements UndoableChange {
   }
 
   /**
-   * Changes the style of {@link cell}` to {@link previous}` using
-   * <Transactions.styleForCellChanged>.
+   * Changes the style of {@link cell} to {@link previous} using {@link GraphDataModel.styleForCellChanged}.
    */
   execute() {
     this.style = this.previous;

--- a/packages/core/src/view/undoable_changes/TerminalChange.ts
+++ b/packages/core/src/view/undoable_changes/TerminalChange.ts
@@ -38,8 +38,7 @@ export class TerminalChange implements UndoableChange {
   }
 
   /**
-   * Changes the terminal of {@link cell}` to {@link previous}` using
-   * <Transactions.terminalForCellChanged>.
+   * Changes the terminal of {@link cell} to {@link previous} using{@link GraphDataModel.terminalForCellChanged}.
    */
   execute() {
     this.terminal = this.previous;

--- a/packages/core/src/view/undoable_changes/TerminalChange.ts
+++ b/packages/core/src/view/undoable_changes/TerminalChange.ts
@@ -38,7 +38,7 @@ export class TerminalChange implements UndoableChange {
   }
 
   /**
-   * Changes the terminal of {@link cell} to {@link previous} using{@link GraphDataModel.terminalForCellChanged}.
+   * Changes the terminal of {@link cell} to {@link previous} using {@link GraphDataModel.terminalForCellChanged}.
    */
   execute() {
     this.terminal = this.previous;

--- a/packages/core/src/view/undoable_changes/ValueChange.ts
+++ b/packages/core/src/view/undoable_changes/ValueChange.ts
@@ -41,8 +41,7 @@ class ValueChange implements UndoableChange {
   }
 
   /**
-   * Changes the value of {@link cell}` to {@link previous}` using
-   * <Transactions.valueForCellChanged>.
+   * Changes the value of {@link cell} to {@link previous} using {@link GraphDataModel.valueForCellChanged}.
    */
   execute() {
     this.value = this.previous;

--- a/packages/core/src/view/undoable_changes/VisibleChange.ts
+++ b/packages/core/src/view/undoable_changes/VisibleChange.ts
@@ -41,8 +41,7 @@ class VisibleChange implements UndoableChange {
   }
 
   /**
-   * Changes the visible state of {@link cell}` to {@link previous}` using
-   * <Transactions.visibleStateForCellChanged>.
+   * Changes the visible state of {@link cell} to {@link previous} using {@link GraphDataModel.visibleStateForCellChanged}.
    */
   execute() {
     this.visible = this.previous;


### PR DESCRIPTION
Some JSDoc comments previously mention the `Transactions` class which doesn't exist. Use `GraphDataModel` instead.
The `Transactions` class had been temporarily introduced during the mxGraph migration, but had been removed prior the release of version 0.1.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated documentation references from `Transactions` to `GraphDataModel` across multiple files.
	- Simplified and clarified documentation comments in various classes, including the removal of unnecessary comments and default value descriptions.

- **Chores**
	- Marked unused constants `HIGHLIGHT_COLOR` and `CONNECT_TARGET_COLOR` for potential future removal.

These changes primarily enhance the clarity and accuracy of the project's documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->