### PR TITLE
refactor!: remove unused domUtils.importNodeImplementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ They are replaced by global configuration in `EdgeHandlerConfig`:
   - removeEnabled --> removeBendOnShiftClickEnabled
   - virtualBendOpacity
   - virtualBendsEnabled
-
+- `domUtils.importNodeImplementation` has been removed because it was unused. It was only used internally in `mxGraph` and should not have been exposed.
 
 ## 0.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,12 @@ They are replaced by global configuration in `EdgeHandlerConfig`:
   - removeEnabled --> removeBendOnShiftClickEnabled
   - virtualBendOpacity
   - virtualBendsEnabled
-- `domUtils.importNodeImplementation` has been removed because it was unused. It was only used internally in `mxGraph` and should not have been exposed.
+- `domUtils.importNodeImplementation` has been removed:
+  - This function was only used internally in `mxGraph` to support older versions of IE
+  - It was not intended to be part of the public API
+  - No migration steps are needed as the function was unused
+
+
 
 ## 0.14.0
 

--- a/packages/core/src/util/domUtils.ts
+++ b/packages/core/src/util/domUtils.ts
@@ -298,51 +298,6 @@ export const importNode = (doc: Document, node: Element, allChildren: boolean) =
 };
 
 /**
- * Full DOM API implementation for importNode without using importNode API call.
- *
- * @param doc Document to import the node into.
- * @param node Node to be imported.
- * @param allChildren If all children should be imported.
- */
-export const importNodeImplementation = (
-  doc: Document,
-  node: Element,
-  allChildren: boolean
-) => {
-  switch (node.nodeType) {
-    case 1 /* element */: {
-      const newNode = doc.createElement(node.nodeName);
-
-      if (node.attributes && node.attributes.length > 0) {
-        for (let i = 0; i < node.attributes.length; i += 1) {
-          newNode.setAttribute(
-            node.attributes[i].nodeName,
-            <string>node.getAttribute(node.attributes[i].nodeName)
-          );
-        }
-      }
-
-      if (allChildren && node.childNodes && node.childNodes.length > 0) {
-        for (let i = 0; i < node.childNodes.length; i += 1) {
-          newNode.appendChild(
-            <Node>importNodeImplementation(doc, <Element>node.childNodes[i], allChildren)
-          );
-        }
-      }
-
-      return newNode;
-      break;
-    }
-    case 3: /* text */
-    case 4: /* cdata-section */
-    case 8 /* comment */: {
-      return doc.createTextNode(node.nodeValue || '');
-      break;
-    }
-  }
-};
-
-/**
  * Clears the current selection in the page.
  */
 export const clearSelection = () => {


### PR DESCRIPTION
In mxGraph, it was only used at a single place to "support older versions of IE".
https://github.com/jgraph/mxgraph/blob/ff141aab158417bd866e2dfebd06c61d40773cd2/javascript/src/js/util/mxSvgCanvas2D.js#L1270

BREAKING CHANGES: this function has been removed because it was unused.
It was only used internally in `mxGraph` and should not have been exposed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Removed unused `importNodeImplementation` function for clarity.
	- Replaced `EdgeHandler` properties with more descriptive global configurations.
	- Simplified node importing logic by using the native `importNode` method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->