### PR TITLE
refactor: simplify type management in Codecs

### DIFF
--- a/packages/core/__tests__/util/mathUtils.test.ts
+++ b/packages/core/__tests__/util/mathUtils.test.ts
@@ -1,0 +1,52 @@
+/*
+Copyright 2025-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, expect, test } from '@jest/globals';
+import { isNumeric } from '../../src/util/mathUtils';
+
+describe('isNumeric', () => {
+  test.each([null, undefined])('nullish value: %s', (value: null | undefined) => {
+    expect(isNumeric(value)).toBeFalsy();
+  });
+
+  test('number', () => {
+    expect(isNumeric(9465.45654)).toBeTruthy();
+  });
+
+  test('Infinity', () => {
+    expect(isNumeric(Infinity)).toBeFalsy();
+  });
+
+  test('empty string', () => {
+    expect(isNumeric('')).toBeFalsy();
+  });
+
+  test('hexadecimal in string', () => {
+    expect(isNumeric('0x354354')).toBeFalsy();
+  });
+
+  test('string which is not a number', () => {
+    expect(isNumeric('354354b')).toBeFalsy();
+  });
+
+  test('too large number in a string', () => {
+    expect(isNumeric('9465456546987616587651356846')).toBeTruthy();
+  });
+
+  test('Object', () => {
+    expect(isNumeric({ attribute: 'value' })).toBeFalsy();
+  });
+});

--- a/packages/core/src/editor/EditorPopupMenu.ts
+++ b/packages/core/src/editor/EditorPopupMenu.ts
@@ -186,12 +186,12 @@ export class EditorPopupMenu {
   ) {
     let addSeparator = false;
 
-    while (item != null) {
+    while (item) {
       if (item.nodeName === 'add') {
         const condition = item.getAttribute('if');
 
         if (condition == null || conditions[condition]) {
-          let as = <string>item.getAttribute('as');
+          let as = item.getAttribute('as')!;
           as = Translations.get(as) || as;
           const funct = eval(getTextContent(<Text>(<unknown>item)));
           const action = item.getAttribute('action');

--- a/packages/core/src/internal-types.ts
+++ b/packages/core/src/internal-types.ts
@@ -1,0 +1,28 @@
+/*
+Copyright 2025-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @internal
+ * @private
+ */
+export type UserObject = {
+  nodeType?: number;
+  getAttribute?: (name: string) => string | null;
+  hasAttribute?: (name: string) => boolean;
+  setAttribute?: (name: string, value: string) => void;
+  clone?: () => UserObject;
+  cloneNode?: (deep: boolean) => UserObject;
+};

--- a/packages/core/src/serialization/Codec.ts
+++ b/packages/core/src/serialization/Codec.ts
@@ -21,8 +21,7 @@ import CodecRegistry from './CodecRegistry';
 import Cell from '../view/cell/Cell';
 import { GlobalConfig } from '../util/config';
 import { getFunctionName } from '../util/StringUtils';
-import { importNode, isNode } from '../util/domUtils';
-import { isElement } from '../util/xmlUtils';
+import { importNode, isElement, isNode } from '../util/domUtils';
 
 const createXmlDocument = () => {
   return document.implementation.createDocument('', '', null);

--- a/packages/core/src/serialization/Codec.ts
+++ b/packages/core/src/serialization/Codec.ts
@@ -18,11 +18,11 @@ limitations under the License.
 
 import CellPath from '../view/cell/CellPath';
 import CodecRegistry from './CodecRegistry';
-import { NODETYPE } from '../util/Constants';
 import Cell from '../view/cell/Cell';
 import { GlobalConfig } from '../util/config';
 import { getFunctionName } from '../util/StringUtils';
 import { importNode, isNode } from '../util/domUtils';
+import { isElement } from '../util/xmlUtils';
 
 const createXmlDocument = () => {
   return document.implementation.createDocument('', '', null);
@@ -248,7 +248,7 @@ class Codec {
    * Adds the given element to {@link elements} if it has an ID.
    */
   addElement(node: Element): void {
-    if (node.nodeType === NODETYPE.ELEMENT) {
+    if (isElement(node)) {
       const id = node.getAttribute('id');
 
       if (id != null) {
@@ -359,7 +359,7 @@ class Codec {
     this.updateElements();
     let obj = null;
 
-    if (node != null && node.nodeType === NODETYPE.ELEMENT) {
+    if (isElement(node)) {
       const dec = CodecRegistry.getCodecByName(node.nodeName);
 
       if (dec != null) {
@@ -429,7 +429,7 @@ class Codec {
    * Default is `true`.
    */
   decodeCell(node: Element, restoreStructures = true): Cell | null {
-    if (node?.nodeType !== NODETYPE.ELEMENT) {
+    if (!isElement(node)) {
       return null;
     }
 

--- a/packages/core/src/serialization/ObjectCodec.ts
+++ b/packages/core/src/serialization/ObjectCodec.ts
@@ -20,11 +20,11 @@ import ObjectIdentity from '../util/ObjectIdentity';
 import { GlobalConfig } from '../util/config';
 import Geometry from '../view/geometry/Geometry';
 import Point from '../view/geometry/Point';
-import { NODETYPE } from '../util/Constants';
 import { isInteger, isNumeric } from '../util/mathUtils';
 import { getTextContent } from '../util/domUtils';
 import { load } from '../util/MaxXmlRequest';
 import type Codec from './Codec';
+import { isElement } from '../util/xmlUtils';
 
 /**
  * Generic codec for JavaScript objects that implements a mapping between
@@ -791,10 +791,10 @@ class ObjectCodec {
   decodeChildren(dec: Codec, node: Element, obj?: any): void {
     let child = <Element>node.firstChild;
 
-    while (child != null) {
+    while (child) {
       const tmp = <Element>child.nextSibling;
 
-      if (child.nodeType === NODETYPE.ELEMENT && !this.processInclude(dec, child, obj)) {
+      if (isElement(child) && !this.processInclude(dec, child, obj)) {
         this.decodeChild(dec, child, obj);
       }
 

--- a/packages/core/src/serialization/ObjectCodec.ts
+++ b/packages/core/src/serialization/ObjectCodec.ts
@@ -21,10 +21,9 @@ import { GlobalConfig } from '../util/config';
 import Geometry from '../view/geometry/Geometry';
 import Point from '../view/geometry/Point';
 import { isInteger, isNumeric } from '../util/mathUtils';
-import { getTextContent } from '../util/domUtils';
+import { getTextContent, isElement } from '../util/domUtils';
 import { load } from '../util/MaxXmlRequest';
 import type Codec from './Codec';
-import { isElement } from '../util/xmlUtils';
 
 /**
  * Generic codec for JavaScript objects that implements a mapping between

--- a/packages/core/src/serialization/codecs/CellCodec.ts
+++ b/packages/core/src/serialization/codecs/CellCodec.ts
@@ -18,9 +18,8 @@ import CodecRegistry from '../CodecRegistry';
 import ObjectCodec from '../ObjectCodec';
 import Cell from '../../view/cell/Cell';
 import type Codec from '../Codec';
-import { importNode } from '../../util/domUtils';
+import { importNode, isElement } from '../../util/domUtils';
 import { removeWhitespace } from '../../util/StringUtils';
-import { isElement } from '../../util/xmlUtils';
 
 /**
  * Codec for {@link Cell}s.

--- a/packages/core/src/serialization/codecs/CellCodec.ts
+++ b/packages/core/src/serialization/codecs/CellCodec.ts
@@ -18,9 +18,9 @@ import CodecRegistry from '../CodecRegistry';
 import ObjectCodec from '../ObjectCodec';
 import Cell from '../../view/cell/Cell';
 import type Codec from '../Codec';
-import { NODETYPE } from '../../util/Constants';
 import { importNode } from '../../util/domUtils';
 import { removeWhitespace } from '../../util/StringUtils';
+import { isElement } from '../../util/xmlUtils';
 
 /**
  * Codec for {@link Cell}s.
@@ -82,7 +82,7 @@ export class CellCodec extends ObjectCodec {
   isExcluded(obj: any, attr: string, value: Element, isWrite: boolean) {
     return (
       super.isExcluded(obj, attr, value, isWrite) ||
-      (isWrite && attr === 'value' && value.nodeType === NODETYPE.ELEMENT)
+      (isWrite && attr === 'value' && isElement(value))
     );
   }
 
@@ -90,7 +90,7 @@ export class CellCodec extends ObjectCodec {
    * Encodes a {@link Cell} and wraps the XML up inside the XML of the user object (inversion).
    */
   afterEncode(enc: Codec, obj: Cell, node: Element) {
-    if (obj.value != null && obj.value.nodeType === NODETYPE.ELEMENT) {
+    if (isElement(obj.value)) {
       // Wraps the graphical annotation up in the user object (inversion)
       // by putting the result of the default encoding into a clone of the
       // user object (node type 1) and returning this cloned user object.

--- a/packages/core/src/serialization/codecs/ChildChangeCodec.ts
+++ b/packages/core/src/serialization/codecs/ChildChangeCodec.ts
@@ -17,7 +17,8 @@ limitations under the License.
 import ObjectCodec from '../ObjectCodec';
 import ChildChange from '../../view/undoable_changes/ChildChange';
 import type Codec from '../Codec';
-import { NODETYPE } from '../../util/Constants';
+
+import { isElement } from '../../util/xmlUtils';
 
 /**
  * Codec for {@link ChildChange}s.
@@ -93,7 +94,7 @@ export class ChildChangeCodec extends ObjectCodec {
    * Decodes any child nodes as using the respective codec from the registry.
    */
   beforeDecode(dec: Codec, _node: Element, obj: any): any {
-    if (_node.firstChild != null && _node.firstChild.nodeType === NODETYPE.ELEMENT) {
+    if (isElement(_node.firstChild)) {
       // Makes sure the original node isn't modified
       const node = _node.cloneNode(true);
 
@@ -104,23 +105,23 @@ export class ChildChangeCodec extends ObjectCodec {
       (<Element>tmp.parentNode).removeChild(tmp);
       tmp = tmp2;
 
-      while (tmp != null) {
+      while (tmp) {
         tmp2 = <Element>tmp.nextSibling;
 
-        if (tmp.nodeType === NODETYPE.ELEMENT) {
+        if (isElement(tmp)) {
           // Ignores all existing cells because those do not need to
           // be re-inserted into the model. Since the encoded version
           // of these cells contains the new parent, this would leave
           // to an inconsistent state on the model (i.e. a parent
           // change without a call to parentForCellChanged).
-          const id = <string>tmp.getAttribute('id');
+          const id = tmp.getAttribute('id')!;
 
           if (dec.lookup(id) == null) {
             dec.decodeCell(tmp);
           }
         }
 
-        (<Element>tmp.parentNode).removeChild(tmp);
+        tmp.parentNode?.removeChild(tmp);
         tmp = tmp2;
       }
 

--- a/packages/core/src/serialization/codecs/ChildChangeCodec.ts
+++ b/packages/core/src/serialization/codecs/ChildChangeCodec.ts
@@ -18,7 +18,7 @@ import ObjectCodec from '../ObjectCodec';
 import ChildChange from '../../view/undoable_changes/ChildChange';
 import type Codec from '../Codec';
 
-import { isElement } from '../../util/xmlUtils';
+import { isElement } from '../../util/domUtils';
 
 /**
  * Codec for {@link ChildChange}s.

--- a/packages/core/src/serialization/codecs/RootChangeCodec.ts
+++ b/packages/core/src/serialization/codecs/RootChangeCodec.ts
@@ -17,7 +17,8 @@ limitations under the License.
 import ObjectCodec from '../ObjectCodec';
 import RootChange from '../../view/undoable_changes/RootChange';
 import type Codec from '../Codec';
-import { NODETYPE } from '../../util/Constants';
+
+import { isElement } from '../../util/xmlUtils';
 
 /**
  * Codec for {@link RootChange}s.
@@ -50,7 +51,7 @@ export class RootChangeCodec extends ObjectCodec {
    * Decodes the optional children as cells using the respective decoder.
    */
   beforeDecode(dec: Codec, node: Element, obj: any): any {
-    if (node.firstChild != null && node.firstChild.nodeType === NODETYPE.ELEMENT) {
+    if (isElement(node.firstChild)) {
       // Makes sure the original node isn't modified
       node = <Element>node.cloneNode(true);
 
@@ -58,13 +59,13 @@ export class RootChangeCodec extends ObjectCodec {
       obj.root = dec.decodeCell(tmp, false);
 
       let tmp2 = <Element>tmp.nextSibling;
-      (<Element>tmp.parentNode).removeChild(tmp);
+      tmp.parentNode?.removeChild(tmp);
       tmp = tmp2;
 
       while (tmp != null) {
         tmp2 = <Element>tmp.nextSibling;
         dec.decodeCell(tmp);
-        (<Element>tmp.parentNode).removeChild(tmp);
+        tmp.parentNode?.removeChild(tmp);
         tmp = tmp2;
       }
     }

--- a/packages/core/src/serialization/codecs/RootChangeCodec.ts
+++ b/packages/core/src/serialization/codecs/RootChangeCodec.ts
@@ -18,7 +18,7 @@ import ObjectCodec from '../ObjectCodec';
 import RootChange from '../../view/undoable_changes/RootChange';
 import type Codec from '../Codec';
 
-import { isElement } from '../../util/xmlUtils';
+import { isElement } from '../../util/domUtils';
 
 /**
  * Codec for {@link RootChange}s.

--- a/packages/core/src/serialization/codecs/StylesheetCodec.ts
+++ b/packages/core/src/serialization/codecs/StylesheetCodec.ts
@@ -125,22 +125,22 @@ export class StylesheetCodec extends ObjectCodec {
     const obj = into || new this.template.constructor();
     const id = _node.getAttribute('id');
 
-    if (id != null) {
+    if (id) {
       dec.objects[id] = obj;
     }
 
     let node: Element | ChildNode | null = _node.firstChild;
 
-    while (node != null) {
+    while (node) {
       if (!this.processInclude(dec, <Element>node, obj) && node.nodeName === 'add') {
         const as = (<Element>node).getAttribute('as');
 
-        if (as != null) {
+        if (as) {
           const extend = (<Element>node).getAttribute('extend');
-          let style = extend != null ? clone(obj.styles[extend]) : null;
+          let style = extend ? clone(obj.styles[extend]) : null;
 
-          if (style == null) {
-            if (extend != null) {
+          if (!style) {
+            if (extend) {
               GlobalConfig.logger.warn(
                 `StylesheetCodec.decode: stylesheet ${extend} not found to extend`
               );
@@ -168,7 +168,7 @@ export class StylesheetCodec extends ObjectCodec {
                   }
                 }
 
-                if (value != null) {
+                if (value) {
                   style[key] = value;
                 }
               } else if (entry.nodeName === 'remove') {

--- a/packages/core/src/serialization/codecs/StylesheetCodec.ts
+++ b/packages/core/src/serialization/codecs/StylesheetCodec.ts
@@ -93,35 +93,32 @@ export class StylesheetCodec extends ObjectCodec {
    * Reads a sequence of the following child nodes and attributes:
    *
    * Child Nodes:
-   *
-   * add - Adds a new style.
+   * - `add` - Adds a new style.
    *
    * Attributes:
-   *
-   * as - Name of the style.
-   * extend - Name of the style to inherit from.
+   * - `as` - Name of the style.
+   * - `extend` - Name of the style to inherit from.
    *
    * Each node contains another sequence of add and remove nodes with the following attributes:
-   *
-   * as - Name of the style (see {@link Constants}).
-   * value - Value for the style.
+   * - `as` - Name of the style (see properties of {@link CellStateStyle}).
+   * - `value` - Value for the style.
    *
    * Instead of the value-attribute, one can put Javascript expressions into the node as follows if {@link allowEval} is `true`:
-   * <add as="perimeter">mxPerimeter.RectanglePerimeter</add>
+   * <add as="perimeter">Perimeter.RectanglePerimeter</add>
    *
    * A remove node will remove the entry with the name given in the as-attribute from the style.
    *
    * Example:
    *
    * ```javascript
-   * <mxStylesheet as="stylesheet">
+   * <Stylesheet as="stylesheet">
    *   <add as="text">
    *     <add as="fontSize" value="12"/>
    *   </add>
    *   <add as="defaultVertex" extend="text">
    *     <add as="shape" value="rectangle"/>
    *   </add>
-   * </mxStylesheet>
+   * </Stylesheet>
    * ```
    */
   decode(dec: Codec, _node: Element, into: any): any {

--- a/packages/core/src/serialization/codecs/StylesheetCodec.ts
+++ b/packages/core/src/serialization/codecs/StylesheetCodec.ts
@@ -21,8 +21,7 @@ import StyleRegistry from '../../view/style/StyleRegistry';
 import { clone } from '../../util/cloneUtils';
 import { GlobalConfig } from '../../util/config';
 import { isNumeric } from '../../util/mathUtils';
-import { getTextContent } from '../../util/domUtils';
-import { isElement } from '../../util/xmlUtils';
+import { getTextContent, isElement } from '../../util/domUtils';
 
 /**
  * Codec for {@link Stylesheet}s.

--- a/packages/core/src/serialization/codecs/StylesheetCodec.ts
+++ b/packages/core/src/serialization/codecs/StylesheetCodec.ts
@@ -167,7 +167,7 @@ export class StylesheetCodec extends ObjectCodec {
                   value = entry.getAttribute('value');
 
                   if (isNumeric(value)) {
-                    value = parseFloat(value!); // value is not null here (see isNumeric)
+                    value = parseFloat(value);
                   }
                 }
 

--- a/packages/core/src/serialization/codecs/StylesheetCodec.ts
+++ b/packages/core/src/serialization/codecs/StylesheetCodec.ts
@@ -20,9 +20,9 @@ import type Codec from '../Codec';
 import StyleRegistry from '../../view/style/StyleRegistry';
 import { clone } from '../../util/cloneUtils';
 import { GlobalConfig } from '../../util/config';
-import { NODETYPE } from '../../util/Constants';
 import { isNumeric } from '../../util/mathUtils';
 import { getTextContent } from '../../util/domUtils';
+import { isElement } from '../../util/xmlUtils';
 
 /**
  * Codec for {@link Stylesheet}s.
@@ -154,22 +154,21 @@ export class StylesheetCodec extends ObjectCodec {
           }
 
           let entry = node.firstChild;
-
-          while (entry != null) {
-            if (entry.nodeType === NODETYPE.ELEMENT) {
-              const key = <string>(<Element>entry).getAttribute('as');
+          while (entry) {
+            if (isElement(entry)) {
+              const key = entry.getAttribute('as')!;
 
               if (entry.nodeName === 'add') {
                 const text = getTextContent(<Text>(<unknown>entry));
                 let value = null;
 
-                if (text != null && text.length > 0 && StylesheetCodec.allowEval) {
+                if (text && StylesheetCodec.allowEval) {
                   value = eval(text);
                 } else {
-                  value = (<Element>entry).getAttribute('value');
+                  value = entry.getAttribute('value');
 
                   if (isNumeric(value)) {
-                    value = parseFloat(<string>value);
+                    value = parseFloat(value!); // value is not null here (see isNumeric)
                   }
                 }
 

--- a/packages/core/src/serialization/codecs/editor/EditorCodec.ts
+++ b/packages/core/src/serialization/codecs/editor/EditorCodec.ts
@@ -193,12 +193,11 @@ export class EditorCodec extends ObjectCodec {
           editor.setStatusContainer(element);
         } else if (as === 'map') {
           throw new Error('Unimplemented');
-          //editor.setMapContainer(element);
         }
       } else if (tmp.nodeName === 'resource') {
-        Translations.add(<string>tmp.getAttribute('basename'));
+        Translations.add(tmp.getAttribute('basename')!);
       } else if (tmp.nodeName === 'stylesheet') {
-        addLinkToHead('stylesheet', <string>tmp.getAttribute('name'));
+        addLinkToHead('stylesheet', tmp.getAttribute('name')!);
       }
 
       tmp = <Element>tmp.nextSibling;

--- a/packages/core/src/serialization/codecs/editor/EditorToolbarCodec.ts
+++ b/packages/core/src/serialization/codecs/editor/EditorToolbarCodec.ts
@@ -22,9 +22,8 @@ import { GlobalConfig } from '../../../util/config';
 import { convertPoint } from '../../../util/styleUtils';
 import { getClientX, getClientY } from '../../../util/EventUtils';
 import InternalEvent from '../../../view/event/InternalEvent';
-import { getChildNodes, getTextContent } from '../../../util/domUtils';
+import { getChildNodes, getTextContent, isElement } from '../../../util/domUtils';
 import Translations from '../../../i18n/Translations';
-import { isElement } from '../../../util/xmlUtils';
 
 /**
  * Custom codec for configuring {@link EditorToolbar}s.

--- a/packages/core/src/serialization/codecs/editor/EditorToolbarCodec.ts
+++ b/packages/core/src/serialization/codecs/editor/EditorToolbarCodec.ts
@@ -18,13 +18,13 @@ import ObjectCodec from '../../ObjectCodec';
 import { EditorToolbar } from '../../../editor/EditorToolbar';
 import type Codec from '../../Codec';
 import type Editor from '../../../editor/Editor';
-import { NODETYPE } from '../../../util/Constants';
 import { GlobalConfig } from '../../../util/config';
 import { convertPoint } from '../../../util/styleUtils';
 import { getClientX, getClientY } from '../../../util/EventUtils';
 import InternalEvent from '../../../view/event/InternalEvent';
 import { getChildNodes, getTextContent } from '../../../util/domUtils';
 import Translations from '../../../i18n/Translations';
+import { isElement } from '../../../util/xmlUtils';
 
 /**
  * Custom codec for configuring {@link EditorToolbar}s.
@@ -134,7 +134,7 @@ export class EditorToolbarCodec extends ObjectCodec {
       let node: Element | null = <Element | null>_node.firstChild;
 
       while (node != null) {
-        if (node.nodeType === NODETYPE.ELEMENT) {
+        if (isElement(node)) {
           if (!this.processInclude(dec, node, into)) {
             if (node.nodeName === 'separator') {
               into.addSeparator();

--- a/packages/core/src/util/domUtils.ts
+++ b/packages/core/src/util/domUtils.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import { NODETYPE } from './Constants';
+import { UserObject } from '../internal-types';
 
 /**
  * Returns the text content of the specified node.
@@ -359,3 +360,10 @@ export const addLinkToHead = (
   const head = doc.getElementsByTagName('head')[0];
   head.appendChild(link);
 };
+/**
+ * Returns true if the parameter is not `nullish` and its nodeType relates to an {@link Element}.
+ * @internal
+ * @private
+ */
+export const isElement = (node?: Node | UserObject | null): node is Element =>
+  node?.nodeType === NODETYPE.ELEMENT;

--- a/packages/core/src/util/domUtils.ts
+++ b/packages/core/src/util/domUtils.ts
@@ -85,7 +85,7 @@ export const extractTextWithWhitespace = (elems: Element[]): string => {
  * @param node DOM node to return the text content for.
  */
 export const getTextContent = (node: Text | null): string => {
-  return node != null && node.textContent ? node.textContent : '';
+  return node?.textContent ?? '';
 };
 
 /**
@@ -262,8 +262,7 @@ export const isAncestorNode = (ancestor: Element, child: Element | null) => {
  * Returns an array of child nodes that are of the given node type.
  *
  * @param node Parent DOM node to return the children from.
- * @param nodeType Optional node type to return. Default is
- * {@link Constants#NODETYPE_ELEMENT}.
+ * @param nodeType Optional node type to return. Default is {@link NODETYPE.ELEMENT}.
  */
 export const getChildNodes = (
   node: Element,
@@ -285,7 +284,7 @@ export const getChildNodes = (
 };
 
 /**
- * Cross browser implementation for document.importNode. Uses document.importNode
+ * Cross browser implementation for document.importNode. Uses {@link Document.importNode}
  * in all browsers but IE, where the node is cloned by creating a new node and
  * copying all attributes and children into it using importNode, recursively.
  *

--- a/packages/core/src/util/mathUtils.ts
+++ b/packages/core/src/util/mathUtils.ts
@@ -658,7 +658,7 @@ export const intersectsHotspot = (
  *
  * @param n String representing the possibly numeric value.
  */
-export const isNumeric = (n: any) => {
+export const isNumeric = (n: any): n is {} => {
   return (
     !Number.isNaN(parseFloat(n)) &&
     isFinite(+n) &&

--- a/packages/core/src/util/mathUtils.ts
+++ b/packages/core/src/util/mathUtils.ts
@@ -658,7 +658,7 @@ export const intersectsHotspot = (
  *
  * @param n String representing the possibly numeric value.
  */
-export const isNumeric = (n: any): n is {} => {
+export const isNumeric = (n: any): n is number | string => {
   return (
     !Number.isNaN(parseFloat(n)) &&
     isFinite(+n) &&

--- a/packages/core/src/util/xmlUtils.ts
+++ b/packages/core/src/util/xmlUtils.ts
@@ -26,6 +26,7 @@ import TemporaryCellStates from '../view/cell/TemporaryCellStates';
 import type { StyleValue } from '../types';
 import { getTextContent } from './domUtils';
 import Codec from '../serialization/Codec';
+import { UserObject } from '../internal-types';
 
 /**
  * Returns a new, empty XML document.
@@ -228,7 +229,7 @@ export const findNode = (
   attr: string,
   value: StyleValue
 ): Element | null => {
-  if (node.nodeType === NODETYPE.ELEMENT) {
+  if (isElement(node)) {
     const tmp = node.getAttribute(attr);
     if (tmp && tmp === value) {
       return node;
@@ -247,3 +248,11 @@ export const findNode = (
 
   return null;
 };
+
+/**
+ * Returns true if the parameter is not `nullish` and its nodeType relates to an {@link Element}.
+ * @internal
+ * @private
+ */
+export const isElement = (node?: Node | UserObject | null): node is Element =>
+  node?.nodeType === NODETYPE.ELEMENT;

--- a/packages/core/src/util/xmlUtils.ts
+++ b/packages/core/src/util/xmlUtils.ts
@@ -24,9 +24,8 @@ import { htmlEntities, trim } from './StringUtils';
 import TemporaryCellStates from '../view/cell/TemporaryCellStates';
 
 import type { StyleValue } from '../types';
-import { getTextContent } from './domUtils';
+import { getTextContent, isElement } from './domUtils';
 import Codec from '../serialization/Codec';
-import { UserObject } from '../internal-types';
 
 /**
  * Returns a new, empty XML document.
@@ -248,11 +247,3 @@ export const findNode = (
 
   return null;
 };
-
-/**
- * Returns true if the parameter is not `nullish` and its nodeType relates to an {@link Element}.
- * @internal
- * @private
- */
-export const isElement = (node?: Node | UserObject | null): node is Element =>
-  node?.nodeType === NODETYPE.ELEMENT;

--- a/packages/core/src/view/cell/Cell.ts
+++ b/packages/core/src/view/cell/Cell.ts
@@ -16,7 +16,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { NODETYPE } from '../../util/Constants';
 import Geometry from '../geometry/Geometry';
 import CellOverlay from './CellOverlay';
 import { clone } from '../../util/cloneUtils';

--- a/packages/core/src/view/cell/Cell.ts
+++ b/packages/core/src/view/cell/Cell.ts
@@ -25,15 +25,8 @@ import CellPath from './CellPath';
 import { isNotNullish } from '../../util/Utils';
 
 import type { CellStyle, FilterFunction, IdentityObject } from '../../types';
-
-type UserObject = {
-  nodeType?: number;
-  getAttribute?: (name: string) => string | null;
-  hasAttribute?: (name: string) => boolean;
-  setAttribute?: (name: string, value: string) => void;
-  clone?: () => UserObject;
-  cloneNode?: (deep: boolean) => UserObject;
-};
+import { isElement } from '../../util/xmlUtils';
+import type { UserObject } from '../../internal-types';
 
 /**
  * Cells are the elements of the graph model. They represent the state
@@ -573,12 +566,9 @@ export class Cell implements IdentityObject {
   hasAttribute(name: string): boolean {
     const userObject: UserObject = this.getValue();
 
-    return (
-      isNotNullish(userObject) &&
-      (userObject.nodeType === NODETYPE.ELEMENT && userObject.hasAttribute
-        ? userObject.hasAttribute(name)
-        : isNotNullish(userObject.getAttribute?.(name)))
-    );
+    return isElement(userObject) && userObject.hasAttribute
+      ? userObject.hasAttribute(name)
+      : isNotNullish(userObject.getAttribute?.(name));
   }
 
   /**
@@ -590,10 +580,7 @@ export class Cell implements IdentityObject {
    */
   getAttribute(name: string, defaultValue?: any): any {
     const userObject: UserObject = this.getValue();
-    const val =
-      isNotNullish(userObject) && userObject.nodeType === NODETYPE.ELEMENT
-        ? userObject.getAttribute?.(name)
-        : null;
+    const val = isElement(userObject) ? userObject.getAttribute?.(name) : null;
 
     return val ?? defaultValue;
   }
@@ -607,7 +594,7 @@ export class Cell implements IdentityObject {
   setAttribute(name: string, value: any): void {
     const userObject: UserObject = this.getValue();
 
-    if (isNotNullish(userObject) && userObject.nodeType === NODETYPE.ELEMENT) {
+    if (isElement(userObject)) {
       userObject.setAttribute?.(name, value);
     }
   }

--- a/packages/core/src/view/cell/Cell.ts
+++ b/packages/core/src/view/cell/Cell.ts
@@ -25,8 +25,8 @@ import CellPath from './CellPath';
 import { isNotNullish } from '../../util/Utils';
 
 import type { CellStyle, FilterFunction, IdentityObject } from '../../types';
-import { isElement } from '../../util/xmlUtils';
 import type { UserObject } from '../../internal-types';
+import { isElement } from '../../util/domUtils';
 
 /**
  * Cells are the elements of the graph model. They represent the state

--- a/packages/core/src/view/geometry/node/StencilShape.ts
+++ b/packages/core/src/view/geometry/node/StencilShape.ts
@@ -24,7 +24,6 @@ import { isNotNullish } from '../../../util/Utils';
 import {
   ALIGN,
   DIRECTION,
-  NODETYPE,
   NONE,
   RECTANGLE_ROUNDING_FACTOR,
   TEXT_DIRECTION,
@@ -34,6 +33,7 @@ import { getChildNodes, getTextContent } from '../../../util/domUtils';
 import Point from '../Point';
 import AbstractCanvas2D from '../../canvas/AbstractCanvas2D';
 import { AlignValue, ColorValue, VAlignValue } from '../../../types';
+import { isElement } from '../../../util/xmlUtils';
 
 /**
  * Configure global settings for stencil shapes.
@@ -276,7 +276,7 @@ class StencilShape extends Shape {
       let tmp = node.firstChild as Element;
 
       while (tmp) {
-        if (tmp.nodeType === NODETYPE.ELEMENT) {
+        if (isElement(tmp)) {
           this.drawNode(canvas, shape, tmp, aspect, disableShadow, paint);
         }
 
@@ -375,7 +375,7 @@ class StencilShape extends Shape {
           let childNode = node.firstChild as Element;
 
           while (childNode != null) {
-            if (childNode.nodeType === NODETYPE.ELEMENT) {
+            if (isElement(childNode)) {
               const childName = childNode.nodeName;
 
               if (childName === 'move' || childName === 'line') {
@@ -423,7 +423,7 @@ class StencilShape extends Shape {
           let childNode = node.firstChild as Element;
 
           while (childNode) {
-            if (childNode.nodeType === NODETYPE.ELEMENT) {
+            if (isElement(childNode)) {
               this.drawNode(canvas, shape, childNode, aspect, disableShadow, paint);
             }
 

--- a/packages/core/src/view/geometry/node/StencilShape.ts
+++ b/packages/core/src/view/geometry/node/StencilShape.ts
@@ -29,11 +29,10 @@ import {
   TEXT_DIRECTION,
 } from '../../../util/Constants';
 import StencilShapeRegistry from './StencilShapeRegistry';
-import { getChildNodes, getTextContent } from '../../../util/domUtils';
+import { getChildNodes, getTextContent, isElement } from '../../../util/domUtils';
 import Point from '../Point';
 import AbstractCanvas2D from '../../canvas/AbstractCanvas2D';
 import { AlignValue, ColorValue, VAlignValue } from '../../../types';
-import { isElement } from '../../../util/xmlUtils';
 
 /**
  * Configure global settings for stencil shapes.


### PR DESCRIPTION
Simplify null checks and introduce the `xmlUtils.isElement` internal function that narrow down Element type (no longer need to cast types manually).
This new function is used in other places when possible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined internal processing of interface components to simplify element and attribute handling, ensuring robust and consistent behavior.
  - Enhanced logic for checking node types using a centralized utility function.
  
- **New Features**
  - Introduced a new utility function `isElement` for improved element type checking across various components.
  
- **Tests**
  - Added a new test suite for the `isNumeric` function, covering various input scenarios to ensure expected behavior.

These improvements enhance the app’s stability and reliability while keeping user functionality and appearance unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->