### PR TITLE
feat!: introduce global config for the Orthogonal connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ They had been made public by mistake, and had been considered internal since the
     - `stringUtils.getColor`
     - `stringUtils.getNumber`
     - `stringUtils.getStringValue`
+- `OrthConnector` is now configured with the global `OrthConnectorConfig` object.
+The following properties that were previously on `EdgeStyle` have moved to `OrthConnectorConfig`:
+  - `orthBuffer` to `buffer`
+  - `orthPointsFallback` to `pointsFallback`
+
 
 ## 0.15.1
 

--- a/packages/core/__tests__/view/style/config.test.ts
+++ b/packages/core/__tests__/view/style/config.test.ts
@@ -1,0 +1,34 @@
+/*
+Copyright 2025-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { expect, test } from '@jest/globals';
+import { OrthConnectorConfig, resetOrthConnectorConfig } from '../../../src';
+
+test('resetOrthConnectorConfig', () => {
+  // Keep track of original default values
+  const originalConfig = { ...OrthConnectorConfig };
+
+  // Change some values
+  OrthConnectorConfig.buffer = 18;
+  OrthConnectorConfig.pointsFallback = false;
+
+  resetOrthConnectorConfig();
+
+  // Ensure that the values have correctly been reset
+  expect(OrthConnectorConfig.buffer).toBe(10);
+  expect(OrthConnectorConfig.pointsFallback).toBeTruthy();
+  expect(OrthConnectorConfig).toStrictEqual(originalConfig);
+});

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -446,8 +446,8 @@ export type CellStateStyle = {
    */
   indicatorWidth?: number;
   /**
-   * The jetty size in {@link EdgeStyle.OrthConnector}.
-   * @default 10
+   * The jetty size in {@link EdgeStyle.OrthConnector} when {@link sourceJettySize} or {@link targetJettySize}.
+   * @default {@link OrthConnectorConfig.buffer}
    */
   jettySize?: number | 'auto';
   /**
@@ -482,6 +482,7 @@ export type CellStateStyle = {
    * The possible values are the functions defined in {@link EdgeStyle}.
    *
    * See {@link edgeStyle}.
+   * See {@link Graph.defaultLoopStyle}.
    */
   loopStyle?: EdgeStyleFunction;
   /**

--- a/packages/core/src/view/style/EdgeStyle.ts
+++ b/packages/core/src/view/style/EdgeStyle.ts
@@ -40,6 +40,7 @@ import { Loop as LoopFunction } from './edge/Loop';
 import { SegmentConnector as SegmentConnectorFunction } from './edge/Segment';
 import { SideToSide as SideToSideFunction } from './edge/SideToSide';
 import { TopToBottom as TopToBottomFunction } from './edge/TopToBottom';
+import { OrthConnectorConfig } from './config';
 
 /**
  * Provides various edge styles to be used as the values for `edgeStyle` in a cell style.
@@ -51,13 +52,13 @@ import { TopToBottom as TopToBottomFunction } from './edge/TopToBottom';
  * style.edgeStyle = EdgeStyle.ElbowConnector;
  * ```
  *
- * To write a custom edge style, a function can be added to the `EdgeStyle` object as follows.
+ * To write a custom edge style, create a function as follows.
  * In the example below, a right angle is created using a point on the horizontal center of the target vertex and the vertical center of the source vertex.
  * The code checks if that point intersects the source vertex and makes the edge straight if it does.
  * The point is then added into the result array, which acts as the return value of the function.
  *
  * ```javascript
- * EdgeStyle.MyStyle = (state, source, target, points, result) => {
+ * const MyStyle = (state, source, target, points, result) => {
  *   if (source && target) {
  *     const pt = new Point(target.getCenterX(), source.getCenterY());
  *
@@ -72,7 +73,7 @@ import { TopToBottom as TopToBottomFunction } from './edge/TopToBottom';
  *
  * The new edge style can then be registered in the {@link StyleRegistry} as follows:
  * ```javascript
- * StyleRegistry.putValue('myEdgeStyle', EdgeStyle.MyStyle);
+ * StyleRegistry.putValue('myEdgeStyle', MyStyle);
  * ```
  *
  * The custom edge style above can now be used in a specific edge as follows:
@@ -86,7 +87,7 @@ import { TopToBottom as TopToBottomFunction } from './edge/TopToBottom';
  * The custom EdgeStyle can be used for all edges in the graph as follows:
  *
  * ```javascript
- * let style = graph.getStylesheet().getDefaultEdgeStyle();
+ * const style = graph.getStylesheet().getDefaultEdgeStyle();
  * style.edgeStyle = EdgeStyle.MyStyle;
  * ```
  *
@@ -147,10 +148,6 @@ class EdgeStyle {
    * @param result Array of {@link Point} that represent the actual points of the edge.
    */
   static SegmentConnector = SegmentConnectorFunction;
