### PR TITLE
docs: add a first blog post in the website

### DIFF
--- a/packages/website/blog/2025/02-12-looking-ahead-maxgraph-in-2025.md
+++ b/packages/website/blog/2025/02-12-looking-ahead-maxgraph-in-2025.md
@@ -40,7 +40,7 @@ maxGraph, as a fork of mxGraph, inherited some limitations—one being inefficie
 
 From the start, one of maxGraph’s goals has been to provide better tree-shaking support. Here’s how improvements have been made so far:
 
-In the initial release, Internet Explorer support was removed and custom code was replaced with modern ECMAScript APIs. This reduced the size of the library and prepared the ground for new improvements. 🔧
+In the initial release, Internet Explorer support was removed, and custom code was replaced with modern ECMAScript APIs. This reduced the size of the library and prepared the ground for new improvements. 🔧
 
 Subsequent notable releases brought further tree-shaking improvements, reducing the size of applications that don't use related features:
 
@@ -61,11 +61,11 @@ While there may be breaking changes, efforts will be made to minimize their impa
 
 ## Other Topics for 2025
 
-With documentation and tree-shaking optimizations underway, other important areas are also being addressed in 2025.
+With documentation and tree-shaking optimizations underway, several other key areas are also being addressed in 2025. 🔍 This list is not exhaustive, and additional improvements are likely to be implemented throughout the year.
 
 ### Stabilization and Bug Fixes
 
-Maintaining library stability is always a top priority. Issues will continue to be addressed and performance improvements will be made. 🛠️
+Maintaining library stability is always a top priority. Issues will continue to be addressed, and performance improvements will be made if required. 🛠️
 
 ### Defining the Public API
 

--- a/packages/website/blog/2025/02-12-looking-ahead-maxgraph-in-2025.md
+++ b/packages/website/blog/2025/02-12-looking-ahead-maxgraph-in-2025.md
@@ -44,9 +44,9 @@ In the initial release, Internet Explorer support was removed, and custom code w
 
 Subsequent notable releases brought further tree-shaking improvements, reducing the size of applications that don't use related features:
 
