### PR TITLE
refactor!: move internal utils functions to a dedicated directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _**Note:** Yet to be released breaking changes appear here._
 
 **Breaking Changes**:
 - `StylesheetCodec.allowEval` is now set to `false` by default to prevent unwanted use of the eval function, as it carries a possible security risk.
+- `Utils.copyTextToClipboard` is no longer available. It was intended to be internal and had been made public by mistake.
 
 ## 0.16.0
 

--- a/packages/core/__tests__/internal/utils.test.ts
+++ b/packages/core/__tests__/internal/utils.test.ts
@@ -1,0 +1,34 @@
+/*
+Copyright 2025-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, expect, test } from '@jest/globals';
+import { FONT } from '../../src/util/Constants';
+import { matchBinaryMask } from '../../src/internal/utils';
+
+describe('matchBinaryMask', () => {
+  test('match self', () => {
+    expect(matchBinaryMask(FONT.STRIKETHROUGH, FONT.STRIKETHROUGH)).toBeTruthy();
+  });
+  test('match', () => {
+    expect(matchBinaryMask(9465, FONT.BOLD)).toBeTruthy();
+  });
+  test('match another', () => {
+    expect(matchBinaryMask(19484, FONT.UNDERLINE)).toBeTruthy();
+  });
+  test('no match', () => {
+    expect(matchBinaryMask(46413, FONT.ITALIC)).toBeFalsy();
+  });
+});

--- a/packages/core/__tests__/util/styleUtils.test.ts
+++ b/packages/core/__tests__/util/styleUtils.test.ts
@@ -16,7 +16,6 @@ limitations under the License.
 
 import { describe, expect, test } from '@jest/globals';
 import {
-  matchBinaryMask,
   parseCssNumber,
   setStyleFlag,
   setCellStyleFlags,
@@ -25,21 +24,6 @@ import {
 import { FONT } from '../../src/util/Constants';
 import { type CellStyle } from '../../src/types';
 import { createGraphWithoutPlugins } from '../utils';
-
-describe('matchBinaryMask', () => {
-  test('match self', () => {
-    expect(matchBinaryMask(FONT.STRIKETHROUGH, FONT.STRIKETHROUGH)).toBeTruthy();
-  });
-  test('match', () => {
-    expect(matchBinaryMask(9465, FONT.BOLD)).toBeTruthy();
-  });
-  test('match another', () => {
-    expect(matchBinaryMask(19484, FONT.UNDERLINE)).toBeTruthy();
-  });
-  test('no match', () => {
-    expect(matchBinaryMask(46413, FONT.ITALIC)).toBeFalsy();
-  });
-});
 
 describe('parseCssNumber', () => {
   test.each([

--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -58,7 +58,7 @@ import type PanningHandler from '../view/plugins/PanningHandler';
 import { cloneCell } from '../util/cellArrayUtils';
 import { TranslationsConfig } from '../i18n/config';
 import type MaxPopupMenu from '../gui/MaxPopupMenu';
-import { isNullish } from '../util/Utils';
+import { isNullish } from '../internal/utils';
 
 /**
  * Extends {@link EventSource} to implement an application wrapper for a graph that

--- a/packages/core/src/editor/EditorPopupMenu.ts
+++ b/packages/core/src/editor/EditorPopupMenu.ts
@@ -21,10 +21,8 @@ import MaxPopupMenu from '../gui/MaxPopupMenu';
 import { getTextContent } from '../util/domUtils';
 import Translations from '../i18n/Translations';
 import Editor from './Editor';
-
 import { PopupMenuItem } from '../types';
-import { isNullish } from '../util/Utils';
-import { doEval } from '../internal/utils';
+import { doEval, isNullish } from '../internal/utils';
 
 /**
  * Creates popupmenus for mouse events.

--- a/packages/core/src/gui/MaxLog.ts
+++ b/packages/core/src/gui/MaxLog.ts
@@ -22,9 +22,20 @@ import { getInnerHtml, write } from '../util/domUtils';
 import { toString } from '../util/StringUtils';
 import MaxWindow, { popup } from './MaxWindow';
 import { KeyboardEventListener, MouseEventListener } from '../types';
-import { copyTextToClipboard } from '../util/Utils';
-import { getElapseMillisecondsMessage } from '../util/logger';
+import { getElapseMillisecondsMessage } from '../internal/time-utils';
 import { VERSION } from '../util/Constants';
+import { GlobalConfig } from '../util/config';
+
+const copyTextToClipboard = (text: string): void => {
+  navigator.clipboard.writeText(text).then(
+    function () {
+      GlobalConfig.logger.info('Async: Copying to clipboard was successful!');
+    },
+    function (err) {
+      GlobalConfig.logger.error('Async: Could not copy text: ', err);
+    }
+  );
+};
 
 /**
  * A singleton class that implements a simple console.

--- a/packages/core/src/i18n/config.ts
+++ b/packages/core/src/i18n/config.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { isNullish } from '../util/Utils';
-import { shallowCopy } from '../util/cloneUtils';
+import { isNullish } from '../internal/utils';
+import { shallowCopy } from '../internal/clone-utils';
 
 function getNavigatorLanguage() {
   return typeof window !== 'undefined' ? navigator.language : 'en';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -206,4 +206,3 @@ export { default as Multiplicity } from './view/other/Multiplicity';
 // Ensure types are exported in the type definitions
 export type { HTMLImageElementWithProps } from './gui/MaxToolbar';
 export * from './types';
-export { getElapseMillisecondsMessage } from './internal/time-utils';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -206,3 +206,4 @@ export { default as Multiplicity } from './view/other/Multiplicity';
 // Ensure types are exported in the type definitions
 export type { HTMLImageElementWithProps } from './gui/MaxToolbar';
 export * from './types';
+export { getElapseMillisecondsMessage } from './internal/time-utils';

--- a/packages/core/src/internal/clone-utils.ts
+++ b/packages/core/src/internal/clone-utils.ts
@@ -33,8 +33,8 @@ export const shallowCopy = <T extends object>(source: T, target: T): void => {
     if (Object.prototype.hasOwnProperty.call(source, key)) {
       const sourceValue = source[key];
       if (Array.isArray(sourceValue)) {
-        // @ts-ignore source and target are of the same type
-        target[key] = [...sourceValue];
+        // TypeScript cannot infer that the key in target will also be an array when source and target are of the same type
+        (target[key] as unknown[]) = [...sourceValue];
       } else {
         target[key] = sourceValue;
       }

--- a/packages/core/src/internal/clone-utils.ts
+++ b/packages/core/src/internal/clone-utils.ts
@@ -1,0 +1,43 @@
+/*
+Copyright 2025-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Shallow copies properties from the source object to the target object.
+ *
+ * **WARNING**: This function performs only a **shallow** copy i.e. there is no deep copy of the properties that are objects, expect for arrays.
+ *
+ * @template T The type of the objects.
+ *
+ * @param source The source object from which properties will be copied.
+ * @param target The target object to which properties will be copied.
+ *
+ * @private not part of the public API, can be removed or changed without prior notice
+ * @since 0.14.0
+ */
+export const shallowCopy = <T extends object>(source: T, target: T): void => {
+  for (const key in source) {
+    // attempt to prevent prototype pollution
+    if (Object.prototype.hasOwnProperty.call(source, key)) {
+      const sourceValue = source[key];
+      if (Array.isArray(sourceValue)) {
+        // @ts-ignore source and target are of the same type
+        target[key] = [...sourceValue];
+      } else {
+        target[key] = sourceValue;
+      }
+    }
+  }
+};

