### PR TITLE
chore: add a script to simplify version update on release

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,9 @@
   "private": false,
   "version": "0.14.0",
   "type": "module",
-  "sideEffects": ["**/*.css"],
+  "sideEffects": [
+    "**/*.css"
+  ],
   "description": "maxGraph is a fully client side JavaScript diagramming library that uses SVG and HTML for rendering.",
   "keywords": [
     "browser",

--- a/packages/core/src/Client.ts
+++ b/packages/core/src/Client.ts
@@ -22,6 +22,8 @@ class Client {
   /**
    * The version of the `maxGraph` library.
    */
+  // WARN: this constant is updated at release time by the script located at `scripts/update-versions.mjs`.
+  // So, if you modify the name of this file or this constant, please update the script accordingly.
   static VERSION = '0.14.0';
 
   /**

--- a/packages/website/docs/development/release.md
+++ b/packages/website/docs/development/release.md
@@ -35,8 +35,7 @@ Apply changes in the source code
   - Releases are done from the default branch, so all changes are done in the `main` branch.
   - These changes are going to be done locally, and then pushed to the repository.
   - Make sure that the code is up-to-date with the `main` branch. Run `git pull` to get the latest changes.
-- Update the version in `packages/core/package.json` and the `VERSION` constant in the `packages/core/src/Client.ts` file.
-- Update the `package-lock.json` file by running `npm install` at the root of the repository. It should only change the version of `@maxgraph/core`.
+- Update the version in various files by running, from the repository root: `node scripts/update-versions.mjs <version>` (replace `<version>` with the new version).
 - Update the `CHANGELOG` file to list the major changes included in the new version. Be generic and add a
 link to the future GitHub release that will contain detailed release notes, as shown below.
 ```

--- a/scripts/update-versions.mjs
+++ b/scripts/update-versions.mjs
@@ -1,0 +1,66 @@
+/*
+Copyright 2025-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: this script is intended to run as part of a GitHub workflow which is not installing the dependencies of the project.
+// So please, do not import code that is not provided by the node runtime. Otherwise, update the GitHub workflow definition
+import { readFileSync, writeFileSync } from 'node:fs';
+
+// run from the root of the repository: node scripts/update-versions.mjs 0.12.0.alpha-1
+const newVersion = process.argv[2];
+
+console.info('Updating version in various files, version:', newVersion);
+updateVersionInRootPackageLockJsonFile(newVersion);
+updateVersionInCorePackageJsonFile(newVersion);
+updateVersionInSourceFile(newVersion);
+console.info('Files have been updated');
+
+function updateVersionInRootPackageLockJsonFile(newVersion) {
+  const path = 'package-lock.json';
+  console.info('Updating', path);
+  const fileContent = readFileContent(path);
+  const packageJson = JSON.parse(fileContent);
+  packageJson.packages['packages/core'].version = newVersion;
+  writeJsonContentToFile(path, packageJson);
+}
+
+function updateVersionInCorePackageJsonFile(newVersion) {
+  const path = 'packages/core/package.json';
+  console.info('Updating', path);
+  const fileContent = readFileContent(path);
+  const packageJson = JSON.parse(fileContent);
+  packageJson.version = newVersion;
+  writeJsonContentToFile(path, packageJson);
+}
+
+function updateVersionInSourceFile(newVersion) {
+  const path = 'packages/core/src/Client.ts';
+  console.info('Updating', path);
+  const content = readFileContent(path);
+  // replace the 1st occurrence, this is OK as the constant appears only once in the file
+  const updatedContent = content.replace(
+    /static VERSION =.*/,
+    `static VERSION = '${newVersion}';`
+  );
+  writeFileSync(path, updatedContent);
+}
+
+function readFileContent(path) {
+  return readFileSync(path, 'utf8').toString();
+}
+
+function writeJsonContentToFile(path, obj) {
+  writeFileSync(path, JSON.stringify(obj, null, 2) + '\n');
+}


### PR DESCRIPTION
The script simplifies the update of the version in various files by running a single command, instead of modifying several files manually.

In addition, lint `packages/core/package.json` to not introduce changes when the file is updated by the script.

### Notes

Script logs
```
$ node scripts/update-versions.mjs 0.16.1
Updating version in various files, version: 0.16.1
Updating package-lock.json
Updating packages/core/package.json
Updating packages/core/src/Client.ts
Files have been updated
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Introduced an automated script for updating package versions across multiple files
	- Simplified version update process during release preparation
	- Reformatted package configuration for better readability

- **Documentation**
	- Updated release documentation with new version update instructions
	- Added comments in source files to guide version management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->