### PR TITLE
feat!: introduce a way to configure the I18n provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _**Note:** Yet to be released breaking changes appear here._
 
 **Breaking Changes**:
 - `StylesheetCodec.allowEval` is now set to `false` by default to prevent unwanted use of the eval function, as it carries a possible security risk.
+- The built-in `Translations` class is no longer used by default. To use it, call `GlobalConfig.i18n = new TranslationsAsI18n()`
 
 ## 0.16.0
 

--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -55,7 +55,6 @@ import type ConnectionHandler from '../view/plugins/ConnectionHandler';
 import { show } from '../util/printUtils';
 import type PanningHandler from '../view/plugins/PanningHandler';
 import { cloneCell } from '../util/cellArrayUtils';
-import { TranslationsConfig } from '../i18n/config';
 import type MaxPopupMenu from '../gui/MaxPopupMenu';
 import { isNullish } from '../internal/utils';
 import { isI18nEnabled, translate } from '../internal/i18n-utils';

--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -58,7 +58,7 @@ import { cloneCell } from '../util/cellArrayUtils';
 import { TranslationsConfig } from '../i18n/config';
 import type MaxPopupMenu from '../gui/MaxPopupMenu';
 import { isNullish } from '../util/Utils';
-import { isI18nEnabled, translate } from '../internal/utils';
+import { isI18nEnabled, translate } from '../internal/i18n-utils';
 
 /**
  * Extends {@link EventSource} to implement an application wrapper for a graph that

--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -20,7 +20,6 @@ import EditorPopupMenu from './EditorPopupMenu';
 import UndoManager from '../view/undoable_changes/UndoManager';
 import EditorKeyHandler from './EditorKeyHandler';
 import EventSource from '../view/event/EventSource';
-import Translations from '../i18n/Translations';
 import Client from '../Client';
 import CompactTreeLayout from '../view/layout/CompactTreeLayout';
 import { EditorToolbar } from './EditorToolbar';
@@ -59,6 +58,7 @@ import { cloneCell } from '../util/cellArrayUtils';
 import { TranslationsConfig } from '../i18n/config';
 import type MaxPopupMenu from '../gui/MaxPopupMenu';
 import { isNullish } from '../util/Utils';
+import { isI18nEnabled, translate } from '../internal/utils';
 
 /**
  * Extends {@link EventSource} to implement an application wrapper for a graph that
@@ -445,7 +445,7 @@ export class Editor extends EventSource {
    * key does not exist then the value is used as the error message. Default is 'askZoom'.
    * @default 'askZoom'
    */
-  askZoomResource = TranslationsConfig.isEnabled() ? 'askZoom' : '';
+  askZoomResource = isI18nEnabled() ? 'askZoom' : '';
 
   // =====================================================================================
   // Group: Controls and Handlers