--- a/packages/core/src/internal/time-utils.ts
+++ b/packages/core/src/internal/time-utils.ts
@@ -15,14 +15,11 @@ limitations under the License.
 */
 
 /**
- * @internal
- * @private
+ * If `baseTimestamp` is provided and not zero, returns a message describing the elapsed milliseconds since this value.
+ * Otherwise, returns an empty string.
+ * @param baseTimestamp the base timestamp to compute the elapsed milliseconds from
+ *
+ * @private not part of the public API, can be removed or changed without prior notice
  */
-export type UserObject = {
-  nodeType?: number;
-  getAttribute?: (name: string) => string | null;
-  hasAttribute?: (name: string) => boolean;
-  setAttribute?: (name: string, value: string) => void;
-  clone?: () => UserObject;
-  cloneNode?: (deep: boolean) => UserObject;
-};
+export const getElapseMillisecondsMessage = (baseTimestamp?: number): string =>
+  baseTimestamp ? ` (${new Date().getTime() - baseTimestamp} ms)` : '';

--- a/packages/core/src/internal/types.ts
+++ b/packages/core/src/internal/types.ts
@@ -1,0 +1,27 @@
+/*
+Copyright 2025-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * @private
+ */
+export type UserObject = {
+  nodeType?: number;
+  getAttribute?: (name: string) => string | null;
+  hasAttribute?: (name: string) => boolean;
+  setAttribute?: (name: string, value: string) => void;
+  clone?: () => UserObject;
+  cloneNode?: (deep: boolean) => UserObject;
+};

