### PR TITLE
fix: Graph.isValidAncestor manages null Cell parameter

### DIFF
--- a/packages/core/__tests__/view/mixins/CellMixin.test.ts
+++ b/packages/core/__tests__/view/mixins/CellMixin.test.ts
@@ -256,3 +256,14 @@ describe('isCellRotatable', () => {
     ).toBeFalsy();
   });
 });
+
+describe('isValidAncestor', () => {
+  test('Cell does not match parent', () => {
+    expect(
+      createGraphWithoutPlugins().isValidAncestor(new Cell(), new Cell())
+    ).toBeFalsy();
+  });
+  test('null Cell', () => {
+    expect(createGraphWithoutPlugins().isValidAncestor(null, new Cell())).toBeFalsy();
+  });
+});

--- a/packages/core/__tests__/view/mixins/CellMixin.test.ts
+++ b/packages/core/__tests__/view/mixins/CellMixin.test.ts
@@ -258,12 +258,46 @@ describe('isCellRotatable', () => {
 });
 
 describe('isValidAncestor', () => {
-  test('Cell does not match parent', () => {
-    expect(
-      createGraphWithoutPlugins().isValidAncestor(new Cell(), new Cell())
-    ).toBeFalsy();
+  function configureParentChild(parent: Cell, child: Cell) {
+    child.setParent(parent);
+    parent.children.push(child);
+  }
+
+  test('Parent is the direct parent of the Cell, recurse: false', () => {
+    const parent = new Cell();
+    const cell = new Cell();
+    cell.setParent(parent);
+    expect(createGraphWithoutPlugins().isValidAncestor(cell, parent)).toBeTruthy();
   });
-  test('null Cell', () => {
-    expect(createGraphWithoutPlugins().isValidAncestor(null, new Cell())).toBeFalsy();
+
+  test('Cell is direct child of parent but does not declare it as parent, and recurse: false', () => {
+    const cell = new Cell();
+    const parent = new Cell();
+    parent.children.push(cell);
+    expect(createGraphWithoutPlugins().isValidAncestor(cell, parent)).toBeFalsy();
+  });
+
+  test('Cell is direct child of parent, recurse: true', () => {
+    const cell = new Cell();
+    const intermediateParent = new Cell();
+    configureParentChild(intermediateParent, cell);
+    const parent = new Cell();
+    configureParentChild(parent, intermediateParent);
+    expect(createGraphWithoutPlugins().isValidAncestor(cell, parent, true)).toBeTruthy();
+  });
+
+  test.each([true, false])(
+    'Cell does not match parent, recurse: %s',
+    (recurse: boolean) => {
+      expect(
+        createGraphWithoutPlugins().isValidAncestor(new Cell(), new Cell(), recurse)
+      ).toBeFalsy();
+    }
+  );
+
+  test.each([true, false])('null Cell, recurse: %s', (recurse: boolean) => {
+    expect(
+      createGraphWithoutPlugins().isValidAncestor(null, new Cell(), recurse)
+    ).toBeFalsy();
   });
 });

--- a/packages/core/src/view/mixins/CellsMixin.ts
+++ b/packages/core/src/view/mixins/CellsMixin.ts
@@ -1750,7 +1750,7 @@ export const CellsMixin: PartialType = {
   },
 
   isValidAncestor(cell, parent, recurse = false) {
-    return recurse ? parent.isAncestor(cell) : cell.getParent() === parent;
+    return recurse ? parent.isAncestor(cell) : cell?.getParent() === parent;
   },
 
   /*****************************************************************************

--- a/packages/core/src/view/mixins/CellsMixin.type.ts
+++ b/packages/core/src/view/mixins/CellsMixin.type.ts
@@ -720,7 +720,7 @@ declare module '../Graph' {
      * @param parent {@link Cell} the possible parent cell
      * @param recurse boolean whether to recurse the child ancestors. Default is `false`.
      */
-    isValidAncestor: (cell: Cell, parent: Cell, recurse: boolean) => boolean;
+    isValidAncestor: (cell: Cell | null, parent: Cell, recurse?: boolean) => boolean;
 
     /**
      * Returns `true` if the given cell may not be moved, sized, bended, disconnected, edited or selected.

--- a/packages/core/src/view/mixins/EdgeMixin.ts
+++ b/packages/core/src/view/mixins/EdgeMixin.ts
@@ -341,10 +341,10 @@ export const EdgeMixin: PartialType = {
         (source !== target &&
           ((incoming &&
             target === cell &&
-            (!parent || this.isValidAncestor(<Cell>source, parent, recurse))) ||
+            (!parent || this.isValidAncestor(source, parent, recurse))) ||
             (outgoing &&
               source === cell &&
-              (!parent || this.isValidAncestor(<Cell>target, parent, recurse)))))
+              (!parent || this.isValidAncestor(target, parent, recurse)))))
       ) {
         result.push(edges[i]);
       }


### PR DESCRIPTION
At runtime, some code pass a `null` Cell parameter, for example in `Graph.getEdges`. Previously, the implementation
thrown an error if Cell was `null`.

Also improve the signature of `Graph.isValidAncestor`
- the `cell` parameter accepts `null` values
- the `recurse` parameter is marked as optional


## Notes

Closes #236



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced stability by safely handling cases with missing or invalid inputs during relationship validations, thereby reducing potential runtime errors.
- **Tests**
	- Expanded test coverage to verify that non-valid relationships are correctly identified, including various parent-child scenarios.
- **Refactor**
	- Streamlined type-checking in the validation process for improved maintainability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->