-- [v0.6.0](https://github.com/maxGraph/maxGraph/releases/tag/v0.6.0): Codecs are no longer registered by default.
-- [v0.11.0](https://github.com/maxGraph/maxGraph/releases/tag/v0.11.0): `MaxLog` and `MaxWindow` are no longer called directly, avoiding transitive inclusion.
-- [v0.12.0](https://github.com/maxGraph/maxGraph/releases/tag/v0.12.0): The npm package is declared without side effects.
+- Release [v0.6.0](https://github.com/maxGraph/maxGraph/releases/tag/v0.6.0): Codecs are no longer registered by default.
+- In [v0.11.0](https://github.com/maxGraph/maxGraph/releases/tag/v0.11.0): `MaxLog` and `MaxWindow` are no longer called directly, avoiding transitive inclusion.
+- With [v0.12.0](https://github.com/maxGraph/maxGraph/releases/tag/v0.12.0): The npm package is declared without side effects.
 
 ### What’s Next?
 
@@ -78,5 +78,5 @@ These plans are **not set in stone** but reflect goals and aspirations for **202
 
 👋 **See you next year** to review the progress made together! 🎉🚀
 
-*P.S. We're looking for contributors and maintainers to keep the project alive and kicking. Check out ****[Issue #354](https://github.com/maxGraph/maxGraph/issues/354)**** if you’re interested! 😄*
+*P.S. We're looking for contributors and maintainers to keep the project alive and kicking. Check out **[Issue #354](https://github.com/maxGraph/maxGraph/issues/354)** if you’re interested! 😄*
 

--- a/packages/website/blog/2025/02-12-looking-ahead-maxgraph-in-2025.md
+++ b/packages/website/blog/2025/02-12-looking-ahead-maxgraph-in-2025.md
@@ -1,0 +1,82 @@
+---
+title: "Looking Ahead: maxGraph in 2025"
+description: See what's next for maxGraph in 2025, from streamlined documentation to tree-shaking enhancements and API stabilization
+authors: tbouffard
+tags: [Roadmap]
+---
+
+2024 has been an exciting year for maxGraph! Strides have been made in improving the library, focusing on **documentation**, **tree-shaking**, and **bug fixes**, setting the stage for future enhancements. As 2025 approaches, here is a vision for the year ahead along with a recap of key milestones. 🚀✨
+
+Let's dive into what's been accomplished and what to expect next! 🎯
+
+
+<!-- truncate -->
+
+
+## Documentation and Examples: Making maxGraph Easier to Use
+
+The first major focus in 2024 has been on improving the documentation. With the release of [v0.15.0](https://github.com/maxGraph/maxGraph/releases/tag/v0.15.0), a significant milestone was achieved: the entire mxGraph manuals and tutorials have been integrated and adapted for maxGraph! 📚
+
+This integration ensures comprehensive, structured documentation that benefits from the maturity and experience of mxGraph. Additionally, more examples and demos have been added based on community feedback, making it easier to find relevant code snippets directly from most pages. 💡
+
+### What’s Next?
+
+The documentation journey will continue in 2025, focusing on the following areas:
+
+- Better organization of manuals and tutorials.
+- Creating a clear learning path for newcomers.
+- Ensuring consistency with existing usage documentation.
+
+This is a large topic that will be gradually implemented throughout 2025.
+
+☞ **Interested in contributing to the documentation?** Join the discussion about the documentation roadmap here: [#595](https://github.com/maxGraph/maxGraph/discussions/595)
+
+
+## Tree-Shaking: Shrinking the Library Size
+
+While documentation improvements have enhanced usability, optimizing tree-shaking has been equally important. 
+
+maxGraph, as a fork of mxGraph, inherited some limitations—one being inefficient tree-shaking. Regardless of which parts of mxGraph were used, it contributed about 811KB (minified) to application sizes.
+
+From the start, one of maxGraph’s goals has been to provide better tree-shaking support. Here’s how improvements have been made so far:
+
+In the initial release, Internet Explorer support was removed and custom code was replaced with modern ECMAScript APIs. This reduced the size of the library and prepared the ground for new improvements. 🔧
+
+Subsequent notable releases brought further tree-shaking improvements, reducing the size of applications that don't use related features:
+
+- [v0.6.0](https://github.com/maxGraph/maxGraph/releases/tag/v0.6.0): Codecs are no longer registered by default.
+- [v0.11.0](https://github.com/maxGraph/maxGraph/releases/tag/v0.11.0): `MaxLog` and `MaxWindow` are no longer called directly, avoiding transitive inclusion.
+- [v0.12.0](https://github.com/maxGraph/maxGraph/releases/tag/v0.12.0): The npm package is declared without side effects.
+
+### What’s Next?
+
+Despite these efforts, the contribution of maxGraph to application sizes remains significant (around 450 kB at minimum). Finding ways to reduce this footprint even further is a key goal. 📉
+
+Ongoing discussions and opportunities are described in [Issue #665: Strategies for Further Tree-Shaking Improvements](https://github.com/maxGraph/maxGraph/issues/665), outlining potential enhancements for 2025.
+
+To achieve more efficient tree-shaking, new methods of graph instantiation will be explored while maintaining the current mechanism for those who prefer the default setup, even if it results in a larger bundle size. This balance is necessary to ensure the library remains accessible for newcomers. ✨
+
+While there may be breaking changes, efforts will be made to minimize their impact. These changes will primarily target extension points rather than core functionalities, which will be preserved. The approach will be progressive and incremental across releases—no big bangs here!
+
+
+## Other Topics for 2025
+
+With documentation and tree-shaking optimizations underway, other important areas are also being addressed in 2025.
+
+### Stabilization and Bug Fixes
+
+Maintaining library stability is always a top priority. Issues will continue to be addressed and performance improvements will be made. 🛠️
+
+### Defining the Public API
+
+In mxGraph, everything was public, leading to frequent breaking changes with each improvement. 🔄 The goal is to clearly define what belongs in the public API and what is meant for extensions. This will help limit breaking changes and provide a more stable experience for users.
+
+
+## Wrapping Up
+
+These plans are **not set in stone** but reflect goals and aspirations for **2025**. Exciting developments lie ahead, and the journey continues with the support of the **community**. 🌟✨
+
+👋 **See you next year** to review the progress made together! 🎉🚀
+
+*P.S. We're looking for contributors and maintainers to keep the project alive and kicking. Check out ****[Issue #354](https://github.com/maxGraph/maxGraph/issues/354)**** if you’re interested! 😄*
+

--- a/packages/website/blog/authors.yml
+++ b/packages/website/blog/authors.yml
@@ -1,0 +1,7 @@
+tbouffard:
+  name: Thomas Bouffard
+  title: maxGraph maintainer
+  url: https://github.com/tbouffard
+  image_url: https://github.com/tbouffard.png
+  socials:
+    github: tbouffard

--- a/packages/website/docusaurus.config.ts
+++ b/packages/website/docusaurus.config.ts
@@ -3,6 +3,7 @@ import type { Config } from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 
 const baseUrl = '/maxGraph/';
+const editUrl = 'https://github.com/maxGraph/maxGraph/edit/main/packages/website/';
 
 const config: Config = {
   title: 'maxGraph',
@@ -44,10 +45,12 @@ const config: Config = {
     [
       'classic',
       {
+        blog: {
+          editUrl: editUrl,
+        },
         docs: {
           sidebarPath: './sidebars.ts',
-          // Remove this to remove the "edit this page" links.
-          editUrl: 'https://github.com/maxGraph/maxGraph/tree/main/packages/website/',
+          editUrl,
           showLastUpdateAuthor: false,
           showLastUpdateTime: true,
         },
@@ -80,20 +83,25 @@ const config: Config = {
       },
       items: [
         {
-          label: 'Documentation',
+          label: 'Docs',
           position: 'left',
           sidebarId: 'docsSidebar',
           type: 'docSidebar',
         },
         {
-          href: `${baseUrl}demo/`,
-          label: 'Demo',
+          href: `${baseUrl}api-docs/`,
+          label: 'API',
           position: 'left',
           target: '_blank',
         },
         {
-          href: `${baseUrl}api-docs/`,
-          label: 'API',
+          to: 'blog',
+          label: 'Blog',
+          position: 'left',
+        },
+        {
+          href: `${baseUrl}demo/`,
+          label: 'Demo',
           position: 'left',
           target: '_blank',
         },
@@ -115,13 +123,13 @@ const config: Config = {
               to: '/docs/intro',
             },
             {
-              href: `${baseUrl}demo/`,
-              label: 'Demo',
+              href: `${baseUrl}api-docs/`,
+              label: 'API Reference',
               target: '_blank',
             },
             {
-              href: `${baseUrl}api-docs/`,
-              label: 'API',
+              href: `${baseUrl}demo/`,
+              label: 'Demo',
               target: '_blank',
             },
           ],


### PR DESCRIPTION
This first blog post is an overview about what's been accomplished in 2024 and what to expect next in 2025.

A simple Docusaurus blog configuration has been initialized:
- global authors
- blog edit link

Additional website changes
- Fix regular docs page edit url: use an edit link, not a view link
- Change the order of items in navbar and in the footer after the introduction of the Blog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new blog post outlining future directions for maxGraph.
  - Introduced a new author profile for Thomas Bouffard to enrich community insights.

- **Documentation & Navigation Updates**
  - Enhanced website navigation with clearer labels and dedicated sections for Docs, Blog, and API.
  - Updated documentation configuration to improve the editing and content management experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->