### PR TITLE
feat: refine the type of `CellStateStyle.elbow`

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -198,7 +198,7 @@ export type CellStateStyle = {
    * The possible values are 'horizontal' and 'vertical'.
    * @default 'horizontal'
    */
-  elbow?: string;
+  elbow?: 'horizontal' | 'vertical';
   /**
    * This defines the style of the end arrow marker.
    *


### PR DESCRIPTION
This property can only take two values but the type allowed to specify any string.
Its type is now more precise to better guide usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced internal configuration by restricting orientation settings to only allow "horizontal" or "vertical" values, reducing the risk of incorrect configurations and promoting a more consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->