### PR TITLE
refactor!: move `VERSION` to `constants`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ They had been made public by mistake, and had been considered internal since the
     - `stringUtils.getColor`
     - `stringUtils.getNumber`
     - `stringUtils.getStringValue`
+- `Client.VERSION` moved to `constants.VERSION`. VERSION is supposed to be immutable as it represents the actual version of maxGraph.
+When it was stored in Client, it was a static property that could be modified. Moving it to "constants" ensure that it cannot be modified.
 
 ## 0.15.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ They had been made public by mistake, and had been considered internal since the
 - `Client.isBrowserSupported` has been removed. It didn't correctly validate all prerequisites required to know if the browser supports maxGraph.
 So, remove it without replacement.
 - `Client.VERSION` moved to `constants.VERSION`. VERSION is supposed to be immutable as it represents the actual version of maxGraph.
-When it was stored in Client, it was a static property that could be modified. Moving it to "constants" ensure that it cannot be modified.
+When it was stored in Client, it was a static property that could be modified. Moving it to the constants module ensures that it cannot be modified.
 
 ## 0.15.1
 

--- a/packages/core/src/Client.ts
+++ b/packages/core/src/Client.ts
@@ -20,13 +20,6 @@ import { NS_SVG } from './util/Constants';
 
 class Client {
   /**
-   * The version of the `maxGraph` library.
-   */
-  // WARN: this constant is updated at release time by the script located at `scripts/update-versions.mjs`.
-  // So, if you modify the name of this file or this constant, please update the script accordingly.
-  static VERSION = '0.15.1';
-
-  /**
    * Base path for all URLs in the core without trailing slash.
    *
    * When using a relative path, the path is relative to the URL of the page that contains the assignment. Trailing slashes are automatically removed.

--- a/packages/core/src/gui/MaxLog.ts
+++ b/packages/core/src/gui/MaxLog.ts
@@ -24,6 +24,7 @@ import MaxWindow, { popup } from './MaxWindow';
 import { KeyboardEventListener, MouseEventListener } from '../types';
 import { copyTextToClipboard } from '../util/Utils';
 import { getElapseMillisecondsMessage } from '../util/logger';
+import { VERSION } from '../util/Constants';
 
 /**
  * A singleton class that implements a simple console.
@@ -40,7 +41,7 @@ class MaxLog {
    */
   static init(): void {
     if (MaxLog.window == null && document.body != null) {
-      const title = `${MaxLog.consoleName} - mxGraph ${Client.VERSION}`;
+      const title = `${MaxLog.consoleName} - mxGraph ${VERSION}`;
 
       // Creates a table that maintains the layout
       const table = document.createElement('table');

--- a/packages/core/src/util/Constants.ts
+++ b/packages/core/src/util/Constants.ts
@@ -19,7 +19,7 @@ limitations under the License.
 /**
  * The version of the `maxGraph` library.
  */
-// WARN: this constant is updated at release time by the script located at `scripts/update-versions.mjs`.
+// WARN: this constant is updated at release time by the script located at 'scripts/update-versions.mjs'.
 // So, if you modify the name of this file or this constant, please update the script accordingly.
 export const VERSION = '0.15.1';
 

--- a/packages/core/src/util/Constants.ts
+++ b/packages/core/src/util/Constants.ts
@@ -17,6 +17,13 @@ limitations under the License.
 */
 
 /**
+ * The version of the `maxGraph` library.
+ */
+// WARN: this constant is updated at release time by the script located at `scripts/update-versions.mjs`.
+// So, if you modify the name of this file or this constant, please update the script accordingly.
+export const VERSION = '0.15.1';
+
+/**
  * Defines the portion of the cell which is to be used as a connectable
  * region. Default is 0.3. Possible values are 0 < x <= 1.
  */

--- a/packages/js-example-without-defaults/src/index.js
+++ b/packages/js-example-without-defaults/src/index.js
@@ -17,7 +17,6 @@ limitations under the License.
 import './style.css';
 import {
   CellRenderer,
-  Client,
   constants,
   Graph,
   InternalEvent,
@@ -105,7 +104,7 @@ const initializeGraph = (container) => {
 
 // display the maxGraph version in the footer
 const footer = document.querySelector('footer');
-footer.innerText = `Built with maxGraph ${Client.VERSION}`;
+footer.innerText = `Built with maxGraph ${constants.VERSION}`;
 
 // Creates the graph inside the given container
 initializeGraph(document.querySelector('#graph-container'));

--- a/packages/js-example/src/index.js
+++ b/packages/js-example/src/index.js
@@ -17,7 +17,7 @@ limitations under the License.
 import '@maxgraph/core/css/common.css';
 import './style.css';
 import {
-  Client,
+  constants,
   DomHelpers,
   getDefaultPlugins,
   Graph,
@@ -74,7 +74,7 @@ const initializeGraph = (container) => {
 
 // display the maxGraph version in the footer
 const footer = document.querySelector('footer');
-footer.innerText = `Built with maxGraph ${Client.VERSION}`;
+footer.innerText = `Built with maxGraph ${constants.VERSION}`;
 
 // Creates the graph inside the given container
 const container = document.querySelector('#graph-container');

--- a/packages/ts-example-without-defaults/src/main.ts
+++ b/packages/ts-example-without-defaults/src/main.ts
@@ -17,7 +17,6 @@ limitations under the License.
 import './style.css';
 import {
   CellRenderer,
-  Client,
   constants,
   Graph,
   InternalEvent,
@@ -105,7 +104,7 @@ const initializeGraph = (container: HTMLElement) => {
 
 // display the maxGraph version in the footer
 const footer = <HTMLElement>document.querySelector('footer');
-footer.innerText = `Built with maxGraph ${Client.VERSION}`;
+footer.innerText = `Built with maxGraph ${constants.VERSION}`;
 
 // Creates the graph inside the given container
 initializeGraph(<HTMLElement>document.querySelector('#graph-container'));

--- a/packages/ts-example/src/main.ts
+++ b/packages/ts-example/src/main.ts
@@ -17,7 +17,6 @@ limitations under the License.
 import '@maxgraph/core/css/common.css'; // required by RubberBandHandler
 import './style.css';
 import {
-  Client,
   constants,
   getDefaultPlugins,
   Graph,
@@ -116,7 +115,7 @@ const initializeGraph = (container: HTMLElement) => {
 
 // display the maxGraph version in the footer
 const footer = <HTMLElement>document.querySelector('footer');
-footer.innerText = `Built with maxGraph ${Client.VERSION}`;
+footer.innerText = `Built with maxGraph ${constants.VERSION}`;
 
 // Creates the graph inside the given container
 initializeGraph(<HTMLElement>document.querySelector('#graph-container'));

--- a/packages/ts-support/src/index.ts
+++ b/packages/ts-support/src/index.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Client, Graph, InternalEvent } from '@maxgraph/core';
+import { constants, Graph, InternalEvent } from '@maxgraph/core';
 
-const version = Client.VERSION;
+const version = constants.VERSION;
 
 // Creates the graph inside the given container
 const container = <HTMLElement>document.getElementById('graph-container');

--- a/scripts/update-versions.mjs
+++ b/scripts/update-versions.mjs
@@ -46,13 +46,13 @@ function updateVersionInCorePackageJsonFile(newVersion) {
 }
 
 function updateVersionInSourceFile(newVersion) {
-  const path = 'packages/core/src/Client.ts';
+  const path = 'packages/core/src/util/Constants.ts';
   console.info('Updating', path);
   const content = readFileContent(path);
   // replace the 1st occurrence, this is OK as the constant appears only once in the file
   const updatedContent = content.replace(
-    /static VERSION =.*/,
-    `static VERSION = '${newVersion}';`
+    /const VERSION =.*/,
+    `const VERSION = '${newVersion}';`
   );
   writeFileSync(path, updatedContent);
 }


### PR DESCRIPTION
BREAKING CHANGES: `Client.VERSION` moved to `constants.VERSION`. VERSION is supposed to be immutable as it represents the actual version of maxGraph.
When it was stored in Client, it was a static property that could be modified.
Moving it to the constants module ensures that it cannot be modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Centralized version management now ensures a consistent and immutable display of maxGraph’s version across the application and example projects.
  - Legacy utility methods and browser support checks have been removed in favor of modern language features, streamlining the codebase and dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->