### PR TITLE
ci(release): fix api call to get milestone number

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -21,7 +21,7 @@ jobs:
           echo "Fetching milestone for version ${{ env.VERSION }}..."
           MILESTONE_NUMBER=$(gh api graphql -f query='
           query($version: String!) {
-           repository(owner: "${{ github.repository_owner }}", name: "${{ github.event.repository.name }}) {
+           repository(owner: "${{ github.repository_owner }}", name: "${{ github.event.repository.name }}") {
              milestones(first: 1, query: $version) {
                nodes { number }
              }


### PR DESCRIPTION
The query missed a double quote


## Notes

Detected during the 0.15.0 release

https://github.com/maxGraph/maxGraph/actions/runs/13025775559/job/36334496994#step:3:5
```
   MILESTONE_NUMBER=$(gh api graphql -f query='
  query($version: String!) {
   repository(owner: "maxGraph", name: "maxGraph) {
     milestones(first: 1, query: $version) {
       nodes { number }
     }
   }
  }' -f version="0.15.0" --jq '.data.repository.milestones.nodes[0].number')
  echo "Found milestone: ${MILESTONE_NUMBER}"
  echo "MILESTONE_NUMBER=${MILESTONE_NUMBER:-x}" >> $GITHUB_ENV
  shell: /usr/bin/bash -e {0}
  env:
    VERSION: 0.15.0
    GH_TOKEN: ***
Fetching milestone for version 0.15.0...
gh: Expected string or block string, but it was malformed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to fix GraphQL query syntax for creating releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->