### PR TITLE
refactor!: remove `Client.isBrowserSupported`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ They had been made public by mistake, and had been considered internal since the
     - `stringUtils.getColor`
     - `stringUtils.getNumber`
     - `stringUtils.getStringValue`
-- `Client.isBrowserSupported` has been removed. It didn't correctly validate all prerequisites require to know if the browser supports maxGraph.
+- `Client.isBrowserSupported` has been removed. It didn't correctly validate all prerequisites required to know if the browser supports maxGraph.
 So, remove it without replacement.
 
 ## 0.15.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ They had been made public by mistake, and had been considered internal since the
     - `stringUtils.getColor`
     - `stringUtils.getNumber`
     - `stringUtils.getStringValue`
+- `Client.isBrowserSupported` has been removed. It didn't correctly validate all prerequisites require to know if the browser supports maxGraph.
+So, remove it without replacement.
 
 ## 0.15.1
 

--- a/packages/core/src/Client.ts
+++ b/packages/core/src/Client.ts
@@ -263,23 +263,6 @@ class Client {
     typeof window !== 'undefined' &&
     document.location.href.indexOf('http://') < 0 &&
     document.location.href.indexOf('https://') < 0;
-
-  /**
-   * Returns true if the current browser is supported, that is, if
-   * <Client.IS_SVG> is true.
-   *
-   * Example:
-   *
-   * ```javascript
-   * if (!Client.isBrowserSupported())
-   * {
-   *   mxUtils.error('Browser is not supported!', 200, false);
-   * }
-   * ```
-   */
-  static isBrowserSupported = () => {
-    return Client.IS_SVG;
-  };
 }
 
 export default Client;

--- a/packages/html/stories/Drop.stories.js
+++ b/packages/html/stories/Drop.stories.js
@@ -21,7 +21,6 @@ import {
   styleUtils,
   eventUtils,
   InternalEvent,
-  Client,
   xmlUtils,
 } from '@maxgraph/core';
 


### PR DESCRIPTION
BREAKING CHANGES: This function didn't correctly validate all prerequisites require to know if the browser supports
maxGraph. So, remove it without replacement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Streamlined the library by retiring outdated utilities and simplifying the public interface.
- **Bug Fixes**
  - Removed an inaccurate browser compatibility check from the drag-and-drop file handling, ensuring that files are processed consistently across environments. 
  - Eliminated the `isBrowserSupported` method, which previously provided unreliable browser support validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->