### PR TITLE
refactor: rename `OrthConnectorConfig` to `OrthogonalConnectorConfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,8 @@ The following properties that were previously on `EdgeStyle` have moved to `Manh
   - `MANHATTAN_MAXIMUM_LOOPS` to `maxLoops`
   - `MANHATTAN_START_DIRECTIONS` to `startDirections`
   - `MANHATTAN_STEP` to `step`
-- `OrthConnector` is now configured with the global `OrthConnectorConfig` object.
-The following properties that were previously on `EdgeStyle` have moved to `OrthConnectorConfig`:
+- `OrthConnector` is now configured with the global `OrthogonalConnectorConfig` object.
+The following properties that were previously on `EdgeStyle` have moved to `OrthogonalConnectorConfig`:
   - `orthBuffer` to `buffer`
   - `orthPointsFallback` to `pointsFallback`
 

--- a/packages/core/__tests__/view/style/config.test.ts
+++ b/packages/core/__tests__/view/style/config.test.ts
@@ -17,26 +17,26 @@ limitations under the License.
 import { describe, expect, test } from '@jest/globals';
 import {
   ManhattanConnectorConfig,
-  OrthConnectorConfig,
+  OrthogonalConnectorConfig,
   resetManhattanConnectorConfig,
-  resetOrthConnectorConfig,
+  resetOrthogonalConnectorConfig,
 } from '../../../src';
 import { DIRECTION } from '../../../src/util/Constants';
 
