### PR TITLE
docs: fix typo in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ _**Note:** Yet to be released breaking changes appear here._
 
 ## 0.15.0
 
-Release date: `2025-01-2ç`
+Release date: `2025-01-29`
 
 For more details, see the [0.15.0 Changelog](https://github.com/maxGraph/maxGraph/releases/tag/v0.15.0) on the GitHub release page.
 


### PR DESCRIPTION
The date of the 0.15.0 release contained a letter instead of a number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
	- Updated edge handling configuration with new property names
	- Removed deprecated edge handler properties
	- Removed internal utility method `domUtils.importNodeImplementation`

- **Documentation**
	- Updated changelog for version `0.15.0` with release date correction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->