### PR TITLE
feat: provide i18n default resources

### DIFF
--- a/packages/core/i18n/editor.txt
+++ b/packages/core/i18n/editor.txt
@@ -1,0 +1,5 @@
+askZoom=Enter zoom (%)
+properties=Properties
+outline=Outline
+tasks=Tasks
+help=Help

--- a/packages/core/i18n/editor_de.txt
+++ b/packages/core/i18n/editor_de.txt
@@ -1,0 +1,5 @@
+askZoom=Zoom eingeben (%)
+properties=Eigenschaften
+outline=Uebersicht
+tasks=Aufgaben
+help=Hilfe

--- a/packages/core/i18n/editor_zh.txt
+++ b/packages/core/i18n/editor_zh.txt
@@ -1,0 +1,5 @@
+askZoom=进入缩放(%25)
+properties=属性
+outline=轮廓
+tasks=任务
+help=帮助

--- a/packages/core/i18n/graph.txt
+++ b/packages/core/i18n/graph.txt
@@ -1,0 +1,11 @@
+alreadyConnected=Nodes already connected
+containsValidationErrors=Contains validation errors
+updatingDocument=Updating Document. Please wait...
+updatingSelection=Updating Selection. Please wait...
+collapse-expand=Collapse/Expand
+doubleClickOrientation=Doubleclick to change orientation
+close=Close
+error=Error
+done=Done
+cancel=Cancel
+ok=OK

--- a/packages/core/i18n/graph_de.txt
+++ b/packages/core/i18n/graph_de.txt
@@ -1,0 +1,11 @@
+alreadyConnected=Knoten schon verbunden
+containsValidationErrors=Enthält Validierungsfehler
+updatingDocument=Aktualisiere Dokument. Bitte warten...
+updatingSelection=Aktualisiere Markierung. Bitte warten...
+collapse-expand=Einklappen/Ausklappen
+doubleClickOrientation=Doppelklicken um Orientierung zu ändern
+close=Schliessen
+error=Fehler
+done=Fertig
+cancel=Abbrechen
+ok=OK

--- a/packages/core/i18n/graph_zh.txt
+++ b/packages/core/i18n/graph_zh.txt
@@ -1,0 +1,11 @@
+alreadyConnected=节点已经连接
+containsValidationErrors=包含效验错误
+updatingDocument=更新文档。请等候......
+updatingSelection=更新所选项。请等候......
+collapse-expand=折叠/展开
+doubleClickOrientation=双击以改变方向
+close=关闭
+error=错误
+done=完成
+cancel=取消
+ok=确定

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,7 @@
     },
     "./css/*": "./css/*",
     "./images/*": "./images/*",
+    "./i18n/*": "./i18n/*",
     "./package.json": "./package.json",
     "./xsd/*": "./xsd/*"
   },
@@ -33,6 +34,7 @@
     "css",
     "lib",
     "images",
+    "i18n",
     "xsd"
   ],
   "homepage": "https://github.com/maxGraph/maxGraph",

--- a/packages/core/src/util/Translations.ts
+++ b/packages/core/src/util/Translations.ts
@@ -38,7 +38,7 @@ import type MaxXmlRequest from './MaxXmlRequest';
  * {@link add} or via a resource tag in the UI section of the
  * editor configuration file, eg:
  *
- * ```javascript
+ * ```xml
  * <Editor>
  *   <ui>
  *     <resource basename="examples/resources/mxWorkflow"/>
@@ -66,13 +66,9 @@ import type MaxXmlRequest from './MaxXmlRequest';
  * See {@link resourcesEncoded} to disable this. If you disable this, make sure that
  * your files are UTF-8 encoded.
  *
- * ## Asynchronous loading
+ * ## Loading default resources
  *