--- a/packages/core/src/internal/utils.ts
+++ b/packages/core/src/internal/utils.ts
@@ -14,10 +14,57 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { NODETYPE } from '../util/Constants';
+import { UserObject } from './types';
+import { GlobalConfig } from '../util/config';
+
 /**
- * @internal
+ * @private
  */
 export const doEval = (expression: string): any => {
   // eslint-disable-next-line no-eval -- valid here as we want this function to be the only place in the codebase that uses eval
   return eval(expression);
+};
+
+/**
+ * Returns true if the parameter is not `nullish` and its nodeType relates to an {@link Element}.
+ * @private
+ */
+export const isElement = (node?: Node | UserObject | null): node is Element =>
+  node?.nodeType === NODETYPE.ELEMENT;
+
+/**
+ * @private not part of the public API, can be removed or changed without prior notice
+ */
+export const isNullish = (v: string | object | null | undefined | number | boolean) =>
+  v === null || v === undefined;
+
+/**
+ * Merge a mixin into the destination
+ * @param dest the destination class
+ *
+ * @private not part of the public API, can be removed or changed without prior notice
+ */
+export const mixInto = (dest: any) => (mixin: any) => {
+  const keys = Reflect.ownKeys(mixin);
+  try {
+    for (const key of keys) {
+      Object.defineProperty(dest.prototype, key, {
+        value: mixin[key],
+        writable: true,
+      });
+    }
+  } catch (e) {
+    GlobalConfig.logger.error('Error while mixing', e);
+  }
+};
+
+/**
+ * @param value the value to check.
+ * @param mask the binary mask to apply.
+ * @returns `true` if the value matches the binary mask.
+ * @private Subject to change prior being part of the public API.
+ */
+export const matchBinaryMask = (value: number, mask: number) => {
+  return (value & mask) === mask;
 };

--- a/packages/core/src/serialization/Codec.ts
+++ b/packages/core/src/serialization/Codec.ts
@@ -21,7 +21,8 @@ import CodecRegistry from './CodecRegistry';
 import Cell from '../view/cell/Cell';
 import { GlobalConfig } from '../util/config';
 import { getFunctionName } from '../util/StringUtils';