@@ -456,14 +456,14 @@ export class Editor extends EventSource {
    * this key does not exist then the value is used as the error message. Default is 'lastSaved'.
    * @default 'lastSaved'.
    */
-  lastSavedResource = TranslationsConfig.isEnabled() ? 'lastSaved' : '';
+  lastSavedResource = isI18nEnabled() ? 'lastSaved' : '';
 
   /**
    * Specifies the resource key for the current file info. If the resource for
    * this key does not exist then the value is used as the error message. Default is 'currentFile'.
    * @default 'currentFile'
    */
-  currentFileResource = TranslationsConfig.isEnabled() ? 'currentFile' : '';
+  currentFileResource = isI18nEnabled() ? 'currentFile' : '';
 
   /**
    * Specifies the resource key for the properties window title. If the
@@ -471,7 +471,7 @@ export class Editor extends EventSource {
    * error message. Default is 'properties'.
    * @default 'properties'
    */
-  propertiesResource = TranslationsConfig.isEnabled() ? 'properties' : '';
+  propertiesResource = isI18nEnabled() ? 'properties' : '';
 
   /**
    * Specifies the resource key for the tasks window title. If the
@@ -479,7 +479,7 @@ export class Editor extends EventSource {
    * error message. Default is 'tasks'.
    * @default 'tasks'
    */
-  tasksResource = TranslationsConfig.isEnabled() ? 'tasks' : '';
+  tasksResource = isI18nEnabled() ? 'tasks' : '';
 
   /**
    * Specifies the resource key for the help window title. If the
@@ -487,7 +487,7 @@ export class Editor extends EventSource {
    * error message. Default is 'help'.
    * @default 'help'
    */
-  helpResource = TranslationsConfig.isEnabled() ? 'help' : '';
+  helpResource = isI18nEnabled() ? 'help' : '';
 
   /**
    * Specifies the resource key for the outline window title. If the
@@ -495,7 +495,7 @@ export class Editor extends EventSource {
    * error message. Default is 'outline'.
    * @default 'outline'
    */
-  outlineResource = TranslationsConfig.isEnabled() ? 'outline' : '';
+  outlineResource = isI18nEnabled() ? 'outline' : '';
 
   /**
    * Reference to the {@link MaxWindow} that contains the outline.
@@ -1230,7 +1230,7 @@ export class Editor extends EventSource {
     this.addAction('zoom', (editor: Editor) => {
       const current = editor.graph.getView().scale * 100;
       const preInput = prompt(
-        Translations.get(editor.askZoomResource) || editor.askZoomResource,
+        translate(editor.askZoomResource) || editor.askZoomResource,
         String(current)
       );
 
@@ -1716,16 +1716,14 @@ export class Editor extends EventSource {
       this.addListener(InternalEvent.SAVE, () => {
         const timestamp = new Date().toLocaleString();
         this.setStatus(
-          `${
-            Translations.get(this.lastSavedResource) || this.lastSavedResource
-          }: ${timestamp}`
+          `${translate(this.lastSavedResource) || this.lastSavedResource}: ${timestamp}`
         );
       });
 
       // Updates the statusbar to display the filename when new files are opened
       this.addListener(InternalEvent.OPEN, () => {
         this.setStatus(
-          `${Translations.get(this.currentFileResource) || this.currentFileResource}: ${
+          `${translate(this.currentFileResource) || this.currentFileResource}: ${
             this.filename
           }`
         );
@@ -2040,7 +2038,7 @@ export class Editor extends EventSource {
         // Displays the contents in a window and stores a reference to the
         // window for later hiding of the window
         this.properties = new MaxWindow(
-          Translations.get(this.propertiesResource) || this.propertiesResource,
+          translate(this.propertiesResource) || this.propertiesResource,
           node,
           x,
           y,
@@ -2220,7 +2218,7 @@ export class Editor extends EventSource {
       div.style.paddingLeft = '20px';
       const w = document.body.clientWidth;
       const wnd = new MaxWindow(
-        Translations.get(this.tasksResource) || this.tasksResource,
+        translate(this.tasksResource) || this.tasksResource,
         div,
         w - 220,
         this.tasksTop,
@@ -2282,14 +2280,14 @@ export class Editor extends EventSource {
   /**
    * Shows the help window. If the help window does not exist
    * then it is created using an iframe pointing to the resource
-   * for the <code>urlHelp</code> key or {@link urlHelp} if the resource
+   * for the `urlHelp` key or {@link urlHelp} if the resource
    * is undefined.
    * @param tasks
    */
   showHelp(tasks: any | null = null): void {
     if (this.help == null) {
       const frame = document.createElement('iframe');
-      frame.setAttribute('src', <string>(Translations.get('urlHelp') || this.urlHelp));
+      frame.setAttribute('src', (translate('urlHelp') || this.urlHelp)!);
       frame.setAttribute('height', '100%');
       frame.setAttribute('width', '100%');
       frame.setAttribute('frameBorder', '0');
@@ -2299,7 +2297,7 @@ export class Editor extends EventSource {
       const h = document.body.clientHeight || document.documentElement.clientHeight;
 
       const wnd = new MaxWindow(
-        Translations.get(this.helpResource) || this.helpResource,
+        translate(this.helpResource) || this.helpResource,
         frame,
         (w - this.helpWidth) / 2,
         (h - this.helpHeight) / 3,
@@ -2353,7 +2351,7 @@ export class Editor extends EventSource {
       div.style.cursor = 'move';
 
       const wnd = new MaxWindow(
-        Translations.get(this.outlineResource) || this.outlineResource,
+        translate(this.outlineResource) || this.outlineResource,
         div,
         600,
         480,

--- a/packages/core/src/editor/EditorPopupMenu.ts
+++ b/packages/core/src/editor/EditorPopupMenu.ts
@@ -23,7 +23,8 @@ import Editor from './Editor';
 
 import { PopupMenuItem } from '../types';
 import { isNullish } from '../util/Utils';
-import { doEval, translate } from '../internal/utils';
+import { doEval } from '../internal/utils';
+import { translate } from '../internal/i18n-utils';
 
 /**
  * Creates popupmenus for mouse events.

--- a/packages/core/src/editor/EditorPopupMenu.ts
+++ b/packages/core/src/editor/EditorPopupMenu.ts
@@ -19,12 +19,11 @@ limitations under the License.
 import Cell from '../view/cell/Cell';
 import MaxPopupMenu from '../gui/MaxPopupMenu';
 import { getTextContent } from '../util/domUtils';
-import Translations from '../i18n/Translations';
 import Editor from './Editor';
 
 import { PopupMenuItem } from '../types';
 import { isNullish } from '../util/Utils';
-import { doEval } from '../internal/utils';
+import { doEval, translate } from '../internal/utils';
 
 /**
  * Creates popupmenus for mouse events.
@@ -194,7 +193,7 @@ export class EditorPopupMenu {
 
         if (isNullish(condition) || conditions[condition]) {
           let as = item.getAttribute('as')!;
-          as = Translations.get(as) || as;
+          as = translate(as) || as;
           const funct = doEval(getTextContent(<Text>(<unknown>item)));
           const action = item.getAttribute('action');
           let icon = item.getAttribute('icon');

--- a/packages/core/src/gui/MaxForm.ts
+++ b/packages/core/src/gui/MaxForm.ts
@@ -19,7 +19,7 @@ limitations under the License.
 import Client from '../Client';
 import InternalEvent from '../view/event/InternalEvent';
 import { write, writeln } from '../util/domUtils';
-import Translations from '../i18n/Translations';
+import { translate } from '../internal/utils';
 
 /**
  * A simple class for creating HTML forms.
@@ -65,7 +65,7 @@ class MaxForm {
 
     // Adds the ok button
     let button = document.createElement('button');
-    write(button, Translations.get('ok') || 'OK');
+    write(button, translate('ok') || 'OK');
     td.appendChild(button);
 
     InternalEvent.addListener(button, 'click', () => {
@@ -74,7 +74,7 @@ class MaxForm {
 
     // Adds the cancel button
     button = document.createElement('button');
-    write(button, Translations.get('cancel') || 'Cancel');
+    write(button, translate('cancel') || 'Cancel');
     td.appendChild(button);
 
     InternalEvent.addListener(button, 'click', () => {

--- a/packages/core/src/gui/MaxForm.ts
+++ b/packages/core/src/gui/MaxForm.ts
@@ -19,7 +19,8 @@ limitations under the License.
 import Client from '../Client';
 import InternalEvent from '../view/event/InternalEvent';
 import { write, writeln } from '../util/domUtils';
-import { translate } from '../internal/utils';
+
+import { translate } from '../internal/i18n-utils';
 
 /**
  * A simple class for creating HTML forms.

--- a/packages/core/src/gui/MaxWindow.ts
+++ b/packages/core/src/gui/MaxWindow.ts
@@ -27,7 +27,8 @@ import { br, write } from '../util/domUtils';
 import { getClientX, getClientY } from '../util/EventUtils';
 import { htmlEntities } from '../util/StringUtils';
 import { utils } from '../util/Utils';
-import { translate } from '../internal/utils';
+
+import { translate } from '../internal/i18n-utils';
 
 let activeWindow: MaxWindow | null = null;
 

--- a/packages/core/src/gui/MaxWindow.ts
+++ b/packages/core/src/gui/MaxWindow.ts
@@ -24,10 +24,10 @@ import InternalEvent from '../view/event/InternalEvent';
 import Client from '../Client';
 import { NODETYPE } from '../util/Constants';
 import { br, write } from '../util/domUtils';
-import Translations from '../i18n/Translations';
 import { getClientX, getClientY } from '../util/EventUtils';
 import { htmlEntities } from '../util/StringUtils';
 import { utils } from '../util/Utils';
+import { translate } from '../internal/utils';
 
 let activeWindow: MaxWindow | null = null;
 
@@ -1057,7 +1057,7 @@ export const error = (
   const w = document.body.clientWidth;
   const h = document.body.clientHeight || document.documentElement.clientHeight;
   const warn = new MaxWindow(
-    Translations.get(utils.errorResource) || utils.errorResource,
+    translate(utils.errorResource) || utils.errorResource,
     div,
     (w - width) / 2,
     h / 4,
@@ -1079,7 +1079,7 @@ export const error = (
       warn.destroy();
     });
 
-    write(button, Translations.get(utils.closeResource) || utils.closeResource);
+    write(button, translate(utils.closeResource) || utils.closeResource);
 
     tmp.appendChild(button);
     div.appendChild(tmp);

--- a/packages/core/src/i18n/Translations.ts
+++ b/packages/core/src/i18n/Translations.ts
@@ -18,10 +18,11 @@ limitations under the License.
 
 import Client from '../Client';
 import { NONE } from '../util/Constants';
-import { get, load } from '../util/MaxXmlRequest';
 import type MaxXmlRequest from '../util/MaxXmlRequest';
+import { get, load } from '../util/MaxXmlRequest';
 import { TranslationsConfig } from './config';
 import { isNullish } from '../util/Utils';
+import { I18nProvider } from '../types';
 
 // mxGraph source code: https://github.com/jgraph/mxgraph/blob/v4.2.2/javascript/src/js/util/mxResources.js
 
@@ -377,4 +378,35 @@ export default class Translations {
       Translations.add(`${Client.basePath}/resources/graph`, null, callback);
     });
   };
+}
+
+/**
+ * A {@link I18nProvider} that uses {@link Translations} to manage translations.
+ *
+ * The configuration is done using {@link TranslationsConfig}.
+ *
+ * @experimental subject to change or removal. The I18n system may be modified in the future without prior notice.
+ * @category I18n
+ * @since 0.17.0
+ */
+export class TranslationsAsI18n implements I18nProvider {
+  isEnabled(): boolean {
+    return TranslationsConfig.isEnabled();
+  }
+
+  get(
+    key?: string | null,
+    params?: any[] | null,
+    defaultValue?: string | null
+  ): string | null {
+    return Translations.get(key, params, defaultValue);
+  }
+
+  addResource(
+    basename: string,
+    language: string | null,
+    callback: Function | null
+  ): void {
+    Translations.add(basename, language, callback);
+  }
 }

--- a/packages/core/src/i18n/Translations.ts
+++ b/packages/core/src/i18n/Translations.ts
@@ -187,13 +187,13 @@ export default class Translations {
    * @param callback Optional callback for asynchronous loading.
    */
   static add = (
-    basename: string,
+    basename: string | null = null,
     lan: string | null = null,
     callback: Function | null = null
   ): void => {
     lan ??= TranslationsConfig.getLanguage()?.toLowerCase() ?? NONE;
 
-    if (lan !== NONE) {
+    if (!isNullish(basename) && lan !== NONE) {
       const defaultBundle = Translations.getDefaultBundle(basename, lan);
       const specialBundle = Translations.getSpecialBundle(basename, lan);
 
@@ -403,9 +403,9 @@ export class TranslationsAsI18n implements I18nProvider {
   }
 
   addResource(
-    basename: string,
-    language: string | null,
-    callback: Function | null
+    basename?: string | null,
+    language?: string | null,
+    callback?: Function | null
   ): void {
     Translations.add(basename, language, callback);
   }

--- a/packages/core/src/i18n/Translations.ts
+++ b/packages/core/src/i18n/Translations.ts
@@ -21,6 +21,7 @@ import { NONE } from '../util/Constants';
 import { get, load } from '../util/MaxXmlRequest';
 import type MaxXmlRequest from '../util/MaxXmlRequest';
 import { TranslationsConfig } from './config';
+import { isNullish } from '../util/Utils';
 
 // mxGraph source code: https://github.com/jgraph/mxgraph/blob/v4.2.2/javascript/src/js/util/mxResources.js
 
@@ -75,7 +76,7 @@ import { TranslationsConfig } from './config';
  *
  * @category I18n
  */
-class Translations {
+export default class Translations {
   /*
    * Object that maps from keys to values.
    */
@@ -314,19 +315,19 @@ class Translations {
    * @param defaultValue Optional string that specifies the default return value.
    */
   static get = (
-    key: string,
+    key: string | null = null,
     params: any[] | null = null,
     defaultValue: string | null = null
   ): string | null => {
-    let value: string | null = Translations.resources[key];
+    let value: string | null = key ? Translations.resources[key] : null;
 
     // Applies the default value if no resource was found
-    if (value == null) {
+    if (isNullish(value)) {
       value = defaultValue;
     }
 
     // Replaces the placeholders with the values in the array
-    if (value != null && params != null) {
+    if (!isNullish(value) && params) {
       value = Translations.replacePlaceholders(value, params);
     }
     return value;
@@ -377,5 +378,3 @@ class Translations {
     });
   };
 }
-
-export default Translations;

--- a/packages/core/src/i18n/provider.ts
+++ b/packages/core/src/i18n/provider.ts
@@ -15,8 +15,6 @@ limitations under the License.
 */
 
 import { I18nProvider } from '../types';
-import { TranslationsConfig } from './config';
-import Translations from './Translations';
 
 /**
  * A {@link I18nProvider} that does nothing.
@@ -40,36 +38,5 @@ export class NoOpI18n implements I18nProvider {
     _callback: Function | null
   ): void {
     // do nothing
-  }
-}
-
-/**
- * A {@link I18nProvider} that uses {@link Translations} to manage translations.
- *
- * The configuration is done using {@link TranslationsConfig}.
- *
- * @experimental subject to change or removal. The I18n system may be modified in the future without prior notice.
- * @category I18n
- * @since 0.17.0
- */
-export class TranslationsAsI18n implements I18nProvider {
-  isEnabled(): boolean {
-    return TranslationsConfig.isEnabled();
-  }
-
-  get(
-    key?: string | null,
-    params?: any[] | null,
-    defaultValue?: string | null
-  ): string | null {
-    return Translations.get(key, params, defaultValue);
-  }
-
-  addResource(
-    basename: string,
-    language: string | null,
-    callback: Function | null
-  ): void {
-    Translations.add(basename, language, callback);
   }
 }

--- a/packages/core/src/i18n/provider.ts
+++ b/packages/core/src/i18n/provider.ts
@@ -32,11 +32,7 @@ export class NoOpI18n implements I18nProvider {
     return null;
   }
 
-  addResource(
-    _basename: string,
-    _language: string | null,
-    _callback: Function | null
-  ): void {
+  addResource(): void {
     // do nothing
   }
 }

--- a/packages/core/src/i18n/provider.ts
+++ b/packages/core/src/i18n/provider.ts
@@ -1,0 +1,75 @@
+/*
+Copyright 2025-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { I18nProvider } from '../types';
+import { TranslationsConfig } from './config';
+import Translations from './Translations';
+
+/**
+ * A {@link I18nProvider} that does nothing.
+ *
+ * @experimental subject to change or removal. The I18n system may be modified in the future without prior notice.
+ * @since 0.17.0
+ * @category I18n
+ */
+export class NoOpI18n implements I18nProvider {
+  isEnabled() {
+    return false;
+  }
+
+  get() {
+    return null;
+  }
+
+  addResource(
+    _basename: string,
+    _language: string | null,
+    _callback: Function | null
+  ): void {
+    // do nothing
+  }
+}
+
+/**
+ * A {@link I18nProvider} that uses {@link Translations} to manage translations.
+ *
+ * The configuration is done using {@link TranslationsConfig}.
+ *
+ * @experimental subject to change or removal. The I18n system may be modified in the future without prior notice.
+ * @category I18n
+ * @since 0.17.0
+ */
+export class TranslationsAsI18n implements I18nProvider {
+  isEnabled(): boolean {
+    return TranslationsConfig.isEnabled();
+  }
+
+  get(
+    key?: string | null,
+    params?: any[] | null,
+    defaultValue?: string | null
+  ): string | null {
+    return Translations.get(key, params, defaultValue);
+  }
+
+  addResource(
+    basename: string,
+    language: string | null,
+    callback: Function | null
+  ): void {
+    Translations.add(basename, language, callback);
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -123,8 +123,10 @@ export { default as StencilShapeRegistry } from './view/geometry/node/StencilSha
 
 export * as constants from './util/Constants';
 export { default as Guide } from './view/other/Guide';
+
 export { default as Translations } from './i18n/Translations';
 export * from './i18n/config';
+export * from './i18n/provider';
 
 export * as cellArrayUtils from './util/cellArrayUtils';
 export * as cloneUtils from './util/cloneUtils';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -124,7 +124,7 @@ export { default as StencilShapeRegistry } from './view/geometry/node/StencilSha
 export * as constants from './util/Constants';
 export { default as Guide } from './view/other/Guide';
 
-export { default as Translations } from './i18n/Translations';
+export { default as Translations, TranslationsAsI18n } from './i18n/Translations';
 export * from './i18n/config';
 export * from './i18n/provider';
 

--- a/packages/core/src/internal/i18n-utils.ts
+++ b/packages/core/src/internal/i18n-utils.ts
@@ -14,10 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { GlobalConfig } from '../util/config';
+
 /**
- * @internal
+ * @private
  */
-export const doEval = (expression: string): any => {
-  // eslint-disable-next-line no-eval -- valid here as we want this function to be the only place in the codebase that uses eval
-  return eval(expression);
-};
+export function isI18nEnabled(): boolean {
+  return GlobalConfig.i18n.isEnabled();
+}
+
+/**
+ * @private
+ */
+export function translate(
+  key?: string | null,
+  params?: any[] | null,
+  defaultValue?: string
+): string | null {
+  return GlobalConfig.i18n.get(key, params, defaultValue);
+}

--- a/packages/core/src/internal/utils.ts
+++ b/packages/core/src/internal/utils.ts
@@ -14,6 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { TranslationsConfig } from '../i18n/config';
+import Translations from '../i18n/Translations';
+import { GlobalConfig } from '../util/config';
+
 /**
  * @internal
  */
@@ -21,3 +25,21 @@ export const doEval = (expression: string): any => {
   // eslint-disable-next-line no-eval -- valid here as we want this function to be the only place in the codebase that uses eval
   return eval(expression);
 };
+
+/**
+ * @internal
+ */
+export function isI18nEnabled(): boolean {
+  return GlobalConfig.i18n.isEnabled();
+}
+
+/**
+ * @internal
+ */
+export function translate(
+  key?: string | null,
+  params?: any[] | null,
+  defaultValue?: string
+): string | null {
+  return GlobalConfig.i18n.get(key, params, defaultValue);
+}

--- a/packages/core/src/serialization/codecs/editor/EditorCodec.ts
+++ b/packages/core/src/serialization/codecs/editor/EditorCodec.ts
@@ -20,6 +20,8 @@ import type Codec from '../../Codec';
 import MaxWindow from '../../../gui/MaxWindow';
 import Translations from '../../../i18n/Translations';
 import { addLinkToHead, getChildNodes } from '../../../util/domUtils';
+import { translate } from '../../../internal/utils';
+import { GlobalConfig } from '../../../util/config';
 
 /**
  * Codec for {@link Editor}s.
@@ -170,7 +172,7 @@ export class EditorCodec extends ObjectCodec {
           }
 
           const wnd = new MaxWindow(
-            Translations.get(as) || as,
+            translate(as) || as,
             element,
             x,
             y,
@@ -195,7 +197,7 @@ export class EditorCodec extends ObjectCodec {
           throw new Error('Unimplemented');
         }
       } else if (tmp.nodeName === 'resource') {
-        Translations.add(tmp.getAttribute('basename')!);
+        GlobalConfig.i18n.addResource(tmp.getAttribute('basename')!);
       } else if (tmp.nodeName === 'stylesheet') {
         addLinkToHead('stylesheet', tmp.getAttribute('name')!);
       }

--- a/packages/core/src/serialization/codecs/editor/EditorCodec.ts
+++ b/packages/core/src/serialization/codecs/editor/EditorCodec.ts
@@ -197,7 +197,7 @@ export class EditorCodec extends ObjectCodec {
           throw new Error('Unimplemented');
         }
       } else if (tmp.nodeName === 'resource') {
-        GlobalConfig.i18n.addResource(tmp.getAttribute('basename')!);
+        GlobalConfig.i18n.addResource(tmp.getAttribute('basename'));
       } else if (tmp.nodeName === 'stylesheet') {
         addLinkToHead('stylesheet', tmp.getAttribute('name')!);
       }

--- a/packages/core/src/serialization/codecs/editor/EditorCodec.ts
+++ b/packages/core/src/serialization/codecs/editor/EditorCodec.ts
@@ -18,7 +18,6 @@ import ObjectCodec from '../../ObjectCodec';
 import Editor from '../../../editor/Editor';
 import type Codec from '../../Codec';
 import MaxWindow from '../../../gui/MaxWindow';
-import Translations from '../../../i18n/Translations';
 import { addLinkToHead, getChildNodes } from '../../../util/domUtils';
 import { GlobalConfig } from '../../../util/config';
 import { translate } from '../../../internal/i18n-utils';

--- a/packages/core/src/serialization/codecs/editor/EditorCodec.ts
+++ b/packages/core/src/serialization/codecs/editor/EditorCodec.ts
@@ -20,8 +20,8 @@ import type Codec from '../../Codec';
 import MaxWindow from '../../../gui/MaxWindow';
 import Translations from '../../../i18n/Translations';
 import { addLinkToHead, getChildNodes } from '../../../util/domUtils';
-import { translate } from '../../../internal/utils';
 import { GlobalConfig } from '../../../util/config';
+import { translate } from '../../../internal/i18n-utils';
 
 /**
  * Codec for {@link Editor}s.

--- a/packages/core/src/serialization/codecs/editor/EditorToolbarCodec.ts
+++ b/packages/core/src/serialization/codecs/editor/EditorToolbarCodec.ts
@@ -23,7 +23,8 @@ import { convertPoint } from '../../../util/styleUtils';
 import { getClientX, getClientY } from '../../../util/EventUtils';
 import InternalEvent from '../../../view/event/InternalEvent';
 import { getChildNodes, getTextContent, isElement } from '../../../util/domUtils';
-import { doEval, translate } from '../../../internal/utils';
+import { doEval } from '../../../internal/utils';
+import { translate } from '../../../internal/i18n-utils';
 
 /**
  * Custom codec for configuring {@link EditorToolbar}s.

--- a/packages/core/src/serialization/codecs/editor/EditorToolbarCodec.ts
+++ b/packages/core/src/serialization/codecs/editor/EditorToolbarCodec.ts
@@ -23,8 +23,7 @@ import { convertPoint } from '../../../util/styleUtils';
 import { getClientX, getClientY } from '../../../util/EventUtils';
 import InternalEvent from '../../../view/event/InternalEvent';
 import { getChildNodes, getTextContent, isElement } from '../../../util/domUtils';
-import Translations from '../../../i18n/Translations';
-import { doEval } from '../../../internal/utils';
+import { doEval, translate } from '../../../internal/utils';
 
 /**
  * Custom codec for configuring {@link EditorToolbar}s.
@@ -144,7 +143,7 @@ export class EditorToolbarCodec extends ObjectCodec {
               into.toolbar.addLine();
             } else if (node.nodeName === 'add') {
               let as = <string>node.getAttribute('as');
-              as = Translations.get(as) || as;
+              as = translate(as) || as;
               const icon = node.getAttribute('icon');
               const pressedIcon = node.getAttribute('pressedIcon');
               const action = node.getAttribute('action');

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { DIRECTION, IDENTITY_FIELD_NAME } from './util/Constants';
+import { IDENTITY_FIELD_NAME } from './util/Constants';
 import type { Graph } from './view/Graph';
 import type AbstractCanvas2D from './view/canvas/AbstractCanvas2D';
 import type Cell from './view/cell/Cell';
@@ -1303,4 +1303,45 @@ export interface Logger {
   warn(message: string): void;
 
   error(message: string, ...optionalParams: any[]): void;
+}
+
+/**
+ * The abstract interface for the I18n system. The actual implementation is configured in {@link GlobalConfig.i18n}.
+ *
+ * @experimental subject to change or removal. The I18n system may be modified in the future without prior notice.
+ * @since 0.17.0
+ * @category I18n
+ */
+export interface I18nProvider {
+  /**
+   * Returns whether internationalization is enabled.
+   */
+  isEnabled(): boolean;
+
+  /**
+   * Returns the value for the specified resource key.
+   *
+   * @param key String that represents the key of the resource to be returned.
+   * @param params Array of the values for the placeholders to be replaced with in the resulting string. The form of the placeholder is specific to each implementation.
+   * @param defaultValue Optional string that specifies the default return value.   */
+  get(
+    key?: string | null,
+    params?: any[] | null,
+    defaultValue?: string | null
+  ): string | null;
+
+  /**
+   * Load the translation file for the given basename and language.
+   *
+   * This is mainly used by the maxGraph built-in provider to bind to {@link Translations.add}.
+   *
+   * @param basename The basename for which the file should be loaded.
+   * @param language The language for which the file should be loaded. Default is `null`.
+   * @param callback Optional callback for asynchronous loading. Default is `null`.
+   */
+  addResource(
+    basename: string,
+    language?: string | null,
+    callback?: Function | null
+  ): void;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1340,7 +1340,7 @@ export interface I18nProvider {
    * @param callback Optional callback for asynchronous loading. Default is `null`.
    */
   addResource(
-    basename: string,
+    basename?: string | null,
     language?: string | null,
     callback?: Function | null
   ): void;

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -34,7 +34,7 @@ import { NoOpI18n } from '../i18n/provider';
  */
 export const GlobalConfig = {
   /**
-   * Configure the logger to use for all log messages.
+   * Configure the {@link I18nProvider} to use for all translated messages.
    *
    * Available implementations provided by maxGraph are:
    * * {@link NoOpI18n} - Default implementation that does nothing.

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { Logger } from '../types';
+import type { I18nProvider, Logger } from '../types';
 import { NoOpLogger } from './logger';
 import {
   SHADOW_OFFSET_X,
@@ -23,6 +23,7 @@ import {
   SHADOWCOLOR,
 } from './Constants';
 import { shallowCopy } from './cloneUtils';
+import { NoOpI18n } from '../i18n/provider';
 
 /**
  * Global configuration for maxGraph.
@@ -32,6 +33,24 @@ import { shallowCopy } from './cloneUtils';
  * @category Configuration
  */
 export const GlobalConfig = {
+  /**
+   * Configure the logger to use for all log messages.
+   *
+   * Available implementations provided by maxGraph are:
+   * * {@link NoOpI18n} - Default implementation that does nothing.
+   * * {@link TranslationsAsI18n} - Uses {@link Translations} to manage translations.
+   *
+   * To change the i18n provider, set this property to an instance of the desired provider:
+   * ```js
+   * // To use the i18n system provided by maxGraph
+   * GlobalConfig.i18n = new TranslationsAsI18n();
+   * ```
+   *
+   * @default {@link NoOpI18n}
+   * @since 0.17.0
+   */
+  i18n: new NoOpI18n() as I18nProvider,
+
   /**
    * Configure the logger to use for all log messages.
    *

--- a/packages/core/src/view/Graph.ts
+++ b/packages/core/src/view/Graph.ts
@@ -45,7 +45,6 @@ import EdgeHandler from './handler/EdgeHandler';
 import VertexHandler from './handler/VertexHandler';
 import EdgeSegmentHandler from './handler/EdgeSegmentHandler';
 import ElbowEdgeHandler from './handler/ElbowEdgeHandler';
-
 import type {
   EdgeStyleFunction,
   GraphPlugin,
@@ -60,9 +59,7 @@ import { registerDefaultEdgeMarkers } from './geometry/edge/MarkerShape';
 import { registerDefaultStyleElements } from './style/register';
 import { applyGraphMixins } from './mixins/_graph-mixins-apply';
 import { getDefaultPlugins } from './plugins';
-import { TranslationsConfig } from '../i18n/config';
 import { isNullish } from '../internal/utils';
-
 import { isI18nEnabled } from '../internal/i18n-utils';
 
 /**

--- a/packages/core/src/view/Graph.ts
+++ b/packages/core/src/view/Graph.ts
@@ -62,7 +62,8 @@ import { applyGraphMixins } from './mixins/_graph-mixins-apply';
 import { getDefaultPlugins } from './plugins';
 import { TranslationsConfig } from '../i18n/config';
 import { isNullish } from '../util/Utils';
-import { isI18nEnabled } from '../internal/utils';
+
+import { isI18nEnabled } from '../internal/i18n-utils';
 
 /**
  * Extends {@link EventSource} to implement a graph component for the browser. This is the main class of the package.

--- a/packages/core/src/view/Graph.ts
+++ b/packages/core/src/view/Graph.ts
@@ -62,6 +62,7 @@ import { applyGraphMixins } from './mixins/_graph-mixins-apply';
 import { getDefaultPlugins } from './plugins';
 import { TranslationsConfig } from '../i18n/config';
 import { isNullish } from '../util/Utils';
+import { isI18nEnabled } from '../internal/utils';
 
 /**
  * Extends {@link EventSource} to implement a graph component for the browser. This is the main class of the package.
@@ -384,9 +385,7 @@ class Graph extends EventSource {
    * for this key does not exist then the value is used as the error message.
    * @default 'alreadyConnected'
    */
-  alreadyConnectedResource: string = TranslationsConfig.isEnabled()
-    ? 'alreadyConnected'
-    : '';
+  alreadyConnectedResource: string = isI18nEnabled() ? 'alreadyConnected' : '';
 
   /**
    * Specifies the resource key for the warning message to be displayed when
@@ -394,7 +393,7 @@ class Graph extends EventSource {
    * key does not exist then the value is used as the warning message.
    * @default 'containsValidationErrors'
    */
-  containsValidationErrorsResource: string = TranslationsConfig.isEnabled()
+  containsValidationErrorsResource: string = isI18nEnabled()
     ? 'containsValidationErrors'
     : '';
 

--- a/packages/core/src/view/GraphSelectionModel.ts
+++ b/packages/core/src/view/GraphSelectionModel.ts
@@ -24,7 +24,8 @@ import UndoableEdit from './undoable_changes/UndoableEdit';
 import EventObject from './event/EventObject';
 import InternalEvent from './event/InternalEvent';
 import { TranslationsConfig } from '../i18n/config';
-import { isI18nEnabled } from '../internal/utils';
+
+import { isI18nEnabled } from '../internal/i18n-utils';
 
 /**
  * Implements the selection model for a graph. Here is a listener that handles

--- a/packages/core/src/view/GraphSelectionModel.ts
+++ b/packages/core/src/view/GraphSelectionModel.ts
@@ -23,8 +23,6 @@ import SelectionChange from './undoable_changes/SelectionChange';
 import UndoableEdit from './undoable_changes/UndoableEdit';
 import EventObject from './event/EventObject';
 import InternalEvent from './event/InternalEvent';
-import { TranslationsConfig } from '../i18n/config';
-
 import { isI18nEnabled } from '../internal/i18n-utils';
 
 /**

--- a/packages/core/src/view/GraphSelectionModel.ts
+++ b/packages/core/src/view/GraphSelectionModel.ts
@@ -24,6 +24,7 @@ import UndoableEdit from './undoable_changes/UndoableEdit';
 import EventObject from './event/EventObject';
 import InternalEvent from './event/InternalEvent';
 import { TranslationsConfig } from '../i18n/config';
+import { isI18nEnabled } from '../internal/utils';
 
 /**
  * Implements the selection model for a graph. Here is a listener that handles
@@ -78,7 +79,7 @@ class GraphSelectionModel extends EventSource {
    * the status message.
    * @default 'done'
    */
-  doneResource = TranslationsConfig.isEnabled() ? 'done' : '';
+  doneResource = isI18nEnabled() ? 'done' : '';
 
   /**
    * Specifies the resource key for the status message while the selection is
@@ -86,7 +87,7 @@ class GraphSelectionModel extends EventSource {
    * value is used as the status message.
    * @default 'updatingSelection'
    */
-  updatingSelectionResource = TranslationsConfig.isEnabled() ? 'updatingSelection' : '';
+  updatingSelectionResource = isI18nEnabled() ? 'updatingSelection' : '';
 
   /**
    * Specifies if only one selected item at a time is allowed.

--- a/packages/core/src/view/GraphView.ts
+++ b/packages/core/src/view/GraphView.ts
@@ -46,7 +46,7 @@ import StyleRegistry from './style/StyleRegistry';
 import type TooltipHandler from './plugins/TooltipHandler';
 import type { EdgeStyleFunction, MouseEventListener } from '../types';
 import { TranslationsConfig } from '../i18n/config';
-import { doEval } from '../internal/utils';
+import { doEval, isI18nEnabled } from '../internal/utils';
 
 /**
  * @class GraphView
@@ -122,7 +122,7 @@ export class GraphView extends EventSource {
    * the status message.
    * @default 'done'
    */
-  doneResource = TranslationsConfig.isEnabled() ? 'done' : '';
+  doneResource = isI18nEnabled() ? 'done' : '';
 
   /**
    * Specifies the resource key for the status message while the document is
@@ -130,7 +130,7 @@ export class GraphView extends EventSource {
    * value is used as the status message.
    * @default 'updatingSelection'
    */
-  updatingDocumentResource = TranslationsConfig.isEnabled() ? 'updatingDocument' : '';
+  updatingDocumentResource = isI18nEnabled() ? 'updatingDocument' : '';
 
   /**
    * Specifies if string values in cell styles should be evaluated using {@link eval}.

--- a/packages/core/src/view/GraphView.ts
+++ b/packages/core/src/view/GraphView.ts
@@ -45,7 +45,6 @@ import type { Graph } from './Graph';
 import StyleRegistry from './style/StyleRegistry';
 import type TooltipHandler from './plugins/TooltipHandler';
 import type { EdgeStyleFunction, MouseEventListener } from '../types';
-import { TranslationsConfig } from '../i18n/config';
 import { doEval } from '../internal/utils';
 import { isI18nEnabled } from '../internal/i18n-utils';
 

--- a/packages/core/src/view/GraphView.ts
+++ b/packages/core/src/view/GraphView.ts
@@ -46,7 +46,8 @@ import StyleRegistry from './style/StyleRegistry';
 import type TooltipHandler from './plugins/TooltipHandler';
 import type { EdgeStyleFunction, MouseEventListener } from '../types';
 import { TranslationsConfig } from '../i18n/config';
-import { doEval, isI18nEnabled } from '../internal/utils';
+import { doEval } from '../internal/utils';
+import { isI18nEnabled } from '../internal/i18n-utils';
 
 /**
  * @class GraphView

--- a/packages/core/src/view/geometry/node/StencilShape.ts
+++ b/packages/core/src/view/geometry/node/StencilShape.ts
@@ -32,7 +32,8 @@ import { getChildNodes, getTextContent, isElement } from '../../../util/domUtils
 import Point from '../Point';
 import AbstractCanvas2D from '../../canvas/AbstractCanvas2D';
 import { AlignValue, ColorValue, VAlignValue } from '../../../types';
-import { doEval, translate } from '../../../internal/utils';
+import { doEval } from '../../../internal/utils';
+import { translate } from '../../../internal/i18n-utils';
 
 /**
  * Configure global settings for stencil shapes.

--- a/packages/core/src/view/geometry/node/StencilShape.ts
+++ b/packages/core/src/view/geometry/node/StencilShape.ts
@@ -19,7 +19,6 @@ limitations under the License.
 import ConnectionConstraint from '../../other/ConnectionConstraint';
 import Rectangle from '../Rectangle';
 import Shape from '../Shape';
-import Translations from '../../../i18n/Translations';
 import { isNullish } from '../../../util/Utils';
 import {
   ALIGN,
@@ -33,7 +32,7 @@ import { getChildNodes, getTextContent, isElement } from '../../../util/domUtils
 import Point from '../Point';
 import AbstractCanvas2D from '../../canvas/AbstractCanvas2D';
 import { AlignValue, ColorValue, VAlignValue } from '../../../types';
-import { doEval } from '../../../internal/utils';
+import { doEval, translate } from '../../../internal/utils';
 
 /**
  * Configure global settings for stencil shapes.
@@ -176,7 +175,7 @@ class StencilShape extends Shape {
     const loc = node.getAttribute('localized');
 
     if ((StencilShapeConfig.defaultLocalized && !loc) || loc === '1') {
-      result = Translations.get(<string>result);
+      result = translate(result);
     }
     return result;
   }

--- a/packages/core/src/view/handler/ElbowEdgeHandler.ts
+++ b/packages/core/src/view/handler/ElbowEdgeHandler.ts
@@ -25,7 +25,7 @@ import { intersects } from '../../util/mathUtils';
 import { isConsumed } from '../../util/EventUtils';
 import CellState from '../cell/CellState';
 import { HandleConfig } from './config';
-import { isI18nEnabled, translate } from '../../internal/utils';
+import { isI18nEnabled, translate } from '../../internal/i18n-utils';
 
 /**
  * Graph event handler that reconnects edges and modifies control points and

--- a/packages/core/src/view/handler/ElbowEdgeHandler.ts
+++ b/packages/core/src/view/handler/ElbowEdgeHandler.ts
@@ -130,7 +130,7 @@ class ElbowEdgeHandler extends EdgeHandler {
       (node === this.bends[1].node || node.parentNode === this.bends[1].node)
     ) {
       tip = this.doubleClickOrientationResource;
-      tip = translate(tip) || tip; // translate
+      tip = translate(tip) || tip;
     }
 
     return tip;

--- a/packages/core/src/view/handler/ElbowEdgeHandler.ts
+++ b/packages/core/src/view/handler/ElbowEdgeHandler.ts
@@ -20,13 +20,12 @@ import EdgeHandler from './EdgeHandler';
 import { CURSOR, EDGESTYLE, ELBOW } from '../../util/Constants';
 import InternalEvent from '../event/InternalEvent';
 import Point from '../geometry/Point';
-import Translations from '../../i18n/Translations';
-import { TranslationsConfig } from '../../i18n/config';
 import Rectangle from '../geometry/Rectangle';
 import { intersects } from '../../util/mathUtils';
 import { isConsumed } from '../../util/EventUtils';
 import CellState from '../cell/CellState';
 import { HandleConfig } from './config';
+import { isI18nEnabled, translate } from '../../internal/utils';
 
 /**
  * Graph event handler that reconnects edges and modifies control points and
@@ -57,9 +56,7 @@ class ElbowEdgeHandler extends EdgeHandler {
    * exist then the value is used as the error message.
    * @default 'doubleClickOrientation'.
    */
-  doubleClickOrientationResource = TranslationsConfig.isEnabled()
-    ? 'doubleClickOrientation'
-    : '';
+  doubleClickOrientationResource = isI18nEnabled() ? 'doubleClickOrientation' : '';
 
   /**
    * Overrides {@link EdgeHandler.createBends} to create custom bends.
@@ -133,7 +130,7 @@ class ElbowEdgeHandler extends EdgeHandler {
       (node === this.bends[1].node || node.parentNode === this.bends[1].node)
     ) {
       tip = this.doubleClickOrientationResource;
-      tip = Translations.get(tip) || tip; // translate
+      tip = translate(tip) || tip; // translate
     }
 
     return tip;

--- a/packages/core/src/view/mixins/FoldingMixin.ts
+++ b/packages/core/src/view/mixins/FoldingMixin.ts
@@ -24,7 +24,8 @@ import { toRadians } from '../../util/mathUtils';
 import Rectangle from '../geometry/Rectangle';
 import type { Graph } from '../Graph';
 import { TranslationsConfig } from '../../i18n/config';
-import { isI18nEnabled } from '../../internal/utils';
+
+import { isI18nEnabled } from '../../internal/i18n-utils';
 
 type PartialGraph = Pick<
   Graph,

--- a/packages/core/src/view/mixins/FoldingMixin.ts
+++ b/packages/core/src/view/mixins/FoldingMixin.ts
@@ -23,8 +23,6 @@ import Geometry from '../geometry/Geometry';
 import { toRadians } from '../../util/mathUtils';
 import Rectangle from '../geometry/Rectangle';
 import type { Graph } from '../Graph';
-import { TranslationsConfig } from '../../i18n/config';
-
 import { isI18nEnabled } from '../../internal/i18n-utils';
 
 type PartialGraph = Pick<

--- a/packages/core/src/view/mixins/FoldingMixin.ts
+++ b/packages/core/src/view/mixins/FoldingMixin.ts
@@ -24,6 +24,7 @@ import { toRadians } from '../../util/mathUtils';
 import Rectangle from '../geometry/Rectangle';
 import type { Graph } from '../Graph';
 import { TranslationsConfig } from '../../i18n/config';
+import { isI18nEnabled } from '../../internal/utils';
 
 type PartialGraph = Pick<
   Graph,
@@ -63,7 +64,7 @@ export const FoldingMixin: PartialType = {
     collapseToPreferredSize: true,
   },
 
-  collapseExpandResource: TranslationsConfig.isEnabled() ? 'collapse-expand' : '',
+  collapseExpandResource: isI18nEnabled() ? 'collapse-expand' : '',
 
   getCollapseExpandResource() {
     return this.collapseExpandResource;

--- a/packages/core/src/view/mixins/TooltipMixin.ts
+++ b/packages/core/src/view/mixins/TooltipMixin.ts
@@ -20,7 +20,8 @@ import type Cell from '../cell/Cell';
 import type { Graph } from '../Graph';
 import type SelectionCellsHandler from '../plugins/SelectionCellsHandler';
 import type TooltipHandler from '../plugins/TooltipHandler';
-import { translate } from '../../internal/utils';
+
+import { translate } from '../../internal/i18n-utils';
 
 type PartialGraph = Pick<
   Graph,

--- a/packages/core/src/view/mixins/TooltipMixin.ts
+++ b/packages/core/src/view/mixins/TooltipMixin.ts
@@ -15,12 +15,12 @@ limitations under the License.
 */
 
 import { htmlEntities } from '../../util/StringUtils';
-import Translations from '../../i18n/Translations';
 import type Shape from '../geometry/Shape';
 import type Cell from '../cell/Cell';
 import type { Graph } from '../Graph';
 import type SelectionCellsHandler from '../plugins/SelectionCellsHandler';
 import type TooltipHandler from '../plugins/TooltipHandler';
+import { translate } from '../../internal/utils';
 
 type PartialGraph = Pick<
   Graph,
@@ -40,7 +40,7 @@ export const TooltipMixin: PartialType = {
       (node === state.control.node || node.parentNode === state.control.node)
     ) {
       tip = this.getCollapseExpandResource();
-      tip = htmlEntities(Translations.get(tip) || tip, true).replace(/\\n/g, '<br>');
+      tip = htmlEntities(translate(tip) || tip, true).replace(/\\n/g, '<br>');
     }
 
     if (!tip && state.overlays) {

--- a/packages/core/src/view/mixins/TooltipMixin.ts
+++ b/packages/core/src/view/mixins/TooltipMixin.ts
@@ -20,7 +20,6 @@ import type Cell from '../cell/Cell';
 import type { Graph } from '../Graph';
 import type SelectionCellsHandler from '../plugins/SelectionCellsHandler';
 import type TooltipHandler from '../plugins/TooltipHandler';
-
 import { translate } from '../../internal/i18n-utils';
 
 type PartialGraph = Pick<

--- a/packages/core/src/view/mixins/ValidationMixin.ts
+++ b/packages/core/src/view/mixins/ValidationMixin.ts
@@ -17,7 +17,6 @@ limitations under the License.
 import type Cell from '../cell/Cell';
 import { isNode } from '../../util/domUtils';
 import type { Graph } from '../Graph';
-
 import { translate } from '../../internal/i18n-utils';
 
 type PartialGraph = Pick<

--- a/packages/core/src/view/mixins/ValidationMixin.ts
+++ b/packages/core/src/view/mixins/ValidationMixin.ts
@@ -15,9 +15,9 @@ limitations under the License.
 */
 
 import type Cell from '../cell/Cell';
-import Translations from '../../i18n/Translations';
 import { isNode } from '../../util/domUtils';
 import type { Graph } from '../Graph';
+import { translate } from '../../internal/utils';
 
 type PartialGraph = Pick<
   Graph,
@@ -89,7 +89,7 @@ export const ValidationMixin: PartialType = {
         // Checks if the source and target are not connected by another edge
         if (tmp.length > 1 || (tmp.length === 1 && tmp[0] !== edge)) {
           error += `${
-            Translations.get(this.getAlreadyConnectedResource()) ||
+            translate(this.getAlreadyConnectedResource()) ||
             this.getAlreadyConnectedResource()
           }\n`;
         }
@@ -172,7 +172,7 @@ export const ValidationMixin: PartialType = {
     // Adds error for invalid children if collapsed (children invisible)
     if (cell && cell.isCollapsed() && !isValid) {
       warning += `${
-        Translations.get(this.getContainsValidationErrorsResource()) ||
+        translate(this.getContainsValidationErrorsResource()) ||
         this.getContainsValidationErrorsResource()
       }\n`;
     }

--- a/packages/core/src/view/mixins/ValidationMixin.ts
+++ b/packages/core/src/view/mixins/ValidationMixin.ts
@@ -17,7 +17,8 @@ limitations under the License.
 import type Cell from '../cell/Cell';
 import { isNode } from '../../util/domUtils';
 import type { Graph } from '../Graph';
-import { translate } from '../../internal/utils';
+
+import { translate } from '../../internal/i18n-utils';
 
 type PartialGraph = Pick<
   Graph,

--- a/packages/core/src/view/other/Multiplicity.ts
+++ b/packages/core/src/view/other/Multiplicity.ts
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import Translations from '../../i18n/Translations';
+import { translate } from '../../internal/utils';
 import { isNode } from '../../util/domUtils';
 import Cell from '../cell/Cell';
 import { Graph } from '../Graph';
@@ -60,8 +60,8 @@ class Multiplicity {
     this.min = min ?? 0;
     this.max = max ?? Number.MAX_VALUE;
     this.validNeighbors = validNeighbors;
-    this.countError = Translations.get(countError) || countError;
-    this.typeError = Translations.get(typeError) || typeError;
+    this.countError = translate(countError) || countError;
+    this.typeError = translate(typeError) || typeError;
     this.validNeighborsAllowed = validNeighborsAllowed;
   }
 

--- a/packages/core/src/view/other/Multiplicity.ts
+++ b/packages/core/src/view/other/Multiplicity.ts
@@ -16,10 +16,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { translate } from '../../internal/utils';
 import { isNode } from '../../util/domUtils';
 import Cell from '../cell/Cell';
 import { Graph } from '../Graph';
+import { translate } from '../../internal/i18n-utils';
 
 /**
  * @class Multiplicity

--- a/packages/html/.storybook/preview.ts
+++ b/packages/html/.storybook/preview.ts
@@ -16,6 +16,7 @@ import {
   StencilShapeRegistry,
   StylesheetCodec,
   Translations,
+  TranslationsAsI18n,
 } from '@maxgraph/core';
 
 const defaultLogger = new NoOpLogger();
@@ -26,6 +27,8 @@ const defaultLogger = new NoOpLogger();
 // defaultLogger.traceEnabled = true;
 
 defaultLogger.info('[sb-config] Loading i18n resources for Graph...');
+
+const i18nProvider = new TranslationsAsI18n();
 Translations.add(`${Client.basePath}/i18n/graph`, null, (): void => {
   defaultLogger.info('[sb-config] i18n resources loaded for Graph');
 });
@@ -36,6 +39,7 @@ const originalAllowEvalConfig = {
 };
 
 const resetMaxGraphConfigs = (): void => {
+  GlobalConfig.i18n = i18nProvider;
   GlobalConfig.logger = defaultLogger;
 
   resetEdgeHandlerConfig();

--- a/packages/website/docs/usage/i18n.md
+++ b/packages/website/docs/usage/i18n.md
@@ -3,16 +3,38 @@ sidebar_position: 10
 description: How to use i18n with maxGraph.
 ---
 
-## i18n Mechanism in maxGraph
+## Introduction
 
-`maxGraph` provides an internationalization (i18n) mechanism to support multiple languages in applications. It is based on text resource files.
+`maxGraph` provides an internationalization (i18n) mechanism to support multiple languages in your application.
 
-These files are managed by the `Translations` class.\
+Some parts of the API return or display messages that can be translated using key/value pairs with optional parameter substitution.
+
+The i18n mechanism is pluggable via the `I18nProvider` abstraction, so it allows you to use various i18n solutions, such as:
+- built-in solutions provided by `maxGraph`
+- custom implementations to use the i18n solution already used in your application.
+
+:::warning
+
+By default, `maxGraph` uses a no-op i18n implementation that provides no translations.
+
+This keeps the library lightweight because not all applications need internationalization.
+Skipping built-in translations helps reduce bundle size and improve tree-shaking during the build process.
+:::
+
+## Built-in Provider
+
+`maxGraph` includes a built-in provider, `TranslationsAsI18n`, which uses the `Translations` class to load and manage resource files.
+
+As mentioned in the previous paragraph, this mechanism is not enabled by default. So to use it in your application, configure it like this:
+```javascript
+GlobalConfig.i18n = new TranslationsAsI18n();
+```
+
 By default, the following conventions apply:
 - Resource files use the `.txt` extension.
 - The default language is the browser's language, with a fallback to English.
 
-Language support can be configured via `TranslationsConfig.setLanguages`.
+You can override these defaults using the `TranslationsConfig` class. For example, the language support can be configured via `TranslationsConfig.setLanguages`.
 
 `maxGraph` includes built-in translations for the following languages, covering `Graph` and `Editor`:
 - Chinese
@@ -57,3 +79,19 @@ The following stories illustrate the translation of validation messages. Try con
 In the `HelloPort` story, select an edge to display a translated message in the tooltip of the bend point. (Note: The double-click action does not work, same behavior as in mxGraph.)
 - **Live demo**: [HelloPort](https://maxgraph.github.io/maxGraph/demo/?path=/story/misc-helloport--default)
 - **Source code**: [HelloPort.stories.ts](https://github.com/maxGraph/maxGraph/blob/main/packages/html/stories/HelloPort.stories.ts)
+
+
+## Custom Provider
+
+You can implement a custom i18n provider if your application already uses a different translation system.
+
+To do this:
+
+1. Create a class that implements the `I18nProvider` interface — let's call it `MyI18nProvider`.
+2. Register it with:
+
+```js
+GlobalConfig.i18n = new MyI18nProvider();
+```
+
+This gives you full control over how translations are handled inside `maxGraph`, making it easy to integrate with any existing i18n setup.


### PR DESCRIPTION
Previously, the i18n built-in mechanism managed by the `Translations` class was always in use.
It is now possible to plug custom i18n solutions in addition to the built-in implementation.

By default, maxGraph now use an implementation that doesn't provide any translation. This reduces the size of the
applications that don't want to use the built-in implementation.
The bundle size of examples provided in the repository has been reduced by the following values:
  - js-example: 8kB
  - ts-example: 5kB

Some methods of the `Translations` class are now more resilient to errors by accepting nullish parameters:
  - add (basename parameter)
  - get (key parameter)


BREAKING CHANGES: The built-in `Translations` class is no longer used by default. To use it, call `GlobalConfig.i18n = new TranslationsAsI18n()`.

## Notes

Closes #688




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Breaking Changes**
  - Internationalization now requires explicit configuration. The built-in translation support is disabled by default, so users must update their settings to enable translations.
  - The `Translations` class is no longer used by default; users must instantiate `TranslationsAsI18n` to utilize it.

- **New Features**
  - Introduced a new internationalization provider and enhanced translation helper methods, streamlining the localization of UI messages and tooltips.

- **Documentation**
  - Updated guides and examples to walk users through enabling and customizing the internationalization features, including instructions for integrating custom translation systems.
  - Expanded content on the pluggable nature of the internationalization mechanism and detailed the built-in provider `TranslationsAsI18n`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->