-test('resetOrthConnectorConfig', () => {
+test('resetOrthogonalConnectorConfig', () => {
   // Keep track of original default values
-  const originalConfig = { ...OrthConnectorConfig };
+  const originalConfig = { ...OrthogonalConnectorConfig };
 
   // Change some values
-  OrthConnectorConfig.buffer = 18;
-  OrthConnectorConfig.pointsFallback = false;
+  OrthogonalConnectorConfig.buffer = 18;
+  OrthogonalConnectorConfig.pointsFallback = false;
 
-  resetOrthConnectorConfig();
+  resetOrthogonalConnectorConfig();
 
   // Ensure that the values have correctly been reset
-  expect(OrthConnectorConfig.buffer).toBe(10);
-  expect(OrthConnectorConfig.pointsFallback).toBeTruthy();
-  expect(OrthConnectorConfig).toStrictEqual(originalConfig);
+  expect(OrthogonalConnectorConfig.buffer).toBe(10);
+  expect(OrthogonalConnectorConfig.pointsFallback).toBeTruthy();
+  expect(OrthogonalConnectorConfig).toStrictEqual(originalConfig);
 });
 
 describe('resetManhattanConnectorConfig', () => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -447,7 +447,7 @@ export type CellStateStyle = {
   indicatorWidth?: number;
   /**
    * The jetty size in {@link EdgeStyle.OrthConnector} when {@link sourceJettySize} or {@link targetJettySize}.
-   * @default {@link OrthConnectorConfig.buffer}
+   * @default {@link OrthogonalConnectorConfig.buffer}
    */
   jettySize?: number | 'auto';
   /**

--- a/packages/core/src/view/style/config.ts
+++ b/packages/core/src/view/style/config.ts
@@ -53,7 +53,7 @@ export const resetEntityRelationConnectorConfig = (): void => {
  * @since 0.16.0
  * @category Configuration
  */
-export const OrthConnectorConfig = {
+export const OrthogonalConnectorConfig = {
   /**
    * If the value is not set in {@link CellStateStyle.jettySize}, defines the jetty size of the connector.
    *
@@ -71,16 +71,16 @@ export const OrthConnectorConfig = {
   pointsFallback: true,
 };
 
-const originalOrthConnectorConfig = { ...OrthConnectorConfig };
+const originalOrthogonalConnectorConfig = { ...OrthogonalConnectorConfig };
 /**
- * Resets {@link OrthConnectorConfig} to default values.
+ * Resets {@link OrthogonalConnectorConfig} to default values.
  *
  * @experimental Subject to change or removal. maxGraph's global configuration may be modified in the future without prior notice.
  * @since 0.16.0
  * @category Configuration
  */
-export const resetOrthConnectorConfig = (): void => {
-  shallowCopy(originalOrthConnectorConfig, OrthConnectorConfig);
+export const resetOrthogonalConnectorConfig = (): void => {
+  shallowCopy(originalOrthogonalConnectorConfig, OrthogonalConnectorConfig);
 };
 
 export type ManhattanConnectorConfigType = {

--- a/packages/core/src/view/style/edge/Orthogonal.ts
+++ b/packages/core/src/view/style/edge/Orthogonal.ts
@@ -24,7 +24,7 @@ import {
   reversePortConstraints,
 } from '../../../util/mathUtils';
 import type CellState from '../../cell/CellState';
-import { OrthConnectorConfig } from '../config';
+import { OrthogonalConnectorConfig } from '../config';
 import type { EdgeStyleFunction } from '../../../types';
 import Point from '../../geometry/Point';
 import Rectangle from '../../geometry/Rectangle';
@@ -119,7 +119,7 @@ const VERTEX_MASK = 3072;
 // SOURCE_MASK | TARGET_MASK,
 
 function getJettySize(state: CellState, isSource: boolean): number {
-  const buffer = OrthConnectorConfig.buffer;
+  const buffer = OrthogonalConnectorConfig.buffer;
   let value =
     (isSource ? state.style.sourceJettySize : state.style.targetJettySize) ??
     state.style.jettySize ??
@@ -204,7 +204,7 @@ export const OrthogonalConnector: EdgeStyleFunction = (
 
   if (
     tooShort ||
-    (OrthConnectorConfig.pointsFallback &&
+    (OrthogonalConnectorConfig.pointsFallback &&
       controlHints != null &&
       controlHints.length > 0) ||
     sourceEdge ||

--- a/packages/html/.storybook/preview.ts
+++ b/packages/html/.storybook/preview.ts
@@ -6,7 +6,7 @@ import {
   resetEntityRelationConnectorConfig,
   resetHandleConfig,
   resetManhattanConnectorConfig,
-  resetOrthConnectorConfig,
+  resetOrthogonalConnectorConfig,
   resetStyleDefaultsConfig,
   resetVertexHandlerConfig,
 } from '@maxgraph/core';
@@ -25,7 +25,7 @@ const resetMaxGraphConfigs = (): void => {
   resetEntityRelationConnectorConfig();
   resetHandleConfig();
   resetManhattanConnectorConfig();
-  resetOrthConnectorConfig();
+  resetOrthogonalConnectorConfig();
   resetStyleDefaultsConfig();
   resetVertexHandlerConfig();
 };

--- a/packages/website/docs/usage/global-configuration.md
+++ b/packages/website/docs/usage/global-configuration.md
@@ -22,7 +22,7 @@ The following objects can be used to configure `maxGraph` globally:
   - For Connectors/EdgeStyles:
     - `EntityRelationConnectorConfig` (since 0.15.0): for `EntityRelation`.
     - `ManhattanConnectorConfig` (since 0.16.0): for `ManhattanConnector`.
-    - `OrthConnectorConfig` (since 0.16.0): for `OrthConnector`.
+    - `OrthogonalConnectorConfig` (since 0.16.0): for `OrthConnector`.
 
 Some functions are provided to reset the global configuration to the default values. For example:
 
@@ -33,7 +33,7 @@ Some functions are provided to reset the global configuration to the default val
   - For Connectors/EdgeStyles:
     - `resetEntityRelationConnectorConfig` (since 0.15.0)
     - `resetManhattanConnectorConfig` (since 0.16.0)
-    - `resetOrthConnectorConfig` (since 0.16.0)
+    - `resetOrthogonalConnectorConfig` (since 0.16.0)
 
 :::note
 Notice that the new global configuration elements introduced as version _0.11.0_ are experimental and are subject to change in future versions.


### PR DESCRIPTION
The old name was used to match the current name of `OrthConnector`, but as it's more readable not to use abbreviated names, it will be renamed to `OrthogonalConnector` in the future.

So, rename the configuration object now to limit future breaks (it's not included in any version yet).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined global configuration settings by standardizing naming conventions and retiring legacy utility interfaces. Users should now leverage native language features for handling default values and optional access.

- **Documentation**
  - Updated user documentation to reflect the revised configuration defaults and naming conventions.

- **Tests**
  - Adjusted test cases to validate and support the new configuration structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->