-import { importNode, isElement, isNode } from '../util/domUtils';
+import { importNode, isNode } from '../util/domUtils';
+import { isElement } from '../internal/utils';
 
 const createXmlDocument = () => {
   return document.implementation.createDocument('', '', null);

--- a/packages/core/src/serialization/ObjectCodec.ts
+++ b/packages/core/src/serialization/ObjectCodec.ts
@@ -21,10 +21,10 @@ import { GlobalConfig } from '../util/config';
 import Geometry from '../view/geometry/Geometry';
 import Point from '../view/geometry/Point';
 import { isInteger, isNumeric } from '../util/mathUtils';
-import { getTextContent, isElement } from '../util/domUtils';
+import { getTextContent } from '../util/domUtils';
 import { load } from '../util/MaxXmlRequest';
 import type Codec from './Codec';
-import { doEval } from '../internal/utils';
+import { doEval, isElement } from '../internal/utils';
 
 /**
  * Generic codec for JavaScript objects that implements a mapping between

--- a/packages/core/src/serialization/codecs/CellCodec.ts
+++ b/packages/core/src/serialization/codecs/CellCodec.ts
@@ -18,8 +18,9 @@ import CodecRegistry from '../CodecRegistry';
 import ObjectCodec from '../ObjectCodec';
 import Cell from '../../view/cell/Cell';
 import type Codec from '../Codec';
-import { importNode, isElement } from '../../util/domUtils';
+import { importNode } from '../../util/domUtils';
 import { removeWhitespace } from '../../util/StringUtils';
+import { isElement } from '../../internal/utils';
 
 /**
  * Codec for {@link Cell}s.

--- a/packages/core/src/serialization/codecs/ChildChangeCodec.ts
+++ b/packages/core/src/serialization/codecs/ChildChangeCodec.ts
@@ -17,8 +17,7 @@ limitations under the License.
 import ObjectCodec from '../ObjectCodec';
 import ChildChange from '../../view/undoable_changes/ChildChange';
 import type Codec from '../Codec';
-
-import { isElement } from '../../util/domUtils';
+import { isElement } from '../../internal/utils';
 
 /**
  * Codec for {@link ChildChange}s.

--- a/packages/core/src/serialization/codecs/RootChangeCodec.ts
+++ b/packages/core/src/serialization/codecs/RootChangeCodec.ts
@@ -17,8 +17,7 @@ limitations under the License.
 import ObjectCodec from '../ObjectCodec';
 import RootChange from '../../view/undoable_changes/RootChange';
 import type Codec from '../Codec';
-
-import { isElement } from '../../util/domUtils';
+import { isElement } from '../../internal/utils';
 
 /**
  * Codec for {@link RootChange}s.

--- a/packages/core/src/serialization/codecs/StylesheetCodec.ts
+++ b/packages/core/src/serialization/codecs/StylesheetCodec.ts
@@ -21,8 +21,8 @@ import StyleRegistry from '../../view/style/StyleRegistry';
 import { clone } from '../../util/cloneUtils';
 import { GlobalConfig } from '../../util/config';
 import { isNumeric } from '../../util/mathUtils';
-import { getTextContent, isElement } from '../../util/domUtils';
-import { doEval } from '../../internal/utils';
+import { getTextContent } from '../../util/domUtils';
+import { doEval, isElement } from '../../internal/utils';
 
 /**
  * Codec for {@link Stylesheet}s.

--- a/packages/core/src/serialization/codecs/editor/EditorToolbarCodec.ts
+++ b/packages/core/src/serialization/codecs/editor/EditorToolbarCodec.ts
@@ -22,9 +22,9 @@ import { GlobalConfig } from '../../../util/config';
 import { convertPoint } from '../../../util/styleUtils';
 import { getClientX, getClientY } from '../../../util/EventUtils';
 import InternalEvent from '../../../view/event/InternalEvent';
-import { getChildNodes, getTextContent, isElement } from '../../../util/domUtils';
+import { getChildNodes, getTextContent } from '../../../util/domUtils';
 import Translations from '../../../i18n/Translations';
-import { doEval } from '../../../internal/utils';
+import { doEval, isElement } from '../../../internal/utils';
 
 /**
  * Custom codec for configuring {@link EditorToolbar}s.

--- a/packages/core/src/util/Utils.ts
+++ b/packages/core/src/util/Utils.ts
@@ -17,7 +17,6 @@ limitations under the License.
 */
 
 import Client from '../Client';
-import { GlobalConfig } from './config';
 
 /**
  * A singleton class that provides cross-browser helper methods.
@@ -52,41 +51,4 @@ export const utils = {
    * Defines the image used for error dialogs.
    */
   errorImage: `${Client.imageBasePath}/error.gif`,
-};
-
-/**
- * @private not part of the public API, can be removed or changed without prior notice
- */
-export const isNullish = (v: string | object | null | undefined | number | boolean) =>
-  v === null || v === undefined;
-
-/**
- * Merge a mixin into the destination
- * @param dest the destination class
- *
- * @private not part of the public API, can be removed or changed without prior notice
- */
-export const mixInto = (dest: any) => (mixin: any) => {
-  const keys = Reflect.ownKeys(mixin);
-  try {
-    for (const key of keys) {
-      Object.defineProperty(dest.prototype, key, {
-        value: mixin[key],
-        writable: true,
-      });
-    }
-  } catch (e) {
-    GlobalConfig.logger.error('Error while mixing', e);
-  }
-};
-
-export const copyTextToClipboard = (text: string): void => {
-  navigator.clipboard.writeText(text).then(
-    function () {
-      GlobalConfig.logger.info('Async: Copying to clipboard was successful!');
-    },
-    function (err) {
-      GlobalConfig.logger.error('Async: Could not copy text: ', err);
-    }
-  );
 };