-
-  static orthBuffer = 10;
-
-  static orthPointsFallback = true;
 
   static dirVectors = [
     [-1, 0],
@@ -249,10 +246,11 @@ class EdgeStyle {
   // mxEdgeStyle.SOURCE_MASK | mxEdgeStyle.TARGET_MASK,
 
   static getJettySize(state: CellState, isSource: boolean) {
+    const buffer = OrthConnectorConfig.buffer;
     let value =
       (isSource ? state.style.sourceJettySize : state.style.targetJettySize) ??
       state.style.jettySize ??
-      EdgeStyle.orthBuffer;
+      buffer;
 
     if (value === 'auto') {
       // Computes the automatic jetty size
@@ -261,11 +259,9 @@ class EdgeStyle {
       if (type !== NONE) {
         const size =
           (isSource ? state.style.startSize : state.style.endSize) ?? DEFAULT_MARKERSIZE;
-        value =
-          Math.max(2, Math.ceil((size + EdgeStyle.orthBuffer) / EdgeStyle.orthBuffer)) *
-          EdgeStyle.orthBuffer;
+        value = Math.max(2, Math.ceil((size + buffer) / buffer)) * buffer;
       } else {
-        value = 2 * EdgeStyle.orthBuffer;
+        value = 2 * buffer;
       }
     }
 
@@ -335,7 +331,9 @@ class EdgeStyle {
 
     if (
       tooShort ||
-      (EdgeStyle.orthPointsFallback && controlHints != null && controlHints.length > 0) ||
+      (OrthConnectorConfig.pointsFallback &&
+        controlHints != null &&
+        controlHints.length > 0) ||
       sourceEdge ||
       targetEdge
     ) {

--- a/packages/core/src/view/style/config.ts
+++ b/packages/core/src/view/style/config.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import { ENTITY_SEGMENT } from '../../util/Constants';
+import { shallowCopy } from '../../util/cloneUtils';
 
 /**
  * Configure the `Entity Relation connector` defaults for maxGraph.
@@ -42,4 +43,41 @@ export const EntityRelationConnectorConfig = {
 export const resetEntityRelationConnectorConfig = (): void => {
   // implement the reset manually as there are a few properties for now
   EntityRelationConnectorConfig.segment = ENTITY_SEGMENT;
+};
+
+/**
+ * Configure the {@link OrthConnector}.
+ *
+ * @experimental subject to change or removal. maxGraph's global configuration may be modified in the future without prior notice.
+ * @since 0.16.0
+ * @category Configuration
+ */
+export const OrthConnectorConfig = {
+  /**
+   * If the value is not set in {@link CellStateStyle.jettySize}, defines the jetty size of the connector.
+   *
+   * If the computed value of the jetty size coming from {@link CellStateStyle} is 'auto', it is used in the computation of the automatic jetty size.
+   * See the implementation of {@link OrthConnector} for more details.
+   *
+   * @default 10
+   */
+  buffer: 10,
+
+  /**
+   * See the implementation of {@link OrthConnector} for more details.
+   * @default true
+   */
+  pointsFallback: true,
+};
+
+const originalOrthConnectorConfig = { ...OrthConnectorConfig };
+/**
+ * Resets {@link OrthConnectorConfig} to default values.
+ *
+ * @experimental Subject to change or removal. maxGraph's global configuration may be modified in the future without prior notice.
+ * @since 0.16.0
+ * @category Configuration
+ */
+export const resetOrthConnectorConfig = (): void => {
+  shallowCopy(originalOrthConnectorConfig, OrthConnectorConfig);
 };

--- a/packages/html/.storybook/preview.ts
+++ b/packages/html/.storybook/preview.ts
@@ -5,6 +5,7 @@ import {
   resetEdgeHandlerConfig,
   resetEntityRelationConnectorConfig,
   resetHandleConfig,
+  resetOrthConnectorConfig,
   resetStyleDefaultsConfig,
   resetVertexHandlerConfig,
 } from '@maxgraph/core';
@@ -22,6 +23,7 @@ const resetMaxGraphConfigs = (): void => {
   resetEdgeHandlerConfig();
   resetEntityRelationConnectorConfig();
   resetHandleConfig();
+  resetOrthConnectorConfig();
   resetStyleDefaultsConfig();
   resetVertexHandlerConfig();
 };

--- a/packages/website/docs/usage/global-configuration.md
+++ b/packages/website/docs/usage/global-configuration.md
@@ -14,20 +14,24 @@ The following objects can be used to configure `maxGraph` globally:
 
   - `Client`: this is the historical entry point for global configuration, coming from the `mxGraph` library.
   - `EdgeHandlerConfig` (since 0.14.0): for `EdgeHandler` (including subclasses).
-  - `EntityRelationConnectorConfig` (since 0.15.0): for the `EntityRelation` Connector/EdgeStyle.
   - `GlobalConfig` (since 0.11.0): for shared resources (logger).
   - `HandleConfig` (since 0.14.0): for shared handle configurations.
   - `StencilShapeConfig` (since 0.11.0): for stencil shapes.
   - `StyleDefaultsConfig` (since 0.14.0): for the default values of the Cell styles.
   - `VertexHandlerConfig` (since 0.12.0): for `VertexHandler`.
+  - For Connectors/EdgeStyles:
+    - `EntityRelationConnectorConfig` (since 0.15.0): for `EntityRelation`.
+    - `OrthConnectorConfig` (since 0.16.0): for `OrthConnector`.
 
 Some functions are provided to reset the global configuration to the default values. For example:
 
   - `resetEdgeHandlerConfig` (since 0.14.0)
-  - `resetEntityRelationConnectorConfig` (since 0.15.0)
   - `resetHandleConfig` (since 0.14.0)
   - `resetStyleDefaultsConfig` (since 0.14.0)
   - `resetVertexHandlerConfig` (since 0.14.0)
+  - For Connectors/EdgeStyles:
+    - `resetEntityRelationConnectorConfig` (since 0.15.0)
+    - `resetOrthConnectorConfig` (since 0.16.0)
 
 :::note
 Notice that the new global configuration elements introduced as version _0.11.0_ are experimental and are subject to change in future versions.


### PR DESCRIPTION
Introduce a dedicated `OrthConnectorConfig` global object and its companion reset function.

Also improve the CellStateStyle JSDoc, in particular about the jetty size properties.

BREAKING CHANGES: `OrthConnector` is now configured with the global `OrthConnectorConfig` object.
The following properties that were previously hold by `EdgeStyle` have moved to `OrthConnectorConfig`:
- `orthBuffer` to `buffer`
- `orthPointsFallback` to `pointsFallback`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a centralized configuration for connector settings, offering enhanced customization.
- **Documentation**
	- Updated global configuration guides to include new connector options and reset functionality.
- **Refactor**
	- Streamlined internal utilities and migrated connector properties into a unified configuration for improved clarity.
- **Tests**
	- Implemented tests to ensure the connector configuration reset works correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->