### PR TITLE
refactor: improve the management of `CellStateStyle.curved`

### DIFF
--- a/packages/core/src/view/cell/Cell.ts
+++ b/packages/core/src/view/cell/Cell.ts
@@ -90,7 +90,7 @@ export class Cell implements IdentityObject {
   }
 
   // TODO: Document me!
-  // used by invalidate() of mxGraphView
+  // used by invalidate() of GraphView
   invalidating = false;
 
   onInit: (() => void) | null = null;
@@ -99,73 +99,86 @@ export class Cell implements IdentityObject {
   overlays: CellOverlay[] = [];
 
   /**
-   * Holds the Id. Default is null.
+   * Holds the identifier of the Cell.
+   * @default null
    */
   id: string | null = null;
 
   /**
-   * Holds the user object. Default is null.
+   * Holds the user object.
+   * @default null
    */
   value: any = null;
 
   /**
-   * Holds the {@link Geometry}. Default is null.
+   * Holds the {@link Geometry}.
+   * @default null
    */
   geometry: Geometry | null = null;
 
   /**
-   * Holds the style as a string of the form [(stylename|key=value);]. Default is
-   * null.
+   * Holds the style of the Cell.
+   * @default {}
    */
   style: CellStyle = {};
 
   /**
-   * Specifies whether the cell is a vertex. Default is false.
+   * Specifies whether the cell is a vertex.
+   * @default false
    */
   vertex = false;
 
   /**
-   * Specifies whether the cell is an edge. Default is false.
+   * Specifies whether the cell is an edge.
+   * @default false
    */
   edge = false;
 
   /**
-   * Specifies whether the cell is connectable. Default is true.
+   * Specifies whether the cell is connectable.
+   * @default true
    */
   connectable = true;
 
   /**
-   * Specifies whether the cell is visible. Default is true.
+   * Specifies whether the cell is visible.
+   * @default true
    */
   visible = true;
 
   /**
-   * Specifies whether the cell is collapsed. Default is false.
+   * Specifies whether the cell is collapsed.
+   * @default false
    */
   collapsed = false;
 
   /**
    * Reference to the parent cell.
+   * @default null
    */
   parent: Cell | null = null;
 
   /**
    * Reference to the source terminal.
+   * @default null
    */
   source: Cell | null = null;
 
   /**
    * Reference to the target terminal.
+   * @default null
    */
   target: Cell | null = null;
 
   /**
    * Holds the child cells.
+   * @default []
    */
   children: Cell[] = [];
 
   /**
    * Holds the edges.
+   * @default []
    */
   edges: Cell[] = [];
 

--- a/packages/core/src/view/geometry/edge/ConnectorShape.ts
+++ b/packages/core/src/view/geometry/edge/ConnectorShape.ts
@@ -40,11 +40,11 @@ class ConnectorShape extends PolylineShape {
   }
 
   /**
-   * Updates the <boundingBox> for this shape using <createBoundingBox>
-   * and augmentBoundingBox and stores the result in <boundingBox>.
+   * Updates the {@link boundingBox} for this shape using {@link createBoundingBox}
+   * and {@link augmentBoundingBox} and stores the result in {@link boundingBox}.
    */
   updateBoundingBox() {
-    this.useSvgBoundingBox = !!this.style?.curved;
+    this.useSvgBoundingBox = this.style?.curved ?? false;
     super.updateBoundingBox();
   }
 

--- a/packages/core/src/view/geometry/edge/PolylineShape.ts
+++ b/packages/core/src/view/geometry/edge/PolylineShape.ts
@@ -74,7 +74,7 @@ class PolylineShape extends Shape {
     const prev = c.pointerEventsValue;
     c.pointerEventsValue = 'stroke';
 
-    if (!this.style || !this.style.curved) {
+    if (!this.style?.curved) {
       this.paintLine(c, pts, this.isRounded);
     } else {
       this.paintCurvedLine(c, pts);

--- a/packages/core/src/view/mixins/EdgeMixin.type.ts
+++ b/packages/core/src/view/mixins/EdgeMixin.type.ts
@@ -172,6 +172,9 @@ declare module '../Graph' {
      * Adds a new edge into the given parent {@link Cell} using value as the user object and the given source and target as the terminals of the new edge.
      * The id and style are used for the respective properties of the new {@link Cell}, which is returned.
      *
+     * **IMPORTANT**:
+     * - This is a legacy method to ease the migration from `mxGraph`. Use the {@link insertEdge} method with a single object parameter instead.
+     *
      * @param parent {@link Cell} that specifies the parent of the new edge. If not set, use the default parent.
      * @param id Optional string that defines the Id of the new edge. If not set, the id is auto-generated when creating the vertex.
      * @param value Object to be used as the user object which is generally used to display the label of the edge. The default implementation handles `string` object.

--- a/packages/html/stories/EdgeCurvedAndRounded.stories.ts
+++ b/packages/html/stories/EdgeCurvedAndRounded.stories.ts
@@ -1,0 +1,254 @@
+/*
+Copyright 2025-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {
+  constants,
+  getDefaultPlugins,
+  Graph,
+  Perimeter,
+  Point,
+  RubberBandHandler,
+} from '@maxgraph/core';
+import {
+  contextMenuTypes,
+  contextMenuValues,
+  globalTypes,
+  globalValues,
+  rubberBandTypes,
+  rubberBandValues,
+} from './shared/args.js';
+import {
+  configureImagesBasePath,
+  createGraphContainer,
+  createMainDiv,
+} from './shared/configure.js';
+// style required by RubberBand
+import '@maxgraph/core/css/common.css';
+
+export default {
+  title: 'Styles/EdgeCurvedAndRounded',
+  argTypes: {
+    ...contextMenuTypes,
+    ...globalTypes,
+    ...rubberBandTypes,
+    style: {
+      type: 'text',
+      description: 'Choose the type of source from which to load the model',
+      options: ['curved', 'rounded', 'default'],
+      control: { type: 'select' },
+    },
+  },
+  args: {
+    style: 'curved',
+    ...globalValues,
+    ...contextMenuValues,
+    ...rubberBandValues,
+  },
+};
+
+const Template = ({ label, ...args }: Record<string, string>) => {
+  configureImagesBasePath();
+
+  const div = createMainDiv(`Show usage of curved and rounded edges.
+  <br>
+  Use the Storybook controls to change the style of the edges.
+  `);
+
+  const container = createGraphContainer(args);
+  div.appendChild(container);
+
+  // Enables rubberband selection
+  const plugins = getDefaultPlugins();
+  if (args.rubberBand) plugins.push(RubberBandHandler);
+
+  // Creates the graph inside the given container
+  const graph = new Graph(container, undefined, plugins);
+
+  // No size handles, please...
+  graph.setCellsResizable(false);
+
+  // Makes all cells round with a white, bold label
+  let style = graph.stylesheet.getDefaultVertexStyle();
+  style.shape = 'ellipse';
+  style.perimeter = Perimeter.EllipsePerimeter;
+  style.fontColor = 'white';
+  style.gradientColor = 'white';
+  style.fontStyle = constants.FONT.BOLD;
+  style.fontSize = 14;
+
+  // Makes all edge labels gray with a white background
+  style = graph.stylesheet.getDefaultEdgeStyle();
+  style.fontColor = 'gray';
+  style.fontStyle = constants.FONT.BOLD;
+  style.fontColor = 'black';
+  style.strokeWidth = 2;
+  if (args.style === 'curved') style.curved = true;
+  if (args.style === 'rounded') style.rounded = true;
+
+  // Adds cells to the target model in a single step using custom ids for the vertices and edges
+  const width = 40;
+  const height = 40;
+
+  graph.batchUpdate(() => {
+    const a = graph.insertVertex({
+      id: 'a',
+      value: 'A',
+      position: [20, 20],
+      size: [width, height],
+      style: {
+        fillColor: 'blue',
+      },
+    });
+    const b = graph.insertVertex({
+      id: 'b',
+      value: 'B',
+      position: [20, 400],
+      size: [width, height],
+      style: {
+        fillColor: 'blue',
+      },
+    });
+    const c = graph.insertVertex({
+      id: 'c',
+      value: 'C',
+      position: [200, 20],
+      size: [width, height],
+      style: {
+        fillColor: 'red',
+      },
+    });
+    const d = graph.insertVertex({
+      id: 'd',
+      value: 'D',
+      position: [200, 200],
+      size: [width, height],
+      style: {
+        fillColor: 'red',
+      },
+    });
+
+    const e = graph.insertVertex({
+      id: 'e',
+      value: 'E',
+      position: [400, 20],
+      size: [width, height],
+      style: {
+        fillColor: 'green',
+      },
+    });
+
+    const f = graph.insertVertex({
+      id: 'f',
+      value: 'F',
+      position: [400, 350],
+      size: [width, height],
+      style: {
+        fillColor: 'green',
+      },
+    });
+
+    const edge_ac = graph.insertEdge({
+      id: 'ac',
+      value: 'ac',
+      source: a,
+      target: c,
+      style: {
+        strokeColor: 'blue',
+        verticalAlign: 'bottom',
+      },
+    });
+    edge_ac.geometry!.points = [new Point(100, 10)];
+
+    const edge_ad = graph.insertEdge({
+      id: 'ad',
+      value: 'ad',
+      source: a,
+      target: d,
+      style: {
+        strokeColor: 'blue',
+        align: 'left',
+        verticalAlign: 'bottom',
+      },
+    });
+    edge_ad.geometry!.points = [new Point(0, 100)];
+
+    const edge_da = graph.insertEdge({
+      id: 'da',
+      value: 'da',
+      source: d,
+      target: a,
+      style: {
+        strokeColor: 'blue',
+        align: 'left',
+        verticalAlign: 'bottom',
+      },
+    });
+    edge_da.geometry!.points = [new Point(180, 100)];
+
+    const edge_bd = graph.insertEdge({
+      id: 'bd',
+      value: 'bd',
+      source: b,
+      target: d,
+      style: {
+        strokeColor: 'blue',
+        verticalAlign: 'bottom',
+      },
+    });
+    edge_bd.geometry!.points = [new Point(80, 290)];
+
+    const edge_ce = graph.insertEdge({
+      id: 'ce',
+      value: 'ce',
+      source: c,
+      target: e,
+      style: {
+        strokeColor: 'green',
+        verticalAlign: 'middle',
+      },
+    });
+    edge_ce.geometry!.points = [new Point(300, 70)];
+
+    const edge_ed = graph.insertEdge({
+      id: 'ed',
+      value: 'ed',
+      source: e,
+      target: d,
+      style: {
+        strokeColor: 'green',
+        align: 'right',
+        verticalAlign: 'bottom',
+      },
+    });
+    edge_ed.geometry!.points = [new Point(380, 150)];
+
+    const edge_fd = graph.insertEdge({
+      id: 'fd',
+      value: 'fd',
+      source: f,
+      target: d,
+      style: {
+        strokeColor: 'green',
+        verticalAlign: 'bottom',
+      },
+    });
+    edge_fd.geometry!.points = [new Point(380, 250)];
+  });
+
+  return div;
+};
+
+export const Default = Template.bind({});

--- a/packages/html/stories/EdgeCurvedAndRounded.stories.ts
+++ b/packages/html/stories/EdgeCurvedAndRounded.stories.ts
@@ -204,6 +204,19 @@ const Template = ({ label, ...args }: Record<string, string>) => {
     });
     edge_da.geometry!.points = [new Point(180, 100)];
 
+    const edge_dc = graph.insertEdge({
+      id: 'dc',
+      value: 'dc',
+      source: d,
+      target: c,
+      style: {
+        strokeColor: 'red',
+        align: 'left',
+        verticalAlign: 'bottom',
+      },
+    });
+    edge_dc.geometry!.points = [new Point(250, 140)];
+
     const edge_bd = graph.insertEdge({
       id: 'bd',
       value: 'bd',

--- a/packages/html/stories/EdgeCurvedAndRounded.stories.ts
+++ b/packages/html/stories/EdgeCurvedAndRounded.stories.ts
@@ -46,13 +46,18 @@ export default {
     ...rubberBandTypes,
     style: {
       type: 'text',
-      description: 'Choose the type of source from which to load the model',
       options: ['curved', 'rounded', 'default'],
+      control: { type: 'select' },
+    },
+    arcSize: {
+      type: 'text',
+      options: ['default', '10', '30', '50'],
       control: { type: 'select' },
     },
   },
   args: {
     style: 'curved',
+    arcSize: 'default',
     ...globalValues,
     ...contextMenuValues,
     ...rubberBandValues,
@@ -97,6 +102,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   style.strokeWidth = 2;
   if (args.style === 'curved') style.curved = true;
   if (args.style === 'rounded') style.rounded = true;
+  if (args.arcSize !== 'default') style.arcSize = Number(args.arcSize);
 
   // Adds cells to the target model in a single step using custom ids for the vertices and edges
   const width = 40;

--- a/packages/html/stories/EdgeCurvedAndRounded.stories.ts
+++ b/packages/html/stories/EdgeCurvedAndRounded.stories.ts
@@ -85,7 +85,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   // No size handles, please...
   graph.setCellsResizable(false);
 
-  // Makes all cells round with a white, bold label
+  // Makes all vertices ellipse with a white, bold label
   let style = graph.stylesheet.getDefaultVertexStyle();
   style.shape = 'ellipse';
   style.perimeter = Perimeter.EllipsePerimeter;
@@ -94,7 +94,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   style.fontStyle = constants.FONT.BOLD;
   style.fontSize = 14;
 
-  // Makes all edge labels gray with a white background
+  // Makes all edges with a black, bold label
   style = graph.stylesheet.getDefaultEdgeStyle();
   style.fontStyle = constants.FONT.BOLD;
   style.fontColor = 'black';

--- a/packages/html/stories/EdgeCurvedAndRounded.stories.ts
+++ b/packages/html/stories/EdgeCurvedAndRounded.stories.ts
@@ -96,7 +96,6 @@ const Template = ({ label, ...args }: Record<string, string>) => {
 
   // Makes all edge labels gray with a white background
   style = graph.stylesheet.getDefaultEdgeStyle();
-  style.fontColor = 'gray';
   style.fontStyle = constants.FONT.BOLD;
   style.fontColor = 'black';
   style.strokeWidth = 2;

--- a/packages/html/stories/Merge.stories.ts
+++ b/packages/html/stories/Merge.stories.ts
@@ -65,7 +65,7 @@ const Template = ({ label, ...args }: Record<string, any>) => {
   // No size handles, please...
   graph.setCellsResizable(false);
 
-  // Makes all cells round with a white, bold label
+  // Makes all vertices ellipse with a white, bold label
   let style = graph.stylesheet.getDefaultVertexStyle();
   style.shape = 'ellipse';
   style.perimeter = Perimeter.EllipsePerimeter;
@@ -75,7 +75,7 @@ const Template = ({ label, ...args }: Record<string, any>) => {
   style.fontSize = 14;
   style.shadow = true;
 
-  // Makes all edge labels gray with a white background
+  // Makes all edges with a black, bold label
   style = graph.stylesheet.getDefaultEdgeStyle();
   style.fontStyle = constants.FONT.BOLD;
   style.fontColor = 'black';

--- a/packages/html/stories/Merge.stories.ts
+++ b/packages/html/stories/Merge.stories.ts
@@ -77,7 +77,6 @@ const Template = ({ label, ...args }: Record<string, any>) => {
 
   // Makes all edge labels gray with a white background
   style = graph.stylesheet.getDefaultEdgeStyle();
-  style.fontColor = 'gray';
   style.fontStyle = constants.FONT.BOLD;
   style.fontColor = 'black';
   style.strokeWidth = 2;

--- a/packages/html/stories/Merge.stories.ts
+++ b/packages/html/stories/Merge.stories.ts
@@ -16,6 +16,7 @@ limitations under the License.
 */
 
 import {
+  constants,
   getDefaultPlugins,
   Graph,
   Perimeter,
@@ -28,7 +29,7 @@ import {
   rubberBandTypes,
   rubberBandValues,
 } from './shared/args.js';
-import { createGraphContainer } from './shared/configure.js';
+import { createGraphContainer, createMainDiv } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -45,7 +46,12 @@ export default {
 };
 
 const Template = ({ label, ...args }: Record<string, any>) => {
+  const div = createMainDiv(
+    `This example illustrates the use of the <code>GraphDataModel.mergeChildren</code> function to merge two graphs.`
+  );
+
   const container = createGraphContainer(args);
+  div.appendChild(container);
 
   StyleDefaultsConfig.shadowColor = '#c0c0c0';
 
@@ -65,23 +71,21 @@ const Template = ({ label, ...args }: Record<string, any>) => {
   style.perimeter = Perimeter.EllipsePerimeter;
   style.fontColor = 'white';
   style.gradientColor = 'white';
-  style.fontStyle = 1; // bold
+  style.fontStyle = constants.FONT.BOLD;
   style.fontSize = 14;
   style.shadow = true;
 
   // Makes all edge labels gray with a white background
   style = graph.stylesheet.getDefaultEdgeStyle();
   style.fontColor = 'gray';
-  style.fontStyle = 1; // bold
+  style.fontStyle = constants.FONT.BOLD;
   style.fontColor = 'black';
   style.strokeWidth = 2;
 
-  // Gets the default parent for inserting new cells. This
-  // is normally the first child of the root (ie. layer 0).
+  // Gets the default parent for inserting new cells. This is normally the first child of the root (ie. layer 0).
   const parent = graph.getDefaultParent();
 
-  // Adds cells to the target model in a single step
-  // using custom ids for the vertices and edges
+  // Adds cells to the target model in a single step using custom ids for the vertices and edges
   const w = 40;
   const h = 40;
 
@@ -136,7 +140,7 @@ const Template = ({ label, ...args }: Record<string, any>) => {
       align: 'right',
       verticalAlign: 'bottom',
     });
-    graph2.insertEdge(parent2, 'bd', 'fd', f, d, {
+    graph2.insertEdge(parent2, 'fd', 'fd', f, d, {
       strokeColor: 'green',
       verticalAlign: 'bottom',
     });
@@ -150,7 +154,7 @@ const Template = ({ label, ...args }: Record<string, any>) => {
   // the edge for the same id in the second graph.
   graph.getDataModel().mergeChildren(parent2, parent /* , false */);
 
-  return container;
+  return div;
 };
 
 export const Default = Template.bind({});


### PR DESCRIPTION
Simplify the computation of default values.
Add a new story (inspired by the Merge story) to demonstrate the difference of default, curved and rounded edges.

### Screenshots of the new story


https://github.com/user-attachments/assets/cfc78585-0e39-448d-875e-02e2e648ec9a



### Tasks

- [x] story: add an argument to select the size of the `arcSize`
- [x] add gif

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
  - Enhanced descriptions and default value annotations for cell and edge properties.
  - Updated legacy method documentation to guide users toward modern alternatives.
- **Bug Fixes**
  - Improved edge rendering stability by refining style checks for undefined styling.
- **New Features**
  - Introduced interactive Storybook examples demonstrating curved, rounded, and default edge styles.
  - Enhanced graph examples with updated layout and styling for a more consistent visual experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->