--- a/packages/core/src/util/cloneUtils.ts
+++ b/packages/core/src/util/cloneUtils.ts
@@ -56,31 +56,3 @@ export const clone = function _clone(
 
   return clone;
 };
-
-/**
- * Shallow copies properties from the source object to the target object.
- *
- * **WARNING**: This function performs only a **shallow** copy i.e. there is no deep copy of the properties that are objects, expect for arrays.
- *
- * @template T The type of the objects.
- *
- * @param source The source object from which properties will be copied.
- * @param target The target object to which properties will be copied.
- *
- * @private not part of the public API, can be removed or changed without prior notice
- * @since 0.14.0
- */
-export const shallowCopy = <T extends object>(source: T, target: T): void => {
-  for (const key in source) {
-    // attempt to prevent prototype pollution
-    if (Object.prototype.hasOwnProperty.call(source, key)) {
-      const sourceValue = source[key];
-      if (Array.isArray(sourceValue)) {
-        // @ts-ignore source and target are of the same type
-        target[key] = [...sourceValue];
-      } else {
-        target[key] = sourceValue;
-      }
-    }
-  }
-};

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -22,7 +22,7 @@ import {
   SHADOW_OPACITY,
   SHADOWCOLOR,
 } from './Constants';
-import { shallowCopy } from './cloneUtils';
+import { shallowCopy } from '../internal/clone-utils';
 
 /**
  * Global configuration for maxGraph.

--- a/packages/core/src/util/domUtils.ts
+++ b/packages/core/src/util/domUtils.ts
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 import { NODETYPE } from './Constants';
-import { UserObject } from '../internal-types';
 
 /**
  * Returns the text content of the specified node.
@@ -360,10 +359,3 @@ export const addLinkToHead = (
   const head = doc.getElementsByTagName('head')[0];
   head.appendChild(link);
 };
-/**
- * Returns true if the parameter is not `nullish` and its nodeType relates to an {@link Element}.
- * @internal
- * @private
- */
-export const isElement = (node?: Node | UserObject | null): node is Element =>
-  node?.nodeType === NODETYPE.ELEMENT;

--- a/packages/core/src/util/logger.ts
+++ b/packages/core/src/util/logger.ts
@@ -16,15 +16,7 @@ limitations under the License.
 
 import type { Logger } from '../types';
 
