### PR TITLE
refactor: reset more global configurations in stories

### DIFF
--- a/packages/core/src/serialization/codecs/StylesheetCodec.ts
+++ b/packages/core/src/serialization/codecs/StylesheetCodec.ts
@@ -37,8 +37,9 @@ export class StylesheetCodec extends ObjectCodec {
   }
 
   /**
-   * Static global switch that specifies if the use of eval is allowed for evaluating text content. Default is true.
+   * Static global switch that specifies if the use of eval is allowed for evaluating text content.
    * Set this to `false` if stylesheets may contain user input.
+   * @default true
    */
   static allowEval = true;
 


### PR DESCRIPTION
This will limit the side effects of a story's modification of a global configuration on other stories.

Do not reset the style registries (for shapes, perimeters, ...) at this time. Once they have been filled when initializing a Graph instance, they are not filled again when initializing a new Graph instance.

## Notes

Covers #418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated default setting information for evaluation functionality to enhance clarity.
  
- **Chores**
	- Enhanced reset functionality in the demonstration environment to ensure configuration settings return to their original state after each session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->