### PR TITLE
chore(deps-dev): bump typescript from 5.7.2 to 5.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "eslint-plugin-import": "~2.31.0",
         "eslint-plugin-prettier": "~5.2.3",
         "prettier": "~3.5.3",
-        "typescript": "~5.7.2"
+        "typescript": "~5.8.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -32308,9 +32308,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "eslint-plugin-import": "~2.31.0",
     "eslint-plugin-prettier": "~5.2.3",
     "prettier": "~3.5.3",
-    "typescript": "~5.7.2"
+    "typescript": "~5.8.2"
   }
 }

--- a/packages/core/src/util/MaxXmlRequest.ts
+++ b/packages/core/src/util/MaxXmlRequest.ts
@@ -229,7 +229,7 @@ class MaxXmlRequest {
   /**
    * Creates and returns the inner {@link request} object.
    */
-  create(): XMLHttpRequest {
+  create(): any {
     const req = new XMLHttpRequest();
 
     // TODO: Check for overrideMimeType required here?

--- a/packages/core/src/util/MaxXmlRequest.ts
+++ b/packages/core/src/util/MaxXmlRequest.ts
@@ -220,16 +220,16 @@ class MaxXmlRequest {
 
   /**
    * Returns the status as a number, eg. 404 for "Not found" or 200 for "OK".
-   * Note: The NS_ERROR_NOT_AVAILABLE for invalid responses cannot be cought.
+   * Note: The NS_ERROR_NOT_AVAILABLE for invalid responses cannot be caught.
    */
   getStatus(): number {
-    return this.request != null ? this.request.status : null;
+    return this.request?.status;
   }
 
   /**
    * Creates and returns the inner {@link request} object.
    */
-  create(): any {
+  create(): XMLHttpRequest {
     const req = new XMLHttpRequest();
 
     // TODO: Check for overrideMimeType required here?


### PR DESCRIPTION
Fix new TSC errors now detected by TypeScript.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
  - Upgraded the TypeScript dependency to version ~5.8.2 for improved development reliability.
  
- **Refactor**
  - Streamlined the handling of request status and refined related documentation for enhanced clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->