### PR TITLE
refactor: do not redeclare ImageShape properties already in Shape

### DIFF
--- a/packages/core/src/view/geometry/Shape.ts
+++ b/packages/core/src/view/geometry/Shape.ts
@@ -86,7 +86,10 @@ import { StyleDefaultsConfig } from '../../util/config';
  * ```
  */
 class Shape {
-  // Assigned in mxCellRenderer
+  /**
+   * Switch to preserve image aspect.
+   * @default false
+   */
   preserveImageAspect = false;
   overlay: CellOverlay | null = null;
   indicator: Shape | null = null;

--- a/packages/core/src/view/geometry/node/ImageShape.ts
+++ b/packages/core/src/view/geometry/node/ImageShape.ts
@@ -20,7 +20,6 @@ import RectangleShape from './RectangleShape';
 import type Rectangle from '../Rectangle';
 import CellState from '../../cell/CellState';
 import type AbstractCanvas2D from '../../canvas/AbstractCanvas2D';
-import CellOverlay from '../../cell/CellOverlay';
 import { NONE } from '../../../util/Constants';
 import { ColorValue } from '../../../types';
 
@@ -42,22 +41,11 @@ class ImageShape extends RectangleShape {
 
     this.imageSrc = imageSrc;
     this.shadow = false;
+    this.preserveImageAspect = true;
   }
 
   // TODO: Document me!!
   shadow: boolean;
-
-  imageSrc: string;
-
-  // Used in mxCellRenderer
-  overlay: CellOverlay | null = null;
-
-  /**
-   * Switch to preserve image aspect. Default is true.
-   * @default true
-   */
-  // preserveImageAspect: boolean;
-  preserveImageAspect = true;
 
   /**
    * Disables offset in IE9 for crisper image output.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the description of the image aspect ratio preservation setting for improved clarity.
- **Refactor**
  - Removed redundant elements from image handling to simplify state management.
  - Updated the default behavior for image aspect ratio preservation to enhance consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->