### PR TITLE
feat!: introduce `TranslationsConfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ They had been made public by mistake, and had been considered internal since the
 So, remove it without replacement.
 - `Client.VERSION` moved to `constants.VERSION`. VERSION is supposed to be immutable as it represents the actual version of maxGraph.
 When it was stored in Client, it was a static property that could be modified. Moving it to the constants module ensures that it cannot be modified.
+- All elements that were in `Client` to manage the configuration of `Translations` have moved to `TranslationsConfig`:
+  - `Client.defaultLanguage` to `TranslationsConfig.getDefaultLanguage`
+  - `Client.setDefaultLanguage` to `TranslationsConfig.setDefaultLanguage`
+  - `Client.language` to `TranslationsConfig.getLanguage`
+  - `Client.setLanguage` to `TranslationsConfig.setLanguage`
+  - `Client.languages` to `TranslationsConfig.getLanguages`
+  - `Client.setLanguages` to `TranslationsConfig.setLanguages`
 - `ManhattanConnector` is now configured with the global `ManhattanConnectorConfig` object.
 The following properties that were previously on `EdgeStyle` have moved to `ManhattanConnectorConfig`:
   - `MANHATTAN_END_DIRECTIONS` to `endDirections`

--- a/packages/core/__tests__/i18n/config.test.ts
+++ b/packages/core/__tests__/i18n/config.test.ts
@@ -1,0 +1,42 @@
+/*
+Copyright 2025-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { expect, test } from '@jest/globals';
+import { TranslationsConfig, resetTranslationsConfig } from '../../src';
+
+function getTranslationsConfigValues() {
+  return {
+    defaultLanguage: TranslationsConfig.getDefaultLanguage(),
+    language: TranslationsConfig.getLanguage(),
+    languages: TranslationsConfig.getLanguages(),
+  };
+}
+
+test('resetTranslationsConfig', () => {
+  // Keep track of original default values
+  const originalConfigValues = getTranslationsConfigValues();
+
+  // Change some values
+  TranslationsConfig.setDefaultLanguage('ja');
+  TranslationsConfig.setLanguage('se');
+  TranslationsConfig.setLanguages(['es', 'it', 'fr']);
+
+  resetTranslationsConfig();
+
+  // Ensure that the values have correctly been reset
+  const newConfigValues = getTranslationsConfigValues();
+  expect(newConfigValues).toStrictEqual(originalConfigValues);
+});

--- a/packages/core/src/Client.ts
+++ b/packages/core/src/Client.ts
@@ -61,68 +61,6 @@ class Client {
   };
 
   /**
-   * Defines the language of the client, eg. `en` for english, `de` for german etc.
-   * The special value `none` will disable all built-in internationalization and
-   * resource loading. See {@link Translations.getSpecialBundle} for handling identifiers
-   * with and without a dash.
-   *
-   * If internationalization is disabled, then the following variables should be
-   * overridden to reflect the current language of the system. These variables are
-   * cleared when i18n is disabled.
-   * {@link Editor.askZoomResource}, {@link Editor.lastSavedResource},
-   * {@link Editor.currentFileResource}, {@link Editor.propertiesResource},
-   * {@link Editor.tasksResource}, {@link Editor.helpResource}, {@link Editor.outlineResource},
-   * {@link ElbowEdgeHandler#doubleClickOrientationResource}, {@link utils.errorResource},
-   * {@link utils.closeResource}, {@link GraphSelectionModel#doneResource},
-   * {@link GraphSelectionModel#updatingSelectionResource}, {@link GraphView#doneResource},
-   * {@link GraphView#updatingDocumentResource}, {@link CellRenderer#collapseExpandResource},
-   * {@link Graph#containsValidationErrorsResource} and
-   * {@link Graph#alreadyConnectedResource}.
-   */
-  static language = typeof window !== 'undefined' ? navigator.language : 'en';
-
-  static setLanguage = (value: string | undefined | null) => {
-    if (typeof value !== 'undefined' && value != null) {
-      Client.language = value;
-    } else {
-      Client.language = navigator.language;
-    }
-  };
-
-  /**
-   * Defines the default language which is used in the common resource files. Any
-   * resources for this language will only load the common resource file, but not
-   * the language-specific resource file.
-   * @default 'en'
-   */
-  static defaultLanguage = 'en';
-
-  static setDefaultLanguage = (value: string | undefined | null) => {
-    if (typeof value !== 'undefined' && value != null) {
-      Client.defaultLanguage = value;
-    } else {
-      Client.defaultLanguage = 'en';
-    }
-  };
-
-  /**
-   * Defines the optional array of all supported language extensions. The default
-   * language does not have to be part of this list. See
-   * {@link Translations#isLanguageSupported}.
-   *
-   * This is used to avoid unnecessary requests to language files, ie. if a 404
-   * will be returned.
-   * @default null
-   */
-  static languages: string[] | null = null;
-
-  static setLanguages = (value: string[] | null | undefined) => {
-    if (typeof value !== 'undefined' && value != null) {
-      Client.languages = value;
-    }
-  };
-
-  /**
    * True if the current browser is Microsoft Edge.
    */
   static IS_EDGE =

--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -20,7 +20,7 @@ import EditorPopupMenu from './EditorPopupMenu';
 import UndoManager from '../view/undoable_changes/UndoManager';
 import EditorKeyHandler from './EditorKeyHandler';
 import EventSource from '../view/event/EventSource';
-import Translations from '../util/Translations';
+import Translations from '../i18n/Translations';
 import Client from '../Client';
 import CompactTreeLayout from '../view/layout/CompactTreeLayout';
 import { EditorToolbar } from './EditorToolbar';
@@ -56,20 +56,7 @@ import ConnectionHandler from '../view/handler/ConnectionHandler';
 import { show } from '../util/printUtils';
 import PanningHandler from '../view/handler/PanningHandler';
 import { cloneCell } from '../util/cellArrayUtils';
-
-// TODO disabled side effects, so editor resources are not loaded by default
-// This should be done in a different way
-/**
- * Installs the required language resources at class
- * loading time.
- */
-/*
-if (mxLoadResources) {
-  mxResources.add(`${Client.basePath}/resources/editor`);
-} else {
-  Client.defaultBundles.push(`${Client.basePath}/resources/editor`);
-}
- */
+import { TranslationsConfig } from '../i18n/config';
 
 /**
  * Extends {@link EventSource} to implement an application wrapper for a graph that
@@ -324,6 +311,14 @@ if (mxLoadResources) {
  *
  * resources/editor - Language resources for Editor
  *
+ * To load the resources for the Editor, the following code should be used:
+ * ```javascript
+ * // Load maxGraph builtin resources
+ * Translations.loadResources();
+ * // Load resources for the Editor
+ * Translations.add(`${Client.basePath}/resources/editor`);
+ * ```
+ *
  * #### Callback: onInit
  *
  * Called from within the constructor. In the callback,
@@ -461,8 +456,7 @@ export class Editor extends EventSource {
    * key does not exist then the value is used as the error message. Default is 'askZoom'.
    * @default 'askZoom'
    */
-  // askZoomResource: 'askZoom' | '';
-  askZoomResource = Client.language !== 'none' ? 'askZoom' : '';
+  askZoomResource = TranslationsConfig.isEnabled() ? 'askZoom' : '';
 
   /**
    * Group: Controls and Handlers
@@ -472,14 +466,14 @@ export class Editor extends EventSource {
    * this key does not exist then the value is used as the error message. Default is 'lastSaved'.
    * @default 'lastSaved'.
    */
-  lastSavedResource = Client.language !== 'none' ? 'lastSaved' : '';
+  lastSavedResource = TranslationsConfig.isEnabled() ? 'lastSaved' : '';
 
   /**
    * Specifies the resource key for the current file info. If the resource for
    * this key does not exist then the value is used as the error message. Default is 'currentFile'.
    * @default 'currentFile'
    */
-  currentFileResource = Client.language !== 'none' ? 'currentFile' : '';
+  currentFileResource = TranslationsConfig.isEnabled() ? 'currentFile' : '';
 
   /**
    * Specifies the resource key for the properties window title. If the
@@ -487,7 +481,7 @@ export class Editor extends EventSource {
    * error message. Default is 'properties'.
    * @default 'properties'
    */
-  propertiesResource = Client.language !== 'none' ? 'properties' : '';
+  propertiesResource = TranslationsConfig.isEnabled() ? 'properties' : '';
 
   /**
    * Specifies the resource key for the tasks window title. If the
@@ -495,7 +489,7 @@ export class Editor extends EventSource {
    * error message. Default is 'tasks'.
    * @default 'tasks'
    */
-  tasksResource = Client.language !== 'none' ? 'tasks' : '';
+  tasksResource = TranslationsConfig.isEnabled() ? 'tasks' : '';
 
   /**
    * Specifies the resource key for the help window title. If the
@@ -503,7 +497,7 @@ export class Editor extends EventSource {
    * error message. Default is 'help'.
    * @default 'help'
    */
-  helpResource = Client.language !== 'none' ? 'help' : '';
+  helpResource = TranslationsConfig.isEnabled() ? 'help' : '';
 
   /**
    * Specifies the resource key for the outline window title. If the
@@ -511,7 +505,7 @@ export class Editor extends EventSource {
    * error message. Default is 'outline'.
    * @default 'outline'
    */
-  outlineResource = Client.language !== 'none' ? 'outline' : '';
+  outlineResource = TranslationsConfig.isEnabled() ? 'outline' : '';
 
   /**
    * Reference to the {@link MaxWindow} that contains the outline. The {@link outline}

--- a/packages/core/src/editor/EditorPopupMenu.ts
+++ b/packages/core/src/editor/EditorPopupMenu.ts
@@ -19,7 +19,7 @@ limitations under the License.
 import Cell from '../view/cell/Cell';
 import MaxPopupMenu from '../gui/MaxPopupMenu';
 import { getTextContent } from '../util/domUtils';
-import Translations from '../util/Translations';
+import Translations from '../i18n/Translations';
 import Editor from './Editor';
 
 import { PopupMenuItem } from '../types';

--- a/packages/core/src/gui/MaxForm.ts
+++ b/packages/core/src/gui/MaxForm.ts
@@ -19,7 +19,7 @@ limitations under the License.
 import Client from '../Client';
 import InternalEvent from '../view/event/InternalEvent';
 import { write, writeln } from '../util/domUtils';
-import Translations from '../util/Translations';
+import Translations from '../i18n/Translations';
 
 /**
  * A simple class for creating HTML forms.

--- a/packages/core/src/gui/MaxWindow.ts
+++ b/packages/core/src/gui/MaxWindow.ts
@@ -24,7 +24,7 @@ import InternalEvent from '../view/event/InternalEvent';
 import Client from '../Client';
 import { NODETYPE } from '../util/Constants';
 import { br, write } from '../util/domUtils';
-import Translations from '../util/Translations';
+import Translations from '../i18n/Translations';
 import { getClientX, getClientY } from '../util/EventUtils';
 import { htmlEntities } from '../util/StringUtils';
 import { utils } from '../util/Utils';

--- a/packages/core/src/i18n/Translations.ts
+++ b/packages/core/src/i18n/Translations.ts
@@ -17,9 +17,12 @@ limitations under the License.
 */
 
 import Client from '../Client';
-import { NONE } from './Constants';
-import { get, load } from './MaxXmlRequest';
-import type MaxXmlRequest from './MaxXmlRequest';
+import { NONE } from '../util/Constants';
+import { get, load } from '../util/MaxXmlRequest';
+import type MaxXmlRequest from '../util/MaxXmlRequest';
+import { TranslationsConfig } from './config';
+
+// mxGraph source code: https://github.com/jgraph/mxgraph/blob/v4.2.2/javascript/src/js/util/mxResources.js
 
 /**
  * Implements internationalization. You can provide any number of
@@ -83,32 +86,33 @@ class Translations {
   static extension = '.txt';
 
   /**
-   * Specifies whether values in resource files are encoded with \u or
-   * percentage. Default is false.
+   * Specifies whether values in resource files are encoded with `\u` or percentage.
+   * @default false
    */
   static resourcesEncoded = false;
 
   /**
    * Specifies if the default file for a given basename should be loaded.
-   * Default is true.
+   * @default true
    */
   static loadDefaultBundle = true;
 
   /**
-   * Specifies if the specific language file file for a given basename should
-   * be loaded. Default is true.
+   * Specifies if the specific language file for a given basename should be loaded.
+   * @default true
    */
   static loadSpecialBundle = true;
 
   /**
-   * Hook for subclassers to disable support for a given language. This
-   * implementation returns true if lan is in <Client.languages>.
+   * Hook for subclassers to disable support for a given language.
+   * This implementation returns `true` if `lan` is in {@link TranslationsConfig.languages}.
    *
    * @param lan The current language.
    */
   static isLanguageSupported = (lan: string): boolean => {
-    if (Client.languages != null) {
-      return Client.languages.indexOf(lan) >= 0;
+    const languages = TranslationsConfig.getLanguages();
+    if (languages) {
+      return languages.indexOf(lan) >= 0;
     }
     return true;
   };
@@ -131,21 +135,18 @@ class Translations {
   /**
    * Hook for subclassers to return the URL for the special bundle. This
    * implementation returns `basename + '_' + lan + <extension>` or `null` if
-   * {@link Translations.loadSpecialBundle} is `false` or `lan` equals {@link Client.defaultLanguage}.
+   * {@link loadSpecialBundle} is `false` or `lan` equals {@link TranslationsConfig.getDefaultLanguage}.
    *
-   * If {@link Translations#languages} is not null and {@link Client.language} contains
-   * a dash, then this method checks if {@link Translations.isLanguageSupported} returns `true`
+   * If {@link TranslationsConfig.getLanguages} is not `null` and {@link TranslationsConfig.getLanguage} contains
+   * a dash, then this method checks if {@link isLanguageSupported} returns `true`
    * for the full language (including the dash). If that returns false the
    * first part of the language (up to the dash) will be tried as an extension.
-   *
-   * If {@link Translations#language} is null then the first part of the language is
-   * used to maintain backwards compatibility.
    *
    * @param basename The basename for which the file should be loaded.
    * @param lan The language for which the file should be loaded.
    */
   static getSpecialBundle = (basename: string, lan: string): string | null => {
-    if (Client.languages == null || !Translations.isLanguageSupported(lan)) {
+    if (!TranslationsConfig.getLanguages() || !Translations.isLanguageSupported(lan)) {
       const dash = lan.indexOf('-');
 
       if (dash > 0) {
@@ -156,7 +157,7 @@ class Translations {
     if (
       Translations.loadSpecialBundle &&
       Translations.isLanguageSupported(lan) &&
-      lan != Client.defaultLanguage
+      lan != TranslationsConfig.getDefaultLanguage()
     ) {
       return `${basename}_${lan}${Translations.extension}`;
     }
@@ -186,8 +187,7 @@ class Translations {
     lan: string | null = null,
     callback: Function | null = null
   ): void => {
-    lan =
-      lan != null ? lan : Client.language != null ? Client.language.toLowerCase() : NONE;
+    lan ??= TranslationsConfig.getLanguage()?.toLowerCase() ?? NONE;
 
     if (lan !== NONE) {
       const defaultBundle = Translations.getDefaultBundle(basename, lan);

--- a/packages/core/src/i18n/config.ts
+++ b/packages/core/src/i18n/config.ts
@@ -1,0 +1,129 @@
+/*
+Copyright 2025-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { isNullish } from '../util/Utils';
+import { shallowCopy } from '../util/cloneUtils';
+
+function getNavigatorLanguage() {
+  return typeof window !== 'undefined' ? navigator.language : 'en';
+}
+
+type TranslationsConfigValuesType = {
+  defaultLanguage: string;
+  language: string;
+  languages: string[];
+};
+
+const values: TranslationsConfigValuesType = {
+  defaultLanguage: 'en',
+  language: getNavigatorLanguage(),
+  languages: [],
+};
+
+// @ts-ignore the properties will be added dynamically when calling shallowCopy
+const originalValues: TranslationsConfigValuesType = {};
+shallowCopy(values, originalValues);
+
+export const resetTranslationsConfig = (): void => {
+  shallowCopy(originalValues, values);
+};
+
+/**
+ * Global configuration for {@link Translations}.
+ */
+export const TranslationsConfig = {
+  /**
+   * Returns whether internationalization is enabled.
+   */
+  isEnabled(): boolean {
+    return this.getLanguage() !== 'none';
+  },
+
+  /**
+   * @see setLanguage
+   */
+  getLanguage(): string {
+    return values.language;
+  },
+
+  /**
+   * Defines the language of the client, e.g. `en` for english, `de` for german etc.
+   *
+   * The special value `none` will disable all built-in internationalization and resource loading.
+   * See {@link Translations.getSpecialBundle} for handling identifiers with and without a dash.
+   *
+   * If internationalization is disabled, then the following variables should be overridden to reflect the current language of the system.
+   * These variables are cleared when i18n is disabled:
+   * - {@link CellRenderer.collapseExpandResource}
+   * - {@link Editor.askZoomResource}
+   * - {@link Editor.currentFileResource}
+   * - {@link Editor.helpResource}
+   * - {@link Editor.lastSavedResource}
+   * - {@link Editor.outlineResource}
+   * - {@link Editor.propertiesResource}
+   * - {@link Editor.tasksResource}
+   * - {@link ElbowEdgeHandler.doubleClickOrientationResource}
+   * - {@link GraphSelectionModel.doneResource}
+   * - {@link GraphSelectionModel.updatingSelectionResource}
+   * - {@link Graph.alreadyConnectedResource}.
+   * - {@link Graph.containsValidationErrorsResource} and
+   * - {@link utils.closeResource}
+   * - {@link utils.errorResource}
+   * - {@link GraphView.doneResource}
+   * - {@link GraphView.updatingDocumentResource}
+   *
+   * @param value The language to set. If `null` or `undefined`, use the preferred language of the navigator or 'en' as default.
+   */
+  setLanguage(value: string | undefined | null): void {
+    values.language = !isNullish(value) ? value : getNavigatorLanguage();
+  },
+
+  /**
+   * @see setLanguages
+   */
+  getLanguages(): string[] {
+    return values.languages;
+  },
+
+  /**
+   * Defines the optional array of all supported language extensions.
+   * The default language does not have to be part of this list. See {@link Translations.isLanguageSupported}.
+   *
+   * This is used to avoid unnecessary requests to language files, i.e. if a 404 will be returned.
+   * @default empty array
+   */
+  setLanguages(value: string[] | null | undefined): void {
+    if (!isNullish(value)) {
+      values.languages = value;
+    }
+  },
+
+  /**
+   * @see setDefaultLanguage
+   */
+  getDefaultLanguage(): string {
+    return values.defaultLanguage;
+  },
+
+  /**
+   * Defines the default language which is used in the common resource files.
+   * Any resources for this language will only load the common resource file, but not the language-specific resource file.
+   * @default 'en'
+   */
+  setDefaultLanguage(value: string | undefined | null): void {
+    values.defaultLanguage = !isNullish(value) ? value : 'en';
+  },
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -130,7 +130,8 @@ export { default as StencilShapeRegistry } from './view/geometry/node/StencilSha
 
 export * as constants from './util/Constants';
 export { default as Guide } from './view/other/Guide';
-export { default as Translations } from './util/Translations';
+export { default as Translations } from './i18n/Translations';
+export * from './i18n/config';
 
 export * as cellArrayUtils from './util/cellArrayUtils';
 export * as cloneUtils from './util/cloneUtils';

--- a/packages/core/src/serialization/codecs/editor/EditorCodec.ts
+++ b/packages/core/src/serialization/codecs/editor/EditorCodec.ts
@@ -18,7 +18,7 @@ import ObjectCodec from '../../ObjectCodec';
 import Editor from '../../../editor/Editor';
 import type Codec from '../../Codec';
 import MaxWindow from '../../../gui/MaxWindow';
-import Translations from '../../../util/Translations';
+import Translations from '../../../i18n/Translations';
 import { addLinkToHead, getChildNodes } from '../../../util/domUtils';
 
 /**

--- a/packages/core/src/serialization/codecs/editor/EditorToolbarCodec.ts
+++ b/packages/core/src/serialization/codecs/editor/EditorToolbarCodec.ts
@@ -24,7 +24,7 @@ import { convertPoint } from '../../../util/styleUtils';
 import { getClientX, getClientY } from '../../../util/EventUtils';
 import InternalEvent from '../../../view/event/InternalEvent';
 import { getChildNodes, getTextContent } from '../../../util/domUtils';
-import Translations from '../../../util/Translations';
+import Translations from '../../../i18n/Translations';
 
 /**
  * Custom codec for configuring {@link EditorToolbar}s.

--- a/packages/core/src/view/Graph.ts
+++ b/packages/core/src/view/Graph.ts
@@ -60,6 +60,7 @@ import { registerDefaultEdgeMarkers } from './geometry/edge/MarkerShape';
 import { registerDefaultStyleElements } from './style/register';
 import { applyGraphMixins } from './mixins/_graph-mixins-apply';
 import { getDefaultPlugins } from './plugins';
+import { TranslationsConfig } from '../i18n/config';
 
 /**
  * Extends {@link EventSource} to implement a graph component for the browser. This is the main class of the package.
@@ -382,7 +383,9 @@ class Graph extends EventSource {
    * for this key does not exist then the value is used as the error message.
    * @default 'alreadyConnected'
    */
-  alreadyConnectedResource: string = Client.language != 'none' ? 'alreadyConnected' : '';
+  alreadyConnectedResource: string = TranslationsConfig.isEnabled()
+    ? 'alreadyConnected'
+    : '';
 
   /**
    * Specifies the resource key for the warning message to be displayed when
@@ -390,8 +393,9 @@ class Graph extends EventSource {
    * key does not exist then the value is used as the warning message.
    * @default 'containsValidationErrors'
    */
-  containsValidationErrorsResource: string =
-    Client.language != 'none' ? 'containsValidationErrors' : '';
+  containsValidationErrorsResource: string = TranslationsConfig.isEnabled()
+    ? 'containsValidationErrors'
+    : '';
 
   // ===================================================================================================================
   // Group: "Create Class Instance" factory functions.

--- a/packages/core/src/view/GraphSelectionModel.ts
+++ b/packages/core/src/view/GraphSelectionModel.ts
@@ -16,7 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import Client from '../Client';
 import EventSource from '../view/event/EventSource';
 import { Graph } from './Graph';
 import Cell from './cell/Cell';
@@ -24,10 +23,9 @@ import SelectionChange from './undoable_changes/SelectionChange';
 import UndoableEdit from './undoable_changes/UndoableEdit';
 import EventObject from './event/EventObject';
 import InternalEvent from './event/InternalEvent';
+import { TranslationsConfig } from '../i18n/config';
 
 /**
- * Class: mxGraphSelectionModel
- *
  * Implements the selection model for a graph. Here is a listener that handles
  * all removed selection cells.
  *
@@ -80,7 +78,7 @@ class GraphSelectionModel extends EventSource {
    * the status message.
    * @default 'done'
    */
-  doneResource = Client.language !== 'none' ? 'done' : '';
+  doneResource = TranslationsConfig.isEnabled() ? 'done' : '';
 
   /**
    * Specifies the resource key for the status message while the selection is
@@ -88,7 +86,7 @@ class GraphSelectionModel extends EventSource {
    * value is used as the status message.
    * @default 'updatingSelection'
    */
-  updatingSelectionResource = Client.language !== 'none' ? 'updatingSelection' : '';
+  updatingSelectionResource = TranslationsConfig.isEnabled() ? 'updatingSelection' : '';
 
   /**
    * Specifies if only one selected item at a time is allowed.

--- a/packages/core/src/view/GraphView.ts
+++ b/packages/core/src/view/GraphView.ts
@@ -45,6 +45,7 @@ import type { Graph } from './Graph';
 import StyleRegistry from './style/StyleRegistry';
 import type TooltipHandler from './handler/TooltipHandler';
 import type { EdgeStyleFunction, MouseEventListener } from '../types';
+import { TranslationsConfig } from '../i18n/config';
 
 /**
  * @class GraphView
@@ -120,7 +121,7 @@ export class GraphView extends EventSource {
    * the status message.
    * @default 'done'
    */
-  doneResource = Client.language !== 'none' ? 'done' : '';
+  doneResource = TranslationsConfig.isEnabled() ? 'done' : '';
 
   /**
    * Specifies the resource key for the status message while the document is
@@ -128,7 +129,7 @@ export class GraphView extends EventSource {
    * value is used as the status message.
    * @default 'updatingSelection'
    */
-  updatingDocumentResource = Client.language !== 'none' ? 'updatingDocument' : '';
+  updatingDocumentResource = TranslationsConfig.isEnabled() ? 'updatingDocument' : '';
 
   /**
    * Specifies if string values in cell styles should be evaluated using

--- a/packages/core/src/view/geometry/node/StencilShape.ts
+++ b/packages/core/src/view/geometry/node/StencilShape.ts
@@ -19,7 +19,7 @@ limitations under the License.
 import ConnectionConstraint from '../../other/ConnectionConstraint';
 import Rectangle from '../Rectangle';
 import Shape from '../Shape';
-import Translations from '../../../util/Translations';
+import Translations from '../../../i18n/Translations';
 import { isNotNullish } from '../../../util/Utils';
 import {
   ALIGN,

--- a/packages/core/src/view/handler/ElbowEdgeHandler.ts
+++ b/packages/core/src/view/handler/ElbowEdgeHandler.ts
@@ -20,10 +20,10 @@ import EdgeHandler from './EdgeHandler';
 import { CURSOR, EDGESTYLE, ELBOW } from '../../util/Constants';
 import InternalEvent from '../event/InternalEvent';
 import Point from '../geometry/Point';
-import Translations from '../../util/Translations';
+import Translations from '../../i18n/Translations';
+import { TranslationsConfig } from '../../i18n/config';
 import Rectangle from '../geometry/Rectangle';
 import { intersects } from '../../util/mathUtils';
-import Client from '../../Client';
 import { isConsumed } from '../../util/EventUtils';
 import CellState from '../cell/CellState';
 import { HandleConfig } from './config';
@@ -57,8 +57,9 @@ class ElbowEdgeHandler extends EdgeHandler {
    * exist then the value is used as the error message.
    * @default 'doubleClickOrientation'.
    */
-  doubleClickOrientationResource =
-    Client.language !== 'none' ? 'doubleClickOrientation' : '';
+  doubleClickOrientationResource = TranslationsConfig.isEnabled()
+    ? 'doubleClickOrientation'
+    : '';
 
   /**
    * Overrides {@link EdgeHandler.createBends} to create custom bends.

--- a/packages/core/src/view/mixins/FoldingMixin.ts
+++ b/packages/core/src/view/mixins/FoldingMixin.ts
@@ -23,6 +23,7 @@ import Geometry from '../geometry/Geometry';
 import { toRadians } from '../../util/mathUtils';
 import Rectangle from '../geometry/Rectangle';
 import type { Graph } from '../Graph';
+import { TranslationsConfig } from '../../i18n/config';
 
 type PartialGraph = Pick<
   Graph,
@@ -62,7 +63,7 @@ export const FoldingMixin: PartialType = {
     collapseToPreferredSize: true,
   },
 
-  collapseExpandResource: Client.language != 'none' ? 'collapse-expand' : '',
+  collapseExpandResource: TranslationsConfig.isEnabled() ? 'collapse-expand' : '',
 
   getCollapseExpandResource() {
     return this.collapseExpandResource;

--- a/packages/core/src/view/mixins/TooltipMixin.ts
+++ b/packages/core/src/view/mixins/TooltipMixin.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { htmlEntities } from '../../util/StringUtils';
-import Translations from '../../util/Translations';
+import Translations from '../../i18n/Translations';
 import type Shape from '../geometry/Shape';
 import type Cell from '../cell/Cell';
 import type { Graph } from '../Graph';

--- a/packages/core/src/view/mixins/ValidationMixin.ts
+++ b/packages/core/src/view/mixins/ValidationMixin.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import type Cell from '../cell/Cell';
-import Translations from '../../util/Translations';
+import Translations from '../../i18n/Translations';
 import { isNode } from '../../util/domUtils';
 import type { Graph } from '../Graph';
 

--- a/packages/core/src/view/other/Multiplicity.ts
+++ b/packages/core/src/view/other/Multiplicity.ts
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import Translations from '../../util/Translations';
+import Translations from '../../i18n/Translations';
 import { isNode } from '../../util/domUtils';
 import Cell from '../cell/Cell';
 import { Graph } from '../Graph';

--- a/packages/html/.storybook/preview.ts
+++ b/packages/html/.storybook/preview.ts
@@ -9,6 +9,7 @@ import {
   resetManhattanConnectorConfig,
   resetOrthogonalConnectorConfig,
   resetStyleDefaultsConfig,
+  resetTranslationsConfig,
   resetVertexHandlerConfig,
   Translations,
 } from '@maxgraph/core';
@@ -34,6 +35,7 @@ const resetMaxGraphConfigs = (): void => {
   resetManhattanConnectorConfig();
   resetOrthogonalConnectorConfig();
   resetStyleDefaultsConfig();
+  resetTranslationsConfig();
   resetVertexHandlerConfig();
 };
 

--- a/packages/ts-example-without-defaults/vite.config.js
+++ b/packages/ts-example-without-defaults/vite.config.js
@@ -27,7 +27,7 @@ export default defineConfig(({ mode }) => {
           },
         },
       },
-      chunkSizeWarningLimit: 440, // @maxgraph/core
+      chunkSizeWarningLimit: 441, // @maxgraph/core
     },
   };
 });

--- a/packages/ts-example/vite.config.js
+++ b/packages/ts-example/vite.config.js
@@ -27,7 +27,7 @@ export default defineConfig(({ mode }) => {
           },
         },
       },
-      chunkSizeWarningLimit: 444, // @maxgraph/core
+      chunkSizeWarningLimit: 445, // @maxgraph/core
     },
   };
 });

--- a/packages/website/docs/usage/global-configuration.md
+++ b/packages/website/docs/usage/global-configuration.md
@@ -18,6 +18,7 @@ The following objects can be used to configure `maxGraph` globally:
   - `HandleConfig` (since 0.14.0): for shared handle configurations.
   - `StencilShapeConfig` (since 0.11.0): for stencil shapes.
   - `StyleDefaultsConfig` (since 0.14.0): for the default values of the Cell styles.
+  - `TranslationsConfig` (since 0.16.0): for the configuration of `Translations`.
   - `VertexHandlerConfig` (since 0.12.0): for `VertexHandler`.
   - For Connectors/EdgeStyles:
     - `EntityRelationConnectorConfig` (since 0.15.0): for `EntityRelation`.
@@ -29,6 +30,7 @@ Some functions are provided to reset the global configuration to the default val
   - `resetEdgeHandlerConfig` (since 0.14.0)
   - `resetHandleConfig` (since 0.14.0)
   - `resetStyleDefaultsConfig` (since 0.14.0)
+  - `resetTranslationsConfig` (since 0.16.0)
   - `resetVertexHandlerConfig` (since 0.14.0)
   - For Connectors/EdgeStyles:
     - `resetEntityRelationConnectorConfig` (since 0.15.0)

--- a/packages/website/docs/usage/i18n.md
+++ b/packages/website/docs/usage/i18n.md
@@ -12,11 +12,20 @@ By default, the following conventions apply:
 - Resource files use the `.txt` extension.
 - The default language is the browser's language, with a fallback to English.
 
-Language support can be configured via `Client.languages`.
+Language support can be configured via `TranslationsConfig.setlanguages`.
 
 `maxGraph` includes built-in translations for Chinese, English, and German, covering `Graph` and `Editor`. These resource files are located in the `resources` folder of the npm package:
 - `resources/editor*.txt`
 - `resources/graph*.txt`
+
+The format of the resource files is as follows:
+```txt
+# Comment
+key=value
+# Another comment
+key2=value2
+```
+
 
 ### Loading i18n Resources
 

--- a/packages/website/docs/usage/i18n.md
+++ b/packages/website/docs/usage/i18n.md
@@ -12,7 +12,7 @@ By default, the following conventions apply:
 - Resource files use the `.txt` extension.
 - The default language is the browser's language, with a fallback to English.
 
-Language support can be configured via `TranslationsConfig.setlanguages`.
+Language support can be configured via `TranslationsConfig.setLanguages`.
 
 `maxGraph` includes built-in translations for Chinese, English, and German, covering `Graph` and `Editor`. These resource files are located in the `resources` folder of the npm package:
 - `resources/editor*.txt`

--- a/packages/website/docs/usage/migrate-from-mxgraph.md
+++ b/packages/website/docs/usage/migrate-from-mxgraph.md
@@ -363,9 +363,11 @@ managing development mode in that way anymore.
 - `mxLoadResources`: not used anymore
 - `mxLoadStylesheets`: not used anymore
 - `mxResourceExtension`: it was only used in `Translations`, so only keep the property in `Translations`
+- languages properties are replaced by getters in `TranslationsConfig` (0.16.0)
 
 Removed methods
 - `isBrowserSupported` (0.16.0): no longer necessary
+- `loadResources`: used `Translations.loadResources`
 - `setForceIncludes`: the `mxForceIncludes` property has been removed
 - `setLoadResources`: the `mxLoadResources` property has been removed
 - `setLoadStylesheets`: the `mxLoadStylesheets` property has been removed
@@ -375,6 +377,7 @@ Moved properties
 - `VERSION` moved to `constants.VERSION` (0.16.0)
 
 Moved methods
+- languages setters moved to `TranslationsConfig` (0.16.0)
 - `link` method moved and renamed `domUtils.addLinkToHead`
 
 


### PR DESCRIPTION
Move the configuration related to `Translations` that was previously stored in `Client` to a new `TranslationsConfig` object.
This makes things more explicit and consistent with the other focussed configuration objects.

BREAKING CHANGES: All elements that were in `Client` to manage the configuration of `Translations` have moved to `TranslationsConfig`:
- `Client.defaultLanguage` to `TranslationsConfig.getDefaultLanguage`
- `Client.setDefaultLanguage` to `TranslationsConfig.setDefaultLanguage`
- `Client.language` to `TranslationsConfig.getLanguage`
- `Client.setLanguage` to `TranslationsConfig.setLanguage`
- `Client.languages` to `TranslationsConfig.getLanguages`
- `Client.setLanguages` to `TranslationsConfig.setLanguages`


## Notes

Covers #688



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a centralized translation configuration module for streamlined language management and resource handling.
  - Added a function to reset translation configurations to default values.

- **Refactor**
  - Enhanced internationalization architecture to ensure consistent language settings and enforce a fixed version identifier.

- **Documentation**
  - Updated guides to reflect the new translation setup, including details on configuring language resources and migration instructions.
  - Added documentation for the new `TranslationsConfig` and `resetTranslationsConfig` function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->