- * TODO the following is taken from mxGraph and is probably no longer accurate
- *
- * By default, the core adds two resource files synchronously at load time.
- * To load these files asynchronously, set {@link LoadResources} to false
- * before loading Client and use {@link loadResources} instead.
+ * Call {@link loadResources} to load the default resources file for both {@link Graph} and {@link Editor}.
  */
 class Translations {
   /*

--- a/packages/core/src/view/GraphSelectionModel.ts
+++ b/packages/core/src/view/GraphSelectionModel.ts
@@ -77,20 +77,22 @@ class GraphSelectionModel extends EventSource {
   /**
    * Specifies the resource key for the status message after a long operation.
    * If the resource for this key does not exist then the value is used as
-   * the status message. Default is 'done'.
+   * the status message.
+   * @default 'done'
    */
   doneResource = Client.language !== 'none' ? 'done' : '';
 
   /**
    * Specifies the resource key for the status message while the selection is
    * being updated. If the resource for this key does not exist then the
-   * value is used as the status message. Default is 'updatingSelection'.
+   * value is used as the status message.
+   * @default 'updatingSelection'
    */
   updatingSelectionResource = Client.language !== 'none' ? 'updatingSelection' : '';
 
   /**
    * Specifies if only one selected item at a time is allowed.
-   * Default is false.
+   * @default false.
    */
   singleSelection = false;
 

--- a/packages/core/src/view/GraphView.ts
+++ b/packages/core/src/view/GraphView.ts
@@ -117,14 +117,16 @@ export class GraphView extends EventSource {
   /**
    * Specifies the resource key for the status message after a long operation.
    * If the resource for this key does not exist then the value is used as
-   * the status message. Default is 'done'.
+   * the status message.
+   * @default 'done'
    */
   doneResource = Client.language !== 'none' ? 'done' : '';
 
   /**
    * Specifies the resource key for the status message while the document is
    * being updated. If the resource for this key does not exist then the
-   * value is used as the status message. Default is 'updatingDocument'.
+   * value is used as the status message.
+   * @default 'updatingSelection'
    */
   updatingDocumentResource = Client.language !== 'none' ? 'updatingDocument' : '';
 

--- a/packages/html/.storybook/preview.ts
+++ b/packages/html/.storybook/preview.ts
@@ -20,13 +20,10 @@ const defaultLogger = new NoOpLogger();
 // defaultLogger.debugEnabled = true;
 // defaultLogger.traceEnabled = true;
 
-console.warn('@@@@preview.ts - loading i18n resources for Graph...');
+defaultLogger.info('[sb-config] Loading i18n resources for Graph...');
 Translations.add(`${Client.basePath}/i18n/graph`, null, (): void => {
-  console.warn('@@@@preview.ts - i18n resources loaded for Graph');
+  defaultLogger.info('[sb-config] i18n resources loaded for Graph');
 });
-// Translations.loadResources((): void => {
-//   console.warn('@@@@preview.ts - i18n resources loaded');
-// });
 
 const resetMaxGraphConfigs = (): void => {
   GlobalConfig.logger = defaultLogger;

--- a/packages/html/.storybook/preview.ts
+++ b/packages/html/.storybook/preview.ts
@@ -1,5 +1,6 @@
 import type { Preview } from '@storybook/html';
 import {
+  Client,
   GlobalConfig,
   NoOpLogger,
   resetEdgeHandlerConfig,
@@ -9,6 +10,7 @@ import {
   resetOrthogonalConnectorConfig,
   resetStyleDefaultsConfig,
   resetVertexHandlerConfig,
+  Translations,
 } from '@maxgraph/core';
 
 const defaultLogger = new NoOpLogger();
@@ -17,6 +19,14 @@ const defaultLogger = new NoOpLogger();
 // defaultLogger.infoEnabled = true;
 // defaultLogger.debugEnabled = true;
 // defaultLogger.traceEnabled = true;
+
+console.warn('@@@@preview.ts - loading i18n resources for Graph...');
+Translations.add(`${Client.basePath}/i18n/graph`, null, (): void => {
+  console.warn('@@@@preview.ts - i18n resources loaded for Graph');
+});
+// Translations.loadResources((): void => {
+//   console.warn('@@@@preview.ts - i18n resources loaded');
+// });
 
 const resetMaxGraphConfigs = (): void => {
   GlobalConfig.logger = defaultLogger;

--- a/packages/html/public/i18n/editor.txt
+++ b/packages/html/public/i18n/editor.txt
@@ -1,0 +1,5 @@
+askZoom=Enter zoom (%)
+properties=Properties
+outline=Outline
+tasks=Tasks
+help=Help

--- a/packages/html/public/i18n/editor_de.txt
+++ b/packages/html/public/i18n/editor_de.txt
@@ -1,0 +1,5 @@
+askZoom=Zoom eingeben (%)
+properties=Eigenschaften
+outline=Uebersicht
+tasks=Aufgaben
+help=Hilfe

--- a/packages/html/public/i18n/editor_zh.txt
+++ b/packages/html/public/i18n/editor_zh.txt
@@ -1,0 +1,5 @@
+askZoom=进入缩放(%25)
+properties=属性
+outline=轮廓
+tasks=任务
+help=帮助

--- a/packages/html/public/i18n/graph.txt
+++ b/packages/html/public/i18n/graph.txt
@@ -1,0 +1,11 @@
+alreadyConnected=Nodes already connected
+containsValidationErrors=Contains validation errors
+updatingDocument=Updating Document. Please wait...
+updatingSelection=Updating Selection. Please wait...
+collapse-expand=Collapse/Expand
+doubleClickOrientation=Doubleclick to change orientation
+close=Close
+error=Error
+done=Done
+cancel=Cancel
+ok=OK

--- a/packages/html/public/i18n/graph_de.txt
+++ b/packages/html/public/i18n/graph_de.txt
@@ -1,0 +1,11 @@
+alreadyConnected=Knoten schon verbunden
+containsValidationErrors=Enthält Validierungsfehler
+updatingDocument=Aktualisiere Dokument. Bitte warten...
+updatingSelection=Aktualisiere Markierung. Bitte warten...
+collapse-expand=Einklappen/Ausklappen
+doubleClickOrientation=Doppelklicken um Orientierung zu ändern
+close=Schliessen
+error=Fehler
+done=Fertig
+cancel=Abbrechen
+ok=OK

--- a/packages/html/public/i18n/graph_zh.txt
+++ b/packages/html/public/i18n/graph_zh.txt
@@ -1,0 +1,11 @@
+alreadyConnected=节点已经连接
+containsValidationErrors=包含效验错误
+updatingDocument=更新文档。请等候......
+updatingSelection=更新所选项。请等候......
+collapse-expand=折叠/展开
+doubleClickOrientation=双击以改变方向
+close=关闭
+error=错误
+done=完成
+cancel=取消
+ok=确定

--- a/packages/html/stories/Control.stories.js
+++ b/packages/html/stories/Control.stories.js
@@ -53,7 +53,7 @@ const Template = ({ label, ...args }) => {
   div.appendChild(container);
 
   // Specifies the URL and size of the new control
-  const deleteImage = new ImageBox('images/forbidden.png', 16, 16);
+  const deleteImage = new ImageBox('images/overlays/forbidden.png', 16, 16);
 
   class MyCustomCellRenderer extends CellRenderer {
     createControl(state) {

--- a/packages/html/stories/Permissions.stories.js
+++ b/packages/html/stories/Permissions.stories.js
@@ -29,7 +29,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
-import { createGraphContainer } from './shared/configure.js';
+import { configureImagesBasePath, createGraphContainer } from './shared/configure.js';
 import '@maxgraph/core/css/common.css'; // style required by RubberBand
 
 export default {
@@ -45,6 +45,8 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
+  configureImagesBasePath();
+
   const div = document.createElement('div');
   const container = createGraphContainer(args);
   div.appendChild(container);

--- a/packages/html/stories/SwimLanes.stories.ts
+++ b/packages/html/stories/SwimLanes.stories.ts
@@ -58,9 +58,10 @@ const Template = ({ label, ...args }: Record<string, string>) => {
 
   InternalEvent.disableContextMenu(container);
 
-  // Creates a wrapper editor around a new graph inside
-  // the given container using an XML config for the
-  // keyboard bindings
+  // Creates a wrapper editor around a new graph inside the given container using an XML config for the keyboard bindings
+  // The usage of the editor is currently disable for the following reasons
+  // TODO get the keyhandler-commons.xml resource from mxGraph
+  // TODO make possible to set the container of the graph, see https://github.com/maxGraph/maxGraph/issues/367
   // const config = utils
   //   .load('editors/config/keyhandler-commons.xml')
   //   .getDocumentElement();

--- a/packages/website/docs/development/high-level-api-description.md
+++ b/packages/website/docs/development/high-level-api-description.md
@@ -4,10 +4,9 @@ description: High-level API description of maxGraph, including its structure, co
 
 # High-level API description
 
-:::note
+:::warning
 
-The following is adapted from the [mxGraph API Specification](https://github.com/jgraph/graph/blob/v4.2.2/javascript/src/js/index.txt).
-
+The following is adapted from the [mxGraph API Specification](https://github.com/jgraph/graph/blob/v4.2.2/javascript/src/js/index.txt) and needs to be reworked.
 :::
 
 ## Overview
@@ -119,28 +118,18 @@ The basename of the warning image (images/warning without extension) used in `Gr
 
 ### Translations
 
-:::warning
-
-The following comes from `mxGraph` and needs to be reworked.
-:::
-
-They are managed by the `Translations` class. \
-By default, the following conventions are used:
-- Resource files use .txt extension
-- Translation files are loaded from `${Client.basePath}/resources/`
-
-Language support is configurable via `Client.languages`. The library ships with English and German resource files.
-
-The `Editor` and `Graph` classes add the following resources to `Translations` at class loading time:
-- resources/editor*.txt
-- resources/graph*.txt
+See the [i18n](../usage/i18n.md) documentation for more details.
 
 
 ## Images
 
-The following comes from `Graph` and needs to be updated to reflect the current state of `maxGraph`.
-
 ### Recommendations for using images
+
+:::note
+
+The following comes from `mxGraph` and needs to be updated to reflect the current state of `maxGraph`.
+
+:::
 
 Use GIF images (256 color palette) in HTML elements (such as the toolbar and context menu),
 and PNG images (24 bit) for all images which appear inside the graph component.

--- a/packages/website/docs/usage/i18n.md
+++ b/packages/website/docs/usage/i18n.md
@@ -36,7 +36,7 @@ The following stories illustrate the translation of validation messages. Try con
   - **Source code**: [Validation.stories.js](https://github.com/maxGraph/maxGraph/blob/main/packages/html/stories/Validation.stories.js)
 - **Permissions story**:
   - **Live demo**: [Permissions](https://maxgraph.github.io/maxGraph/demo/?path=/story/misc-permissions--default)
-  - **Source code**: [Permissions.stories.js](https://github.com/maxGraph/maxGraph/blob/main/packages/html/stories/Validation.stories.js)
+  - **Source code**: [Permissions.stories.js](https://github.com/maxGraph/maxGraph/blob/main/packages/html/stories/Permissions.stories.js)
 
 In the `HelloPort` story, select an edge to display a translated message in the tooltip of the bend point. (Note: The double-click action does not work, same behavior as in mxGraph.)
 - **Live demo**: [HelloPort](https://maxgraph.github.io/maxGraph/demo/?path=/story/misc-helloport--default)

--- a/packages/website/docs/usage/i18n.md
+++ b/packages/website/docs/usage/i18n.md
@@ -1,0 +1,43 @@
+---
+sidebar_position: 10
+description: How to use i18n with maxGraph.
+---
+
+## i18n Mechanism in maxGraph
+
+`maxGraph` provides an internationalization (i18n) mechanism to support multiple languages in applications. It is based on text resource files.
+
+These files are managed by the `Translations` class.\
+By default, the following conventions apply:
+- Resource files use the `.txt` extension.
+- The default language is the browser's language, with a fallback to English.
+
+Language support can be configured via `Client.languages`.
+
+`maxGraph` includes built-in translations for Chinese, English, and German, covering `Graph` and `Editor`. These resource files are located in the `resources` folder of the npm package:
+- `resources/editor*.txt`
+- `resources/graph*.txt`
+
+### Loading i18n Resources
+
+To load a resource, you need to:
+1. Ensure that the i18n files are available in your application so they can be fetched via a GET request. This usually involves copying the resource files from the `maxGraph` npm package into a dedicated folder within your application.
+2. Use either `Translations.add` or `Translations.loadResources` to load the required resources. When using `Translations.loadResources`, files are fetched from `${Client.basePath}/resources/`.
+
+### Examples
+
+The Storybook demo showcases how to configure and use the i18n mechanism in different scenarios.
+
+Resource files are loaded in the [`preview.ts`](https://github.com/maxGraph/maxGraph/blob/main/packages/html/.storybook/preview.ts) file.
+
+The following stories illustrate the translation of validation messages. Try connecting the same vertices twice to trigger a validation error displayed in a browser alert:
+- **Validation story**:
+  - **Live demo**: [Validation](https://maxgraph.github.io/maxGraph/demo/?path=/story/misc-validation--default)
+  - **Source code**: [Validation.stories.js](https://github.com/maxGraph/maxGraph/blob/main/packages/html/stories/Validation.stories.js)
+- **Permissions story**:
+  - **Live demo**: [Permissions](https://maxgraph.github.io/maxGraph/demo/?path=/story/misc-permissions--default)
+  - **Source code**: [Permissions.stories.js](https://github.com/maxGraph/maxGraph/blob/main/packages/html/stories/Validation.stories.js)
+
+In the `HelloPort` story, select an edge to display a translated message in the tooltip of the bend point. (Note: The double-click action does not work, same behavior as in mxGraph.)
+- **Live demo**: [HelloPort](https://maxgraph.github.io/maxGraph/demo/?path=/story/misc-helloport--default)
+- **Source code**: [HelloPort.stories.ts](https://github.com/maxGraph/maxGraph/blob/main/packages/html/stories/HelloPort.stories.ts)


### PR DESCRIPTION
These resources were available in mxGraph but were missing in maxGraph.
The Storybook demo shows how to load the i18n resources and the npm package includes them.
The documentation now provides a dedicated page explaining how to use i18n.

In addition, the following stories were improved:
- Control: display overlay image which lets delete the related cell
- Permissions: add missing config to ensure that the connector image is always displayed


## Notes

Covers #688



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced localization support for key UI components with added language resources in English, German, and Chinese.
  - Updated image configurations improve the visual consistency of certain interactive controls.

- **Documentation**
  - Added a comprehensive guide detailing the application’s internationalization approach for a smoother user experience.
  - Updated existing documentation to clarify the usage of the `maxGraph` API and its translation mechanisms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->