### PR TITLE
refactor: use external CSS file MenuStyle and ShowRegion stories

### DIFF
--- a/packages/html/stories/MenuStyle.stories.ts
+++ b/packages/html/stories/MenuStyle.stories.ts
@@ -47,46 +47,8 @@ import { globalTypes, globalValues } from './shared/args.js';
 import { configureImagesBasePath, createGraphContainer } from './shared/configure.js';
 // style required by RubberBand and MaxPopupMenu
 import '@maxgraph/core/css/common.css';
-
-// Use custom CSS for the popup menu
-const CSS_TEMPLATE = `
-body div.mxPopupMenu {
-  -webkit-box-shadow: 3px 3px 6px #C0C0C0;
-  -moz-box-shadow: 3px 3px 6px #C0C0C0;
-  box-shadow: 3px 3px 6px #C0C0C0;
-  background: white;
-  position: absolute;
-  border: 3px solid #e7e7e7;
-  padding: 3px;
-}
-body table.mxPopupMenu {
-  border-collapse: collapse;
-  margin: 0px;
-}
-body tr.mxPopupMenuItem {
-  color: black;
-  cursor: default;
-}
-body td.mxPopupMenuItem {
-  padding: 6px 60px 6px 30px;
-  font-family: Arial;
-  font-size: 10pt;
-}
-body td.mxPopupMenuIcon {
-  background-color: white;
-  padding: 0px;
-}
-body tr.mxPopupMenuItemHover {
-  background-color: #eeeeee;
-  color: black;
-}
-table.mxPopupMenu hr {
-  border-top: solid 1px #cccccc;
-}
-table.mxPopupMenu tr {
-  font-size: 4pt;
-}
-`;
+// custom style for Popup Menu
+import './css/menu-style.css';
 
 export default {
   title: 'Misc/MenuStyle',
@@ -100,10 +62,6 @@ export default {
 
 const Template = ({ label, ...args }: Record<string, string>) => {
   configureImagesBasePath();
-
-  const styleElm = document.createElement('style');
-  styleElm.innerText = CSS_TEMPLATE;
-  document.head.appendChild(styleElm);
 
   const container = createGraphContainer(args);
 

--- a/packages/html/stories/ShowRegion.stories.ts
+++ b/packages/html/stories/ShowRegion.stories.ts
@@ -44,45 +44,8 @@ import {
 import { createGraphContainer } from './shared/configure.js';
 // style required by RubberBand and MaxPopupMenu
 import '@maxgraph/core/css/common.css';
-
-const CSS_TEMPLATE = `
-body div.mxPopupMenu {
-  -webkit-box-shadow: 3px 3px 6px #C0C0C0;
-  -moz-box-shadow: 3px 3px 6px #C0C0C0;
-  box-shadow: 3px 3px 6px #C0C0C0;
-  background: white;
-  position: absolute;
-  border: 3px solid #e7e7e7;
-  padding: 3px;
-}
-body table.mxPopupMenu {
-  border-collapse: collapse;
-  margin: 0px;
-}
-body tr.mxPopupMenuItem {
-  color: black;
-  cursor: default;
-}
-body td.mxPopupMenuItem {
-  padding: 6px 60px 6px 30px;
-  font-family: Arial;
-  font-size: 10pt;
-}
-body td.mxPopupMenuIcon {
-  background-color: white;
-  padding: 0px;
-}
-body tr.mxPopupMenuItemHover {
-  background-color: #eeeeee;
-  color: black;
-}
-table.mxPopupMenu hr {
-  border-top: solid 1px #cccccc;
-}
-table.mxPopupMenu tr {
-  font-size: 4pt;
-}
-`;
+// custom style for Popup Menu
+import './css/show-region.css';
 
 export default {
   title: 'Misc/ShowRegion',
@@ -97,10 +60,6 @@ export default {
 };
 
 const Template = ({ label, ...args }: Record<string, string>) => {
-  const styleElm = document.createElement('style');
-  styleElm.innerText = CSS_TEMPLATE;
-  document.head.appendChild(styleElm);
-
   const mainDiv = document.createElement('div');
   const divMessage = document.createElement('div');
   divMessage.innerHTML =

--- a/packages/html/stories/css/menu-style.css
+++ b/packages/html/stories/css/menu-style.css
@@ -1,0 +1,36 @@
+body div.mxPopupMenu {
+    -webkit-box-shadow: 3px 3px 6px #C0C0C0;
+    -moz-box-shadow: 3px 3px 6px #C0C0C0;
+    box-shadow: 3px 3px 6px #C0C0C0;
+    background: white;
+    position: absolute;
+    border: 3px solid #e7e7e7;
+    padding: 3px;
+}
+body table.mxPopupMenu {
+    border-collapse: collapse;
+    margin: 0;
+}
+body tr.mxPopupMenuItem {
+    color: black;
+    cursor: default;
+}
+body td.mxPopupMenuItem {
+    padding: 6px 60px 6px 30px;
+    font-family: Arial, sans-serif;
+    font-size: 10pt;
+}
+body td.mxPopupMenuIcon {
+    background-color: white;
+    padding: 0;
+}
+body tr.mxPopupMenuItemHover {
+    background-color: #eeeeee;
+    color: black;
+}
+table.mxPopupMenu hr {
+    border-top: solid 1px #cccccc;
+}
+table.mxPopupMenu tr {
+    font-size: 4pt;
+}

--- a/packages/html/stories/css/show-region.css
+++ b/packages/html/stories/css/show-region.css
@@ -1,0 +1,1 @@
+@import "menu-style.css";


### PR DESCRIPTION
Previously, the CSS was included programmatically in the document, which is not the best way to add CSS in the storybook
context. In this case, the CSS was added each time the story was rendered, so the CSS definition was added multiple
times

The stories now use external CSS and use imports to include them. This removes the duplicated includes in the DOM and
makes the thing easier to understand by using standard practices.

Notice that the Scrollbars story is still using the former way of including custom CSS.
It is not functional and requires additional work. So, it will be updated later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated popup menu styling by shifting from inline definitions to external CSS.
	- Introduced a consolidated stylesheet for popup menus, enhancing visual consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->