### PR TITLE
refactor: remove `isNotNullish` internal function

### DIFF
--- a/packages/core/src/util/Utils.ts
+++ b/packages/core/src/util/Utils.ts
@@ -61,12 +61,6 @@ export const isNullish = (v: string | object | null | undefined | number | boole
   v === null || v === undefined;
 
 /**
- * @private not part of the public API, can be removed or changed without prior notice
- */
-export const isNotNullish = (v: string | object | null | undefined | number | boolean) =>
-  !isNullish(v);
-
-/**
  * Merge a mixin into the destination
  * @param dest the destination class
  *

--- a/packages/core/src/view/canvas/SvgCanvas2D.ts
+++ b/packages/core/src/view/canvas/SvgCanvas2D.ts
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { isNotNullish } from '../../util/Utils';
+import { isNullish } from '../../util/Utils';
 import { mod } from '../../util/mathUtils';
 import { getAlignmentAsPoint, matchBinaryMask } from '../../util/styleUtils';
 import Client from '../../Client';
@@ -48,7 +48,6 @@ import {
   TextDirectionValue,
   VAlignValue,
 } from '../../types';
-import { StyleDefaultsConfig } from '../../util/config';
 
 // Activates workaround for gradient ID resolution if base tag is used.
 const useAbsoluteIds =
@@ -58,22 +57,19 @@ const useAbsoluteIds =
   document.getElementsByTagName('base').length > 0;
 
 /**
- * Extends {@link mxAbstractCanvas2D} to implement a canvas for SVG. This canvas writes all calls as SVG output to the
- * given SVG root node.
+ * Extends {@link AbstractCanvas2D} to implement a canvas for SVG.
+ * This canvas writes all calls as SVG output to the given SVG root node.
  *
  * ```javascript
- * var svgDoc = mxUtils.createXmlDocument();
- * var root = (svgDoc.createElementNS != null) ?
+ * const svgDoc = mxUtils.createXmlDocument();
+ * const root = (svgDoc.createElementNS != null) ?
  * 		svgDoc.createElementNS(mxConstants.NS_SVG, 'svg') : svgDoc.createElement('svg');
  *
- * if (svgDoc.createElementNS == null)
- * {
- *   root.setAttribute('xmlns', mxConstants.NS_SVG);
- *   root.setAttribute('xmlns:xlink', mxConstants.NS_XLINK);
- * }
- * else
- * {
- *   root.setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xlink', mxConstants.NS_XLINK);
+ * if (svgDoc.createElementNS == null) {
+ *   root.setAttribute('xmlns', constants.NS_SVG);
+ *   root.setAttribute('xmlns:xlink', constants.NS_XLINK);
+ * } else {
+ *   root.setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xlink', constants.NS_XLINK);
  * }
  *
  * var bounds = graph.getGraphBounds();
@@ -426,7 +422,7 @@ class SvgCanvas2D extends AbstractCanvas2D {
     clip: boolean,
     rotation: number
   ) {
-    return isNotNullish(str) ? this.foAltText : null;
+    return !isNullish(str) ? this.foAltText : null;
   }
 
   /**
@@ -464,7 +460,7 @@ class SvgCanvas2D extends AbstractCanvas2D {
     );
     const s = this.state;
 
-    if (isNotNullish(text) && s.fontSize > 0) {
+    if (!isNullish(text) && s.fontSize > 0) {
       const dy = valign === ALIGN.TOP ? 1 : valign === ALIGN.BOTTOM ? 0 : 0.3;
       const anchor =
         align === ALIGN.RIGHT ? 'end' : align === ALIGN.LEFT ? 'start' : 'middle';

--- a/packages/core/src/view/cell/Cell.ts
+++ b/packages/core/src/view/cell/Cell.ts
@@ -21,7 +21,7 @@ import CellOverlay from './CellOverlay';
 import { clone } from '../../util/cloneUtils';
 import Point from '../geometry/Point';
 import CellPath from './CellPath';
-import { isNotNullish } from '../../util/Utils';
+import { isNullish } from '../../util/Utils';
 
 import type { CellStyle, FilterFunction, IdentityObject } from '../../types';
 import type { UserObject } from '../../internal-types';
@@ -35,8 +35,8 @@ import { isElement } from '../../util/domUtils';
  * For custom attributes we recommend using an XML node as the value of a cell.
  * The following code can be used to create a cell with an XML node as the value:
  * ```javascript
- * var doc = mxUtils.createXmlDocument();
- * var node = doc.createElement('MyNode')
+ * const doc = xmlUtils.createXmlDocument();
+ * const node = doc.createElement('MyNode')
  * node.setAttribute('label', 'MyLabel');
  * node.setAttribute('attribute1', 'value1');
  * graph.insertVertex(graph.getDefaultParent(), null, node, 40, 40, 80, 30);
@@ -46,21 +46,17 @@ import { isElement } from '../../util/domUtils';
  * {@link graph.cellLabelChanged} should be overridden as follows:
  *
  * ```javascript
- * graph.convertValueToString(cell)
- * {
- *   if (mxUtils.isNode(cell.value))
- *   {
+ * graph.convertValueToString(cell) {
+ *   if (domUtils.isNode(cell.value)) {
  *     return cell.getAttribute('label', '')
  *   }
  * };
  *
- * var cellLabelChanged = graph.cellLabelChanged;
- * graph.cellLabelChanged(cell, newValue, autoSize)
- * {
- *   if (mxUtils.isNode(cell.value))
- *   {
+ * const cellLabelChanged = graph.cellLabelChanged;
+ * graph.cellLabelChanged(cell, newValue, autoSize) {
+ *   if (domUtils.isNode(cell.value)) {
  *     // Clones the value for correct undo/redo
- *     var elt = cell.value.cloneNode(true);
+ *     const elt = cell.value.cloneNode(true);
  *     elt.setAttribute('label', newValue);
  *     newValue = elt;
  *   }
@@ -68,7 +64,6 @@ import { isElement } from '../../util/domUtils';
  *   cellLabelChanged.apply(this, arguments);
  * };
  * ```
- * @class Cell
  */
 export class Cell implements IdentityObject {
   constructor(
@@ -567,7 +562,7 @@ export class Cell implements IdentityObject {
 
     return isElement(userObject) && userObject.hasAttribute
       ? userObject.hasAttribute(name)
-      : isNotNullish(userObject.getAttribute?.(name));
+      : !isNullish(userObject.getAttribute?.(name));
   }
 
   /**
@@ -616,10 +611,10 @@ export class Cell implements IdentityObject {
    */
   cloneValue(): any {
     let value: UserObject = this.getValue();
-    if (isNotNullish(value)) {
+    if (!isNullish(value)) {
       if (typeof value.clone === 'function') {
         value = value.clone();
-      } else if (isNotNullish(value.nodeType) && value.cloneNode) {
+      } else if (!isNullish(value.nodeType) && value.cloneNode) {
         value = value.cloneNode(true);
       }
     }

--- a/packages/core/src/view/geometry/Shape.ts
+++ b/packages/core/src/view/geometry/Shape.ts
@@ -17,7 +17,7 @@ limitations under the License.
 */
 
 import Rectangle from './Rectangle';
-import { isNotNullish } from '../../util/Utils';
+import { isNullish } from '../../util/Utils';
 import { getBoundingBox, getDirectedBounds, mod } from '../../util/mathUtils';
 import {
   DIRECTION,
@@ -649,7 +649,7 @@ class Shape {
         }
       }
 
-      if (bg && c.state && isNotNullish(c.state.transform)) {
+      if (bg && c.state && !isNullish(c.state.transform)) {
         bg.setAttribute('transform', <string>c.state.transform);
       }
 

--- a/packages/core/src/view/geometry/node/StencilShape.ts
+++ b/packages/core/src/view/geometry/node/StencilShape.ts
@@ -20,7 +20,7 @@ import ConnectionConstraint from '../../other/ConnectionConstraint';
 import Rectangle from '../Rectangle';
 import Shape from '../Shape';
 import Translations from '../../../i18n/Translations';
-import { isNotNullish } from '../../../util/Utils';
+import { isNullish } from '../../../util/Utils';
 import {
   ALIGN,
   DIRECTION,
@@ -131,7 +131,7 @@ class StencilShape extends Shape {
     // user-defined stroke-width). Note that the strokewidth is scaled
     // by the minimum scaling that is used to draw the shape (sx, sy).
     const sw = this.desc.getAttribute('strokewidth');
-    this.strokeWidthValue = isNotNullish(sw) ? sw : '1';
+    this.strokeWidthValue = !isNullish(sw) ? sw : '1';
   }
 
   /**


### PR DESCRIPTION
Negate the result of the existing `isNullish` function instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced consistency for handling missing or undefined values, ensuring more predictable behavior in visual components.
- **Style**
	- Modernized variable declarations to improve code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->