### PR TITLE
chore(types): enforce usage of explicit override keyword in examples

### DIFF
--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -9,7 +9,9 @@
     "outDir": "./lib",
     "strict": true,
     "skipLibCheck": false,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    // Do not enable for now, as we want maxGraph to support TS 3.8 and this feature requires TS 4.3+
+    "noImplicitOverride": false,
   },
   "include": ["src/**/*.ts"],
   "typedocOptions": {

--- a/packages/html/stories/Anchors.stories.ts
+++ b/packages/html/stories/Anchors.stories.ts
@@ -58,7 +58,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
 
   class MyCustomConnectionHandler extends ConnectionHandler {
     // Enables connect preview for the default edge style
-    createEdgeState(_me: InternalMouseEvent) {
+    override createEdgeState(_me: InternalMouseEvent) {
       const edge = this.graph.createEdge(null, null!, null, null, null);
       return new CellState(this.graph.view, edge, this.graph.getCellStyle(edge));
     }
@@ -78,7 +78,11 @@ const Template = ({ label, ...args }: Record<string, string>) => {
     constructor(container: HTMLElement) {
       super(container, undefined, plugins);
     }
-    getAllConnectionConstraints = (terminal: CellState | null, _source: boolean) => {
+
+    override getAllConnectionConstraints = (
+      terminal: CellState | null,
+      _source: boolean
+    ) => {
       // Overridden to define per-geometry connection points
       return (terminal?.cell?.geometry as MyCustomGeometryClass)?.constraints ?? null;
     };

--- a/packages/html/stories/AutoLayout.stories.ts
+++ b/packages/html/stories/AutoLayout.stories.ts
@@ -74,7 +74,11 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   if (!args.contextMenu) InternalEvent.disableContextMenu(container);
 
   class MyCustomCellRenderer extends CellRenderer {
-    installCellOverlayListeners(state: CellState, overlay: CellOverlay, shape: Shape) {
+    override installCellOverlayListeners(
+      state: CellState,
+      overlay: CellOverlay,
+      shape: Shape
+    ) {
       super.installCellOverlayListeners(state, overlay, shape);
 
       InternalEvent.addListener(
@@ -98,7 +102,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   }
 
   class MyCustomEdgeHandler extends EdgeHandler {
-    connect(
+    override connect(
       edge: Cell,
       terminal: Cell,
       isSource: boolean,
@@ -116,18 +120,18 @@ const Template = ({ label, ...args }: Record<string, string>) => {
       super(container, undefined, plugins);
     }
 
-    createEdgeHandler(
+    override createEdgeHandler(
       state: CellState,
       _edgeStyle: EdgeStyleFunction | null
     ): EdgeHandler {
       return new MyCustomEdgeHandler(state);
     }
 
-    createCellRenderer() {
+    override createCellRenderer() {
       return new MyCustomCellRenderer();
     }
 
-    resizeCell = (cell: Cell, bounds: Rectangle, recurse?: boolean): Cell => {
+    override resizeCell = (cell: Cell, bounds: Rectangle, recurse?: boolean): Cell => {
       const resizedCell = super.resizeCell(cell, bounds, recurse);
       executeLayout();
       return resizedCell;

--- a/packages/html/stories/ContextIcons.stories.ts
+++ b/packages/html/stories/ContextIcons.stories.ts
@@ -158,7 +158,7 @@ const Template = ({ label, ...args }: Record<string, any>) => {
       this.redrawTools();
     }
 
-    redraw() {
+    override redraw() {
       super.redraw();
       this.redrawTools();
     }
@@ -171,7 +171,7 @@ const Template = ({ label, ...args }: Record<string, any>) => {
       }
     }
 
-    onDestroy() {
+    override onDestroy() {
       super.onDestroy();
 
       if (this.domNode) {
@@ -186,7 +186,7 @@ const Template = ({ label, ...args }: Record<string, any>) => {
       super(container, undefined, plugins);
     }
 
-    createHandler(state: CellState) {
+    override createHandler(state: CellState) {
       if (state != null && state.cell.isVertex()) {
         return new CustomVertexToolHandler(state);
       }

--- a/packages/html/stories/Handles.stories.ts
+++ b/packages/html/stories/Handles.stories.ts
@@ -67,7 +67,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
     defaultPos2 = 60;
 
   class MyShape extends CylinderShape {
-    getLabelBounds(rect: Rectangle) {
+    override getLabelBounds(rect: Rectangle) {
       const style: CustomCellStateStyle = this.style!;
       const pos1 = (style.pos1 ?? defaultPos1) * this.scale;
       const pos2 = (style.pos2 ?? defaultPos2) * this.scale;
@@ -79,7 +79,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
       );
     }
 
-    redrawPath(
+    override redrawPath(
       path: AbstractCanvas2D,
       _x: number,
       _y: number,
@@ -118,9 +118,9 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   };
 
   class MyCustomVertexHandler extends VertexHandler {
-    livePreview = true;
+    override livePreview = true;
 
-    createCustomHandles() {
+    override createCustomHandles() {
       if (this.state.style.shape === 'myShape') {
         // Implements the handle for the first divider
         const firstHandle = new VertexHandle(this.state);
@@ -194,7 +194,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
       super(container, undefined, plugins);
     }
 
-    createVertexHandler(state: CellState) {
+    override createVertexHandler(state: CellState) {
       return new MyCustomVertexHandler(state);
     }
   }

--- a/packages/html/stories/Markers.stories.ts
+++ b/packages/html/stories/Markers.stories.ts
@@ -75,7 +75,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
 
   // Defines custom message shape
   class MessageShape extends CylinderShape {
-    redrawPath(
+    override redrawPath(
       c: AbstractCanvas2D,
       _x: number,
       _y: number,
@@ -101,7 +101,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
 
   // Defines custom edge shape
   class LinkShape extends ArrowShape {
-    paintEdgeShape(c: AbstractCanvas2D, pts: Point[]) {
+    override paintEdgeShape(c: AbstractCanvas2D, pts: Point[]) {
       const width = 10;
 
       // Base vector (between end points)

--- a/packages/html/stories/MenuStyle.stories.ts
+++ b/packages/html/stories/MenuStyle.stories.ts
@@ -74,7 +74,11 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   VertexHandlerConfig.selectionColor = '#00a8ff';
 
   class MyCustomCellRenderer extends CellRenderer {
-    installCellOverlayListeners(state: CellState, overlay: CellOverlay, shape: Shape) {
+    override installCellOverlayListeners(
+      state: CellState,
+      overlay: CellOverlay,
+      shape: Shape
+    ) {
       super.installCellOverlayListeners(state, overlay, shape);
       const graph = state.view.graph;
 
@@ -143,7 +147,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   }
 
   class MyCustomGraph extends Graph {
-    createCellRenderer() {
+    override createCellRenderer() {
       return new MyCustomCellRenderer();
     }
   }

--- a/packages/html/stories/Overlays.stories.ts
+++ b/packages/html/stories/Overlays.stories.ts
@@ -68,7 +68,10 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   let overlayCount = 0;
 
   class CustomCellRenderer extends CellRenderer {
-    protected createOverlayShape(_state: CellState, _cellOverlay: CellOverlay): Shape {
+    protected override createOverlayShape(
+      _state: CellState,
+      _cellOverlay: CellOverlay
+    ): Shape {
       overlayCount++;
       switch (overlayCount % 3) {
         case 0:
@@ -81,7 +84,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
       }
     }
 
-    protected configureOverlayShape(
+    protected override configureOverlayShape(
       state: CellState,
       cellOverlay: CellOverlay,
       overlayShape: Shape
@@ -94,7 +97,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   }
 
   class CustomGraph extends Graph {
-    createCellRenderer() {
+    override createCellRenderer() {
       return new CustomCellRenderer();
     }
   }

--- a/packages/html/stories/PerimeterOnLabelBounds.stories.ts
+++ b/packages/html/stories/PerimeterOnLabelBounds.stories.ts
@@ -58,7 +58,7 @@ const Template = ({ label, ...args }: Record<string, any>) => {
     }
 
     // Redirects the perimeter to the label bounds if intersection between edge and label is found
-    getPerimeterPoint(
+    override getPerimeterPoint(
       terminal: CellState,
       next: Point,
       orthogonal: boolean,
@@ -92,7 +92,7 @@ const Template = ({ label, ...args }: Record<string, any>) => {
       super(container, undefined, plugins);
     }
 
-    createGraphView(): GraphView {
+    override createGraphView(): GraphView {
       return new MyCustomGraphView(this);
     }
   }
@@ -110,7 +110,7 @@ const Template = ({ label, ...args }: Record<string, any>) => {
 
   // Adds cells to the model in a single step
 
-  /* 
+  /*
    WARNING:
    setTimeout should be removed in production. It was added because of incompatibility with Storybook.
    In regular environment batchUpdate call should not be inside timeout and should be called regularly.

--- a/packages/html/stories/ShowRegion.stories.ts
+++ b/packages/html/stories/ShowRegion.stories.ts
@@ -79,7 +79,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   const graph = new Graph(container);
 
   class MyCustomRubberBandHandler extends RubberBandHandler {
-    isForceRubberbandEvent(me: InternalMouseEvent) {
+    override isForceRubberbandEvent(me: InternalMouseEvent) {
       return super.isForceRubberbandEvent(me) || me.isPopupTrigger();
     }
 
@@ -99,12 +99,12 @@ const Template = ({ label, ...args }: Record<string, string>) => {
       });
     });
 
-    mouseDown(sender: EventSource, me: InternalMouseEvent) {
+    override mouseDown(sender: EventSource, me: InternalMouseEvent) {
       this.popupMenu.hideMenu();
       super.mouseDown(sender, me);
     }
 
-    mouseUp(sender: EventSource, me: InternalMouseEvent) {
+    override mouseUp(sender: EventSource, me: InternalMouseEvent) {
       if (eventUtils.isPopupTrigger(me.getEvent())) {
         if (!graph.getPlugin<PopupMenuHandler>('PopupMenuHandler').isMenuShowing()) {
           const origin = styleUtils.getScrollOrigin();

--- a/packages/html/stories/Stencils.stories.ts
+++ b/packages/html/stories/Stencils.stories.ts
@@ -89,12 +89,12 @@ const Template = ({ label, ...args }: Record<string, string>) => {
     // Enable rotation handle
     // use an alternate way to enable rotation handle as we already override the VertexHandler for other purposes
     // another way to enable rotation handle is to set `VertexHandlerConfig.rotationEnabled = true`;
-    isRotationEnabled(): boolean {
+    override isRotationEnabled(): boolean {
       return true;
     }
 
     // Uses the shape for resize previews
-    createSelectionShape(bounds: Rectangle) {
+    override createSelectionShape(bounds: Rectangle) {
       const stencil = StencilShapeRegistry.getStencil(this.state.style.shape);
       let shape: Shape;
 
@@ -124,14 +124,20 @@ const Template = ({ label, ...args }: Record<string, string>) => {
       super(container, undefined, plugins);
     }
 
-    createVertexHandler(state: CellState) {
+    override createVertexHandler(state: CellState) {
       return new CustomVertexHandler(state);
     }
   }
 
   // Defines a custom Shape via the canvas API
   class CustomShape extends Shape {
-    paintBackground(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
+    override paintBackground(
+      c: AbstractCanvas2D,
+      x: number,
+      y: number,
+      w: number,
+      h: number
+    ) {
       c.translate(x, y);
 
       // Head

--- a/packages/ts-example-without-defaults/vite.config.js
+++ b/packages/ts-example-without-defaults/vite.config.js
@@ -27,7 +27,7 @@ export default defineConfig(({ mode }) => {
           },
         },
       },
-      chunkSizeWarningLimit: 441, // @maxgraph/core
+      chunkSizeWarningLimit: 436, // @maxgraph/core
     },
   };
 });

--- a/packages/ts-example/src/custom-shapes.ts
+++ b/packages/ts-example/src/custom-shapes.ts
@@ -30,12 +30,24 @@ class CustomRectangleShape extends RectangleShape {
     this.isRounded = true; // force rounded shape
   }
 
-  paintBackground(c: AbstractCanvas2D, x: number, y: number, w: number, h: number): void {
+  override paintBackground(
+    c: AbstractCanvas2D,
+    x: number,
+    y: number,
+    w: number,
+    h: number
+  ): void {
     c.setFillColor('Chartreuse');
     super.paintBackground(c, x, y, w, h);
   }
 
-  paintVertexShape(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
+  override paintVertexShape(
+    c: AbstractCanvas2D,
+    x: number,
+    y: number,
+    w: number,
+    h: number
+  ) {
     c.setStrokeColor('Black');
     super.paintVertexShape(c, x, y, w, h);
   }
@@ -46,7 +58,13 @@ class CustomEllipseShape extends EllipseShape {
     super(bounds, fill, stroke, 5);
   }
 
-  paintVertexShape(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
+  override paintVertexShape(
+    c: AbstractCanvas2D,
+    x: number,
+    y: number,
+    w: number,
+    h: number
+  ) {
     c.setFillColor('Yellow');
     c.setStrokeColor('Red');
     super.paintVertexShape(c, x, y, w, h);

--- a/packages/ts-example/vite.config.js
+++ b/packages/ts-example/vite.config.js
@@ -27,7 +27,7 @@ export default defineConfig(({ mode }) => {
           },
         },
       },
-      chunkSizeWarningLimit: 445, // @maxgraph/core
+      chunkSizeWarningLimit: 440, // @maxgraph/core
     },
   };
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "moduleResolution": "node",
     "strict": true,
     "esModuleInterop": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "noImplicitOverride": true,
   },
   "exclude": ["node_modules", "**/*.spec.ts"],
   "include": ["packages/*/src"]


### PR DESCRIPTION
A lot of refactoring involving methods move are planned in the near future, mainly to improve the tree shaking.
Enabling this check will detect errors early while doing such refactoring.

Do not enable it for now in the code of the lib, as we want maxGraph to support TS 3.8 and this feature requires TS 4.3.

In addition, decrease the chunk size warning limit in the "vite.config.js" file in examples (relates to a previous commit).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build and configuration settings to enhance consistency and diagnostic feedback.
  
- **Refactor**
  - Streamlined internal code by explicitly marking overridden methods, improving clarity and maintainability without affecting end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->