-/**
- * If `baseTimestamp` is provided and not zero, returns a message describing the elapsed milliseconds since this value.
- * Otherwise, returns an empty string.
- * @param baseTimestamp the base timestamp to compute the elapsed milliseconds from
- *
- * @private not part of the public API, can be removed or changed without prior notice
- */
-export const getElapseMillisecondsMessage = (baseTimestamp?: number): string =>
-  baseTimestamp ? ` (${new Date().getTime() - baseTimestamp} ms)` : '';
+import { getElapseMillisecondsMessage } from '../internal/time-utils';
 
 /**
  * A {@link Logger} that does nothing.

--- a/packages/core/src/util/mathUtils.ts
+++ b/packages/core/src/util/mathUtils.ts
@@ -21,7 +21,7 @@ import Point from '../view/geometry/Point';
 import Rectangle from '../view/geometry/Rectangle';
 import CellState from '../view/cell/CellState';
 import type { CellStateStyle } from '../types';
-import { isNullish } from './Utils';
+import { isNullish } from '../internal/utils';
 
 /**
  * Converts the given degree to radians.

--- a/packages/core/src/util/styleUtils.ts
+++ b/packages/core/src/util/styleUtils.ts
@@ -30,8 +30,8 @@ import CellPath from '../view/cell/CellPath';
 import Rectangle from '../view/geometry/Rectangle';
 import Cell from '../view/cell/Cell';
 import GraphDataModel from '../view/GraphDataModel';
-
 import type { CellStateStyle, CellStyle, NumericCellStateStyleKeys } from '../types';
+import { matchBinaryMask } from '../internal/utils';
 
 /**
  * Removes the cursors from the style of the given DOM node and its descendants.
@@ -414,16 +414,6 @@ export const setStyleFlag = (
  */
 export const setOpacity = (node: HTMLElement | SVGElement, value: number) => {
   node.style.opacity = String(value / 100);
-};
-
-/**
- * @param value the value to check.
- * @param mask the binary mask to apply.
- * @returns `true` if the value matches the binary mask.
- * @private Subject to change prior being part of the public API.
- */
-export const matchBinaryMask = (value: number, mask: number) => {
-  return (value & mask) === mask;
 };
 
 /**

--- a/packages/core/src/util/xmlUtils.ts
+++ b/packages/core/src/util/xmlUtils.ts
@@ -22,10 +22,10 @@ import Cell from '../view/cell/Cell';
 import { Graph } from '../view/Graph';
 import { htmlEntities, trim } from './StringUtils';
 import TemporaryCellStates from '../view/cell/TemporaryCellStates';
-
 import type { StyleValue } from '../types';
-import { getTextContent, isElement } from './domUtils';
+import { getTextContent } from './domUtils';
 import Codec from '../serialization/Codec';
+import { isElement } from '../internal/utils';
 
 /**
  * Returns a new, empty XML document.

--- a/packages/core/src/view/Graph.ts
+++ b/packages/core/src/view/Graph.ts
@@ -61,7 +61,7 @@ import { registerDefaultStyleElements } from './style/register';
 import { applyGraphMixins } from './mixins/_graph-mixins-apply';
 import { getDefaultPlugins } from './plugins';
 import { TranslationsConfig } from '../i18n/config';
-import { isNullish } from '../util/Utils';
+import { isNullish } from '../internal/utils';
 
 /**
  * Extends {@link EventSource} to implement a graph component for the browser. This is the main class of the package.

--- a/packages/core/src/view/canvas/SvgCanvas2D.ts
+++ b/packages/core/src/view/canvas/SvgCanvas2D.ts
@@ -16,9 +16,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { isNullish } from '../../util/Utils';
+import { isNullish, matchBinaryMask } from '../../internal/utils';
 import { mod } from '../../util/mathUtils';
-import { getAlignmentAsPoint, matchBinaryMask } from '../../util/styleUtils';
+import { getAlignmentAsPoint } from '../../util/styleUtils';
 import Client from '../../Client';
 import {
   ABSOLUTE_LINE_HEIGHT,

--- a/packages/core/src/view/cell/Cell.ts
+++ b/packages/core/src/view/cell/Cell.ts
@@ -21,11 +21,9 @@ import CellOverlay from './CellOverlay';
 import { clone } from '../../util/cloneUtils';
 import Point from '../geometry/Point';
 import CellPath from './CellPath';
-import { isNullish } from '../../util/Utils';
-
 import type { CellStyle, FilterFunction, IdentityObject } from '../../types';
-import type { UserObject } from '../../internal-types';
-import { isElement } from '../../util/domUtils';
+import type { UserObject } from '../../internal/types';
+import { isElement, isNullish } from '../../internal/utils';
 
 /**
  * Cells are the elements of the graph model. They represent the state

--- a/packages/core/src/view/geometry/Shape.ts
+++ b/packages/core/src/view/geometry/Shape.ts
@@ -17,7 +17,7 @@ limitations under the License.
 */
 
 import Rectangle from './Rectangle';
-import { isNullish } from '../../util/Utils';
+import { isNullish } from '../../internal/utils';
 import { getBoundingBox, getDirectedBounds, mod } from '../../util/mathUtils';
 import {
   DIRECTION,
@@ -35,7 +35,6 @@ import type CellState from '../cell/CellState';
 import type StencilShape from './node/StencilShape';
 import type CellOverlay from '../cell/CellOverlay';
 import type ImageBox from '../image/ImageBox';
-
 import type {
   ArrowValue,
   CellStateStyle,

--- a/packages/core/src/view/geometry/node/StencilShape.ts
+++ b/packages/core/src/view/geometry/node/StencilShape.ts
@@ -20,7 +20,6 @@ import ConnectionConstraint from '../../other/ConnectionConstraint';
 import Rectangle from '../Rectangle';
 import Shape from '../Shape';
 import Translations from '../../../i18n/Translations';
-import { isNullish } from '../../../util/Utils';
 import {
   ALIGN,
   DIRECTION,
@@ -29,11 +28,11 @@ import {
   TEXT_DIRECTION,
 } from '../../../util/Constants';
 import StencilShapeRegistry from './StencilShapeRegistry';
-import { getChildNodes, getTextContent, isElement } from '../../../util/domUtils';
+import { getChildNodes, getTextContent } from '../../../util/domUtils';
 import Point from '../Point';
 import AbstractCanvas2D from '../../canvas/AbstractCanvas2D';
 import { AlignValue, ColorValue, VAlignValue } from '../../../types';
-import { doEval } from '../../../internal/utils';
+import { doEval, isElement, isNullish } from '../../../internal/utils';
 
 /**
  * Configure global settings for stencil shapes.

--- a/packages/core/src/view/geometry/node/TextShape.ts
+++ b/packages/core/src/view/geometry/node/TextShape.ts
@@ -32,7 +32,7 @@ import {
   LINE_HEIGHT,
 } from '../../../util/Constants';
 import { getBoundingBox } from '../../../util/mathUtils';
-import { getAlignmentAsPoint, matchBinaryMask } from '../../../util/styleUtils';
+import { getAlignmentAsPoint } from '../../../util/styleUtils';
 import Point from '../Point';
 import AbstractCanvas2D from '../../canvas/AbstractCanvas2D';
 import Shape from '../Shape';
@@ -48,6 +48,7 @@ import {
   VAlignValue,
 } from '../../../types';
 import SvgCanvas2D from '../../canvas/SvgCanvas2D';
+import { matchBinaryMask } from '../../../internal/utils';
 
 /**
  * Extends {@link Shape} to implement a text shape.

--- a/packages/core/src/view/handler/config.ts
+++ b/packages/core/src/view/handler/config.ts
@@ -28,7 +28,7 @@ import {
   VERTEX_SELECTION_DASHED,
   VERTEX_SELECTION_STROKEWIDTH,
 } from '../../util/Constants';
-import { shallowCopy } from '../../util/cloneUtils';
+import { shallowCopy } from '../../internal/clone-utils';
 
 /**
  * Describes {@link EdgeHandlerConfig}.

--- a/packages/core/src/view/mixins/_graph-mixins-apply.ts
+++ b/packages/core/src/view/mixins/_graph-mixins-apply.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { mixInto } from '../../util/Utils';
+import { mixInto } from '../../internal/utils';
 import type { Graph } from '../Graph';
 import { CellsMixin } from './CellsMixin';
 import { ConnectionsMixin } from './ConnectionsMixin';

--- a/packages/core/src/view/style/config.ts
+++ b/packages/core/src/view/style/config.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { DIRECTION, ENTITY_SEGMENT } from '../../util/Constants';
-import { shallowCopy } from '../../util/cloneUtils';
+import { shallowCopy } from '../../internal/clone-utils';
 import type { DirectionValue } from '../../types';
 
 /**

--- a/packages/core/src/view/undoable_changes/CellAttributeChange.ts
+++ b/packages/core/src/view/undoable_changes/CellAttributeChange.ts
@@ -14,9 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { isNullish } from '../../util/Utils';
+import { isNullish } from '../../internal/utils';
 import Cell from '../cell/Cell';
-
 import type { UndoableChange } from '../../types';
 
 /**


### PR DESCRIPTION
Such functions are now easier to identify, so this should help for the maintenance and should prevent from exporting
them by mistake.

BREAKING CHANGES: `Utils.copyTextToClipboard` is no longer available. It was intended to be internal and had been made public by mistake.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced clipboard copy functionality is now integrated into the console log area for improved text copying.
- **Tests**
	- Expanded test coverage to validate binary mask matching behavior.
- **Refactor**
	- Streamlined module imports and reorganized internal utilities for better maintainability.
- **Chores**
	- Removed deprecated functionalities and updated default configurations to enhance security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->