### PR TITLE
fix(VertexHandler): display overlay when resizing a vertex

### DIFF
--- a/packages/core/src/view/handler/VertexHandler.ts
+++ b/packages/core/src/view/handler/VertexHandler.ts
@@ -689,12 +689,9 @@ class VertexHandler {
         this.preview = this.createSelectionShape(this.bounds);
 
         if (
-          !(
-            Client.IS_SVG &&
-            (this.state.style.rotation ?? 0) != 0 &&
-            this.state.text != null &&
-            this.state.text.node.parentNode === this.graph.container
-          )
+          !(Client.IS_SVG && (this.state.style.rotation ?? 0) != 0) &&
+          this.state.text != null &&
+          this.state.text.node.parentNode === this.graph.container
         ) {
           this.preview.dialect = DIALECT.STRICTHTML;
           this.preview.init(this.graph.container);


### PR DESCRIPTION
This was a regression introduced in c84ac314.


## Notes

Closes #666

[issue_666_fix.webm](https://github.com/user-attachments/assets/42bc7220-ad19-43d1-a717-295573f69104)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the logic for preview display to ensure a more consistent visual experience. This update simplifies the conditions for rendering previews, leading to more reliable and accurate presentation across different scenarios without impacting overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->