### PR TITLE
docs: improve JSDoc of `allowEval` properties

### DIFF
--- a/packages/core/src/serialization/ObjectCodec.ts
+++ b/packages/core/src/serialization/ObjectCodec.ts
@@ -108,7 +108,7 @@ import type Codec from './Codec';
  * value-attribute.
  *
  * For example, the following array contains one atomic value and one object
- * with a field called bar. Furthermore it contains two associative entries
+ * with a field called bar. Furthermore, it contains two associative entries
  * called bar with an atomic value, and foo with an object value.
  *
  * ```javascript
@@ -135,7 +135,7 @@ import type Codec from './Codec';
  * ### References
  *
  * Objects may be represented as child nodes or attributes with ID values,
- * which are used to lookup the object in a table within {@link Codec}. The
+ * which are used to look up the object in a table within {@link Codec}. The
  * {@link isReference} function is in charge of deciding if a specific field should
  * be encoded as a reference or not. Its default implementation returns true if
  * the field name is in {@link idrefs}, an array of strings that is used to configure
@@ -159,7 +159,7 @@ import type Codec from './Codec';
  * In the case of a tree structure we must further avoid infinite recursion by
  * ignoring the parent reference of each child. This is done by returning true
  * in {@link isExcluded}, whose default implementation uses the array of excluded
- * fieldnames passed to the ObjectCodec constructor.
+ * field names passed to the ObjectCodec constructor.
  *
  * References are only used for cells in mxGraph. For defining other
  * referencable object types, the codec must be able to work out the ID of an
@@ -173,11 +173,11 @@ import type Codec from './Codec';
  * For decoding JavaScript expressions, the add-node may be used with a text
  * content that contains the JavaScript expression. For example, the following
  * creates a field called foo in the enclosing object and assigns it the value
- * of {@link Constants.ALIGN.LEFT}.
+ * of {@link ALIGN.LEFT}.
  *
  * ```javascript
  * <Object>
- *   <add as="foo">Constants.ALIGN.LEFT</add>
+ *   <add as="foo">constants.ALIGN.LEFT</add>
  * </Object>
  * ```
  *
@@ -221,7 +221,8 @@ class ObjectCodec {
   /**
    * Static global switch that specifies if expressions in arrays are allowed.
    *
-   * **NOTE**: Enabling this carries a possible security risk.
+   * **WARNING**: Enabling this switch carries a possible security risk.
+   *
    * @default false
    */
   static allowEval = false;

--- a/packages/core/src/serialization/codecs/StylesheetCodec.ts
+++ b/packages/core/src/serialization/codecs/StylesheetCodec.ts
@@ -38,6 +38,9 @@ export class StylesheetCodec extends ObjectCodec {
   /**
    * Static global switch that specifies if the use of eval is allowed for evaluating text content.
    * Set this to `false` if stylesheets may contain user input.
+   *
+   * **WARNING**: Enabling this switch carries a possible security risk.
+   *
    * @default true
    */
   static allowEval = true;

--- a/packages/core/src/view/GraphView.ts
+++ b/packages/core/src/view/GraphView.ts
@@ -132,10 +132,13 @@ export class GraphView extends EventSource {
   updatingDocumentResource = TranslationsConfig.isEnabled() ? 'updatingDocument' : '';
 
   /**
-   * Specifies if string values in cell styles should be evaluated using
-   * {@link eval}. This will only be used if the string values can't be mapped
-   * to objects using {@link StyleRegistry}. Default is false. NOTE: Enabling this
-   * switch carries a possible security risk.
+   * Specifies if string values in cell styles should be evaluated using {@link eval}.
+   *
+   * This will only be used if the string values can't be mapped to objects using {@link StyleRegistry} when resolving {@link CellStateStyle.edgeStyle} and {@link CellStateStyle.perimeter}.
+   *
+   * **WARNING**: Enabling this switch carries a possible security risk.
+   *
+   * @default false
    */
   allowEval = false;
 
@@ -281,10 +284,16 @@ export class GraphView extends EventSource {
     );
   }
 
+  /**
+   * Returns {@link allowEval}.
+   */
   isAllowEval() {
     return this.allowEval;
   }
 
+  /**
+   * Sets {@link allowEval}.
+   */
   setAllowEval(value: boolean) {
     this.allowEval = value;
   }

--- a/packages/core/src/view/geometry/node/StencilShape.ts
+++ b/packages/core/src/view/geometry/node/StencilShape.ts
@@ -44,6 +44,9 @@ export const StencilShapeConfig = {
   /**
    * Specifies if the use of eval is allowed for evaluating text content and images.
    * Set this to `true` if stencils can not contain user input.
+   *
+   * **WARNING**: Enabling this switch carries a possible security risk.
+   *
    * @default false
    */
   allowEval: false,


### PR DESCRIPTION
Highlight with a warning that enabling eval carries a possible security risk.


## Notes

Covers #722



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Revised in-app guidance and warnings to improve clarity and consistency, helping users better understand potential security risks associated with dynamic evaluation.
- **New Features**
  - Enhanced configurability within the graph display settings by introducing controls that allow users to check and update evaluation options more intuitively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->