### PR TITLE
refactor!: expose all exported functions in namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ _**Note:** Yet to be released breaking changes appear here._
 - `StylesheetCodec.allowEval` is now set to `false` by default to prevent unwanted use of the eval function, as it carries a possible security risk.
 - `Utils.copyTextToClipboard` is no longer available. It was intended to be internal and had been made public by mistake.
 - The built-in `Translations` class is no longer used by default. To use it, call `GlobalConfig.i18n = new TranslationsAsI18n()`
+- Some functions are now accessible via a namespace:
+  - `get`, `getAll`, `load`, `submit` via `requestUtils`
+  - `error`, `popup` via `guiUtils`
 
 ## 0.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _**Note:** Yet to be released breaking changes appear here._
 - `Utils.copyTextToClipboard` is no longer available. It was intended to be internal and had been made public by mistake.
 - The built-in `Translations` class is no longer used by default. To use it, call `GlobalConfig.i18n = new TranslationsAsI18n()`
 - Some functions are now accessible via a namespace:
-  - `get`, `getAll`, `load`, `submit` via `requestUtils`
+  - `get`, `getAll`, `load`, `post`, `submit` via `requestUtils`
   - `error`, `popup` via `guiUtils`
 
 ## 0.16.0

--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -28,7 +28,7 @@ import EventObject from '../view/event/EventObject';
 import { getOffset } from '../util/styleUtils';
 import Codec from '../serialization/Codec';
 import { ModelXmlSerializer } from '../serialization/ModelXmlSerializer';
-import MaxWindow, { error } from '../gui/MaxWindow';
+import MaxWindow from '../gui/MaxWindow';
 import MaxForm from '../gui/MaxForm';
 import Outline from '../view/other/Outline';
 import Cell from '../view/cell/Cell';
@@ -45,7 +45,7 @@ import Clipboard from '../util/Clipboard';
 import MaxLog from '../gui/MaxLog';
 import { isNode } from '../util/domUtils';
 import { getViewXml, getXml } from '../util/xmlUtils';
-import { load, post, submit } from '../util/MaxXmlRequest';
+import { load, post, submit } from '../util/requestUtils';
 import type PopupMenuHandler from '../view/plugins/PopupMenuHandler';
 import RubberBandHandler from '../view/plugins/RubberBandHandler';
 import InternalEvent from '../view/event/InternalEvent';
@@ -58,6 +58,7 @@ import { cloneCell } from '../util/cellArrayUtils';
 import type MaxPopupMenu from '../gui/MaxPopupMenu';
 import { isNullish } from '../internal/utils';
 import { isI18nEnabled, translate } from '../internal/i18n-utils';
+import { error } from '../gui/guiUtils';
 
 /**
  * Extends {@link EventSource} to implement an application wrapper for a graph that

--- a/packages/core/src/gui/MaxLog.ts
+++ b/packages/core/src/gui/MaxLog.ts
@@ -20,11 +20,12 @@ import Client from '../Client';
 import InternalEvent from '../view/event/InternalEvent';
 import { getInnerHtml, write } from '../util/domUtils';
 import { toString } from '../util/StringUtils';
-import MaxWindow, { popup } from './MaxWindow';
+import MaxWindow from './MaxWindow';
 import { KeyboardEventListener, MouseEventListener } from '../types';
 import { getElapseMillisecondsMessage } from '../internal/time-utils';
 import { VERSION } from '../util/Constants';
 import { GlobalConfig } from '../util/config';
+import { popup } from './guiUtils';
 
 const copyTextToClipboard = (text: string): void => {
   navigator.clipboard.writeText(text).then(

--- a/packages/core/src/gui/guiUtils.ts
+++ b/packages/core/src/gui/guiUtils.ts
@@ -70,7 +70,7 @@ export const popup = (content: string, isInternalWindow = false) => {
       if (!wnd) {
         throw new Error('Permission not granted to open popup window');
       }
-      wnd.document.writeln(`<pre>${htmlEntities(content)}</pre`);
+      wnd.document.writeln(`<pre>${htmlEntities(content)}</pre>`);
       wnd.document.close();
     } else {
       const wnd = window.open();

--- a/packages/core/src/gui/guiUtils.ts
+++ b/packages/core/src/gui/guiUtils.ts
@@ -1,0 +1,157 @@
+/*
+Copyright 2021-present The maxGraph project Contributors
+Copyright (c) 2006-2015, JGraph Ltd
+Copyright (c) 2006-2015, Gaudenz Alder
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { htmlEntities } from '../util/StringUtils';
+import Client from '../Client';
+import { utils } from '../util/Utils';
+import { br, write } from '../util/domUtils';
+import { translate } from '../internal/i18n-utils';
+import InternalEvent from '../view/event/InternalEvent';
+import MaxWindow from './MaxWindow';
+
+/**
+ * Shows the specified text content in a new {@link MaxWindow} or a new browser window if `isInternalWindow` is `false`.
+ *
+ * @param content String that specifies the text to be displayed.
+ * @param isInternalWindow Optional boolean indicating if an {@link MaxWindow} should be used instead of a new browser window. Default is `false`.
+ */
+export const popup = (content: string, isInternalWindow = false) => {
+  if (isInternalWindow) {
+    const div = document.createElement('div');
+
+    div.style.overflow = 'scroll';
+    div.style.width = '636px';
+    div.style.height = '460px';
+
+    const pre = document.createElement('pre');
+    pre.innerHTML = htmlEntities(content, false)
+      .replace(/\n/g, '<br>')
+      .replace(/ /g, '&nbsp;');
+
+    div.appendChild(pre);
+
+    const w = document.body.clientWidth;
+    const h = Math.max(
+      document.body.clientHeight || 0,
+      document.documentElement.clientHeight
+    );
+    const wnd = new MaxWindow(
+      'Popup Window',
+      div,
+      w / 2 - 320,
+      h / 2 - 240,
+      640,
+      480,
+      false,
+      true
+    );
+
+    wnd.setClosable(true);
+    wnd.setVisible(true);
+  } else {
+    // Wraps up the XML content in a textarea
+    if (Client.IS_NS) {
+      const wnd = window.open();
+      if (!wnd) {
+        throw new Error('Permission not granted to open popup window');
+      }
+      wnd.document.writeln(`<pre>${htmlEntities(content)}</pre`);
+      wnd.document.close();
+    } else {
+      const wnd = window.open();
+      if (!wnd) {
+        throw new Error('Permission not granted to open popup window');
+      }
+      const pre = wnd.document.createElement('pre');
+      pre.innerHTML = htmlEntities(content, false)
+        .replace(/\n/g, '<br>')
+        .replace(/ /g, '&nbsp;');
+      wnd.document.body.appendChild(pre);
+    }
+  }
+};
+
+/**
+ * Displays the given error message in a new <MaxWindow> of the given width.
+ * If close is true then an additional close button is added to the window.
+ * The optional icon specifies the icon to be used for the window. Default is {@link utils.errorImage}.
+ *
+ * @param message String specifying the message to be displayed.
+ * @param width Integer specifying the width of the window.
+ * @param close Optional boolean indicating whether to add a close button.
+ * @param icon Optional icon for the window decoration.
+ */
+export const error = (
+  message: string,
+  width: number,
+  close: boolean,
+  icon: string | null = null
+) => {
+  const div = document.createElement('div');
+  div.style.padding = '20px';
+
+  const img = document.createElement('img');
+  img.setAttribute('src', icon || utils.errorImage);
+  img.setAttribute('valign', 'bottom');
+  img.style.verticalAlign = 'middle';
+  div.appendChild(img);
+
+  div.appendChild(document.createTextNode('\u00a0')); // &nbsp;
+  div.appendChild(document.createTextNode('\u00a0')); // &nbsp;
+  div.appendChild(document.createTextNode('\u00a0')); // &nbsp;
+  write(div, message);
+
+  const w = document.body.clientWidth;
+  const h = document.body.clientHeight || document.documentElement.clientHeight;
+  const warn = new MaxWindow(
+    translate(utils.errorResource) || utils.errorResource,
+    div,
+    (w - width) / 2,
+    h / 4,
+    width,
+    null,
+    false,
+    true
+  );
+
+  if (close) {
+    br(div);
+
+    const tmp = document.createElement('p');
+    const button = document.createElement('button');
+
+    button.setAttribute('style', 'float:right');
+
+    InternalEvent.addListener(button, 'click', (evt: MouseEvent) => {
+      warn.destroy();
+    });
+
+    write(button, translate(utils.closeResource) || utils.closeResource);
+
+    tmp.appendChild(button);
+    div.appendChild(tmp);
+
+    br(div);
+
+    warn.setClosable(true);
+  }
+
+  warn.setVisible(true);
+
+  return warn;
+};

--- a/packages/core/src/i18n/Translations.ts
+++ b/packages/core/src/i18n/Translations.ts
@@ -19,7 +19,7 @@ limitations under the License.
 import Client from '../Client';
 import { NONE } from '../util/Constants';
 import type MaxXmlRequest from '../util/MaxXmlRequest';
-import { get, load } from '../util/MaxXmlRequest';
+import { get, load } from '../util/requestUtils';
 import { TranslationsConfig } from './config';
 import { isNullish } from '../internal/utils';
 import { I18nProvider } from '../types';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -179,7 +179,7 @@ export { MaxLogAsLogger } from './gui/MaxLogAsLogger';
 export { default as MaxPopupMenu } from './gui/MaxPopupMenu';
 export { default as MaxToolbar } from './gui/MaxToolbar';
 export { default as MaxWindow } from './gui/MaxWindow';
-export { popup, error } from './gui/MaxWindow';
+export * as guiUtils from './gui/guiUtils';
 
 export { default as ImageBox } from './view/image/ImageBox';
 export { default as ImageBundle } from './view/image/ImageBundle';
@@ -187,7 +187,7 @@ export { default as ImageExport } from './view/image/ImageExport';
 
 export { default as UrlConverter } from './util/UrlConverter';
 export { default as MaxXmlRequest } from './util/MaxXmlRequest';
-export { load, get, getAll, post, submit } from './util/MaxXmlRequest';
+export * as requestUtils from './util/requestUtils';
 
 export { default as AutoSaveManager } from './view/other/AutoSaveManager';
 export { default as Clipboard } from './util/Clipboard';

--- a/packages/core/src/serialization/ObjectCodec.ts
+++ b/packages/core/src/serialization/ObjectCodec.ts
@@ -22,7 +22,7 @@ import Geometry from '../view/geometry/Geometry';
 import Point from '../view/geometry/Point';
 import { isInteger, isNumeric } from '../util/mathUtils';
 import { getTextContent } from '../util/domUtils';
-import { load } from '../util/MaxXmlRequest';
+import { load } from '../util/requestUtils';
 import type Codec from './Codec';
 import { doEval, isElement } from '../internal/utils';
 

--- a/packages/core/src/util/MaxXmlRequest.ts
+++ b/packages/core/src/util/MaxXmlRequest.ts
@@ -19,70 +19,71 @@ limitations under the License.
 import { write } from './domUtils';
 
 /**
- * XML HTTP request wrapper. See also: {@link mxUtils.get}, {@link mxUtils.post} and
- * {@link mxUtils.load}. This class provides a cross-browser abstraction for Ajax
- * requests.
+ * This class provides a cross-browser abstraction for Ajax requests. It is an XML HTTP request wrapper.
  *
- * ### Encoding:
+ * See also {@link get}, {@link getAll}, {@link post} and {@link load}.
+ *
+ * ### Encoding
  *
  * For encoding parameter values, the built-in encodeURIComponent JavaScript
  * method must be used. For automatic encoding of post data in {@link Editor} the
  * {@link Editor.escapePostData} switch can be set to true (default). The encoding
  * will be carried out using the conte type of the page. That is, the page
- * containting the editor should contain a meta tag in the header, eg.
+ * containing the editor should contain a meta tag in the header, e.g.
+ * ```html
  * <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+ * ```
  *
  * @example
- * ```JavaScript
- * var onload = function(req)
- * {
- *   mxUtils.alert(req.getDocumentElement());
+ * ```js
+ * const onload = function(req) {
+ *   window.alert(req.getDocumentElement());
  * }
  *
- * var onerror = function(req)
- * {
- *   mxUtils.alert('Error');
+ * const onerror = function(req) {
+ *   window.alert('Error');
  * }
  * new MaxXmlRequest(url, 'key=value').send(onload, onerror);
  * ```
  *
+ * ### Sending requests
+ *
  * Sends an asynchronous POST request to the specified URL.
  *
  * @example
- * ```JavaScript
- * var req = new MaxXmlRequest(url, 'key=value', 'POST', false);
+ * ```js
+ * const req = new MaxXmlRequest(url, 'key=value', 'POST', false);
  * req.send();
- * mxUtils.alert(req.getDocumentElement());
+ * window.alert(req.getDocumentElement());
  * ```
  *
  * Sends a synchronous POST request to the specified URL.
  *
  * @example
- * ```JavaScript
- * var encoder = new Codec();
- * var result = encoder.encode(graph.getDataModel());
- * var xml = encodeURIComponent(mxUtils.getXml(result));
- * new MaxXmlRequest(url, 'xml='+xml).send();
+ * ```js
+ * const encoder = new Codec();
+ * const result = encoder.encode(graph.getDataModel());
+ * const xml = encodeURIComponent(xmlUtils.getXml(result));
+ * new MaxXmlRequest(url, `xml=${xml}`).send();
  * ```
  *
  * Sends an encoded graph model to the specified URL using xml as the
  * parameter name. The parameter can then be retrieved in C# as follows:
  *
- * ```javascript
+ * ```csharp
  * string xml = HttpUtility.UrlDecode(context.Request.Params["xml"]);
  * ```
  *
  * Or in Java as follows:
  *
- * ```javascript
+ * ```java
  * String xml = URLDecoder.decode(request.getParameter("xml"), "UTF-8").replace("
 ", "&#xa;");
  * ```
  *
- * Note that the linefeeds should only be replaced if the XML is
- * processed in Java, for example when creating an image.
+ * Note that the linefeed should only be replaced if the XML is processed in Java, for example when creating an image.
  */
-class MaxXmlRequest {
+export default class MaxXmlRequest {
   constructor(
     url: string,
     params: string | null = null,
@@ -375,189 +376,3 @@ class MaxXmlRequest {
     }
   }
 }
-
-/**
- * Loads the specified URL *synchronously* and returns the {@link MaxXmlRequest}.
- * Throws an exception if the file cannot be loaded.
- * See {@link get} for  an asynchronous implementation.
- *
- * Example:
- *
- * ```javascript
- * try {
- *   const req = load(filename);
- *   cont root = req.getDocumentElement();
- *   // Process XML DOM...
- * } catch (e) {
- *   console.error(`Cannot load $filename`, e);
- * }
- * ```
- *
- * @param url URL to get the data from.
- */
-export const load = (url: string): MaxXmlRequest => {
-  const req = new MaxXmlRequest(url, null, 'GET', false);
-  req.send();
-  return req;
-};
-
-/**
- * Loads the specified URL *asynchronously* and invokes the given functions depending on the request status.
- * Returns the {@link MaxXmlRequest} in use.
- * Both functions take the {@link MaxXmlRequest} as the only parameter.
- * See {@link load} for a synchronous implementation.
- *
- * Example:
- *
- * ```javascript
- * get(url, (req) => {
- *    const node = req.getDocumentElement();
- *    // Process XML DOM...
- * });
- * ```
- *
- * So for example, to load a diagram into an existing graph model, the following code is used.
- *
- * ```javascript
- * get(url, (req) => {
- *   const node = req.getDocumentElement();
- *   const dec = new Codec(node.ownerDocument);
- *   dec.decode(node, graph.getDataModel());
- * });
- * ```
- *
- * @param url URL to get the data from.
- * @param onload Optional function to execute for a successful response.
- * @param onerror Optional function to execute on error.
- * @param binary Optional boolean parameter that specifies if the request is
- * binary.
- * @param timeout Optional timeout in ms before calling ontimeout.
- * @param ontimeout Optional function to execute on timeout.
- * @param headers Optional with headers, eg. {'Authorization': 'token xyz'}
- */
-export const get = (
-  url: string,
-  onload: Function | null = null,
-  onerror: Function | null = null,
-  binary = false,
-  timeout: number | null = null,
-  ontimeout: Function | null = null,
-  headers: { [key: string]: string } | null = null
-) => {
-  const req = new MaxXmlRequest(url, null, 'GET');
-  const { setRequestHeaders } = req;
-
-  if (headers) {
-    req.setRequestHeaders = (request, params) => {
-      setRequestHeaders.apply(this, [request, params]);
-      for (const key in headers) {
-        request.setRequestHeader(key, headers[key]);
-      }
-    };
-  }
-
-  if (binary != null) {
-    req.setBinary(binary);
-  }
-
-  req.send(onload, onerror, timeout, ontimeout);
-  return req;
-};
-
-/**
- * Loads the URLs in the given array *asynchronously* and invokes the given function
- * if all requests returned with a valid 2xx status. The error handler is invoked
- * once on the first error or invalid response.
- *
- * @param urls Array of URLs to be loaded.
- * @param onload Callback with array of {@link XmlRequests}.
- * @param onerror Optional function to execute on error.
- */
-export const getAll = (
-  urls: string[],
-  onload: (arg0: any) => void,
-  onerror: () => void
-) => {
-  let remain = urls.length;
-  const result: MaxXmlRequest[] = [];
-  let errors = 0;
-  const err = () => {
-    if (errors == 0 && onerror != null) {
-      onerror();
-    }
-    errors++;
-  };
-
-  for (let i = 0; i < urls.length; i += 1) {
-    ((url, index) => {
-      get(
-        url,
-        (req: MaxXmlRequest) => {
-          const status = req.getStatus();
-
-          if (status < 200 || status > 299) {
-            err();
-          } else {
-            result[index] = req;
-            remain--;
-
-            if (remain == 0) {
-              onload(result);
-            }
-          }
-        },
-        err
-      );
-    })(urls[i], i);
-  }
-
-  if (remain == 0) {
-    onload(result);
-  }
-};
-
-/**
- * Posts the specified params to the given URL *asynchronously* and invokes the given functions depending on the request status.
- * Returns the {@link MaxXmlRequest} in use.
- * Both functions take the {@link MaxXmlRequest} as the only parameter.
- * Make sure to use encodeURIComponent for the parameter values.
- *
- * Example:
- *
- * ```javascript
- * post(url, 'key=value', (req) => {
- *   alert('Ready: ' + req.isReady() + ' Status: ' + req.getStatus());
- *  // Process req.getDocumentElement() using DOM API if OK...
- * });
- * ```
- *
- * @param url URL to get the data from.
- * @param params Parameters for the post request.
- * @param onload Optional function to execute for a successful response.
- * @param onerror Optional function to execute on error.
- */
-export const post = (
-  url: string,
-  params: string | null = null,
-  onload: Function,
-  onerror: Function | null = null
-) => {
-  return new MaxXmlRequest(url, params).send(onload, onerror);
-};
-
-/**
- * Submits the given parameters to the specified URL using
- * <MaxXmlRequest.simulate> and returns the <MaxXmlRequest>.
- * Make sure to use encodeURIComponent for the parameter
- * values.
- *
- * @param url URL to get the data from.
- * @param params Parameters for the form.
- * @param doc Document to create the form in.
- * @param target Target to send the form result to.
- */
-export const submit = (url: string, params: string, doc: XMLDocument, target: string) => {
-  return new MaxXmlRequest(url, params).simulate(doc, target);
-};
-
-export default MaxXmlRequest;

--- a/packages/core/src/util/MaxXmlRequest.ts
+++ b/packages/core/src/util/MaxXmlRequest.ts
@@ -77,8 +77,7 @@ import { write } from './domUtils';
  * Or in Java as follows:
  *
  * ```java
- * String xml = URLDecoder.decode(request.getParameter("xml"), "UTF-8").replace("
-", "&#xa;");
+ * String xml = URLDecoder.decode(request.getParameter("xml"), "UTF-8").replace("\n", "&#xa;");
  * ```
  *
  * Note that the linefeed should only be replaced if the XML is processed in Java, for example when creating an image.

--- a/packages/core/src/util/requestUtils.ts
+++ b/packages/core/src/util/requestUtils.ts
@@ -1,0 +1,200 @@
+/*
+Copyright 2021-present The maxGraph project Contributors
+Copyright (c) 2006-2020, JGraph Ltd
+Copyright (c) 2006-2020, draw.io AG
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import MaxXmlRequest from './MaxXmlRequest';
+
+/**
+ * Loads the specified URL *synchronously* and returns the {@link MaxXmlRequest}.
+ * Throws an exception if the file cannot be loaded.
+ * See {@link get} for  an asynchronous implementation.
+ *
+ * Example:
+ *
+ * ```javascript
+ * try {
+ *   const req = load(filename);
+ *   cont root = req.getDocumentElement();
+ *   // Process XML DOM...
+ * } catch (e) {
+ *   console.error(`Cannot load $filename`, e);
+ * }
+ * ```
+ *
+ * @param url URL to get the data from.
+ */
+export const load = (url: string): MaxXmlRequest => {
+  const req = new MaxXmlRequest(url, null, 'GET', false);
+  req.send();
+  return req;
+};
+
+/**
+ * Loads the specified URL *asynchronously* and invokes the given functions depending on the request status.
+ * Returns the {@link MaxXmlRequest} in use.
+ * Both functions take the {@link MaxXmlRequest} as the only parameter.
+ * See {@link load} for a synchronous implementation.
+ *
+ * Example:
+ *
+ * ```javascript
+ * get(url, (req) => {
+ *    const node = req.getDocumentElement();
+ *    // Process XML DOM...
+ * });
+ * ```
+ *
+ * So for example, to load a diagram into an existing graph model, the following code is used.
+ *
+ * ```javascript
+ * get(url, (req) => {
+ *   const node = req.getDocumentElement();
+ *   const dec = new Codec(node.ownerDocument);
+ *   dec.decode(node, graph.getDataModel());
+ * });
+ * ```
+ *
+ * @param url URL to get the data from.
+ * @param onload Optional function to execute for a successful response.
+ * @param onerror Optional function to execute on error.
+ * @param binary Optional boolean parameter that specifies if the request is binary.
+ * @param timeout Optional timeout in ms before calling ontimeout.
+ * @param ontimeout Optional function to execute on timeout.
+ * @param headers Optional with headers, eg. {'Authorization': 'token xyz'}
+ */
+export const get = (
+  url: string,
+  onload: Function | null = null,
+  onerror: Function | null = null,
+  binary = false,
+  timeout: number | null = null,
+  ontimeout: Function | null = null,
+  headers: { [key: string]: string } | null = null
+) => {
+  const req = new MaxXmlRequest(url, null, 'GET');
+  const { setRequestHeaders } = req;
+
+  if (headers) {
+    req.setRequestHeaders = (request, params) => {
+      setRequestHeaders.apply(this, [request, params]);
+      for (const key in headers) {
+        request.setRequestHeader(key, headers[key]);
+      }
+    };
+  }
+
+  if (binary != null) {
+    req.setBinary(binary);
+  }
+
+  req.send(onload, onerror, timeout, ontimeout);
+  return req;
+};
+
+/**
+ * Loads the URLs in the given array *asynchronously* and invokes the given function
+ * if all requests returned with a valid 2xx status. The error handler is invoked
+ * once on the first error or invalid response.
+ *
+ * @param urls Array of URLs to be loaded.
+ * @param onload Callback with array of {@link MaxXmlRequest}s.
+ * @param onerror Optional function to execute on error.
+ */
+export const getAll = (
+  urls: string[],
+  onload: (requests: MaxXmlRequest[]) => void,
+  onerror: () => void
+) => {
+  let remain = urls.length;
+  const result: MaxXmlRequest[] = [];
+  let errors = 0;
+  const err = () => {
+    if (errors == 0 && onerror != null) {
+      onerror();
+    }
+    errors++;
+  };
+
+  for (let i = 0; i < urls.length; i += 1) {
+    ((url, index) => {
+      get(
+        url,
+        (req: MaxXmlRequest) => {
+          const status = req.getStatus();
+
+          if (status < 200 || status > 299) {
+            err();
+          } else {
+            result[index] = req;
+            remain--;
+
+            if (remain == 0) {
+              onload(result);
+            }
+          }
+        },
+        err
+      );
+    })(urls[i], i);
+  }
+
+  if (remain == 0) {
+    onload(result);
+  }
+};
+
+/**
+ * Posts the specified params to the given URL *asynchronously* and invokes the given functions depending on the request status.
+ * Returns the {@link MaxXmlRequest} in use.
+ * Both functions take the {@link MaxXmlRequest} as the only parameter.
+ * Make sure to use encodeURIComponent for the parameter values.
+ *
+ * Example:
+ *
+ * ```javascript
+ * post(url, 'key=value', (req) => {
+ *   alert('Ready: ' + req.isReady() + ' Status: ' + req.getStatus());
+ *  // Process req.getDocumentElement() using DOM API if OK...
+ * });
+ * ```
+ *
+ * @param url URL to get the data from.
+ * @param params Parameters for the post request.
+ * @param onload Optional function to execute for a successful response.
+ * @param onerror Optional function to execute on error.
+ */
+export const post = (
+  url: string,
+  params: string | null = null,
+  onload: Function,
+  onerror: Function | null = null
+) => {
+  return new MaxXmlRequest(url, params).send(onload, onerror);
+};
+
+/**
+ * Submits the given parameters to the specified URL using {@link MaxXmlRequest.simulate} and returns the {@link MaxXmlRequest}.
+ * Make sure to use encodeURIComponent for the parameter values.
+ *
+ * @param url URL to get the data from.
+ * @param params Parameters for the form.
+ * @param doc Document to create the form in.
+ * @param target Target to send the form result to.
+ */
+export const submit = (url: string, params: string, doc: XMLDocument, target: string) => {
+  return new MaxXmlRequest(url, params).simulate(doc, target);
+};

--- a/packages/html/stories/FileIO.stories.ts
+++ b/packages/html/stories/FileIO.stories.ts
@@ -25,7 +25,7 @@ import {
   FastOrganicLayout,
   Graph,
   InternalEvent,
-  load,
+  requestUtils,
   ModelXmlSerializer,
   type PanningHandler,
   Perimeter,
@@ -146,7 +146,7 @@ function loadModelFromCustomTextFile(graph: Graph, filename: string) {
   // Gets the default parent for inserting new cells. This is normally the first child of the root (ie. layer 0).
   const parent = graph.getDefaultParent();
 
-  const req = load(filename);
+  const req = requestUtils.load(filename);
   const text = req.getText();
 
   const lines = text.split('\n');
@@ -192,7 +192,7 @@ function loadModelFromCustomTextFile(graph: Graph, filename: string) {
 // Loads the Graph file format (standard maxGraph XML file)
 // Parses the Graph XML file format
 function loadModelFromXmlFile(graph: Graph, filename: string) {
-  const req = load(filename);
+  const req = requestUtils.load(filename);
   const xml = req.getText();
   new ModelXmlSerializer(graph.getDataModel()).import(xml);
 }

--- a/packages/html/stories/HelloPort.stories.ts
+++ b/packages/html/stories/HelloPort.stories.ts
@@ -22,7 +22,7 @@ import {
   Graph,
   ModelXmlSerializer,
   Point,
-  popup,
+  guiUtils,
   RubberBandHandler,
 } from '@maxgraph/core';
 
@@ -122,7 +122,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   const button = DomHelpers.button('View XML', function () {
     const xml = new ModelXmlSerializer(graph.getDataModel()).export();
     // TODO missing CSS for the popup
-    popup(xml, true);
+    guiUtils.popup(xml, true);
   });
 
   controller.appendChild(button);

--- a/packages/html/stories/JsonData.stories.ts
+++ b/packages/html/stories/JsonData.stories.ts
@@ -22,7 +22,7 @@ import {
   CodecRegistry,
   InternalEvent,
   domUtils,
-  popup,
+  guiUtils,
   RubberBandHandler,
   ModelXmlSerializer,
   type Cell,
@@ -106,7 +106,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   buttons.appendChild(
     DomHelpers.button('Show JSON', function () {
       const xml = new ModelXmlSerializer(graph.getDataModel()).export();
-      popup(xml, true);
+      guiUtils.popup(xml, true);
     })
   );
 

--- a/packages/html/stories/Stencils.stories.ts
+++ b/packages/html/stories/Stencils.stories.ts
@@ -28,7 +28,7 @@ import {
   Graph,
   HandleConfig,
   InternalEvent,
-  load,
+  requestUtils,
   Point,
   type Rectangle,
   RubberBandHandler,
@@ -169,7 +169,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   CellRenderer.registerShape('customShape', CustomShape);
 
   // Loads the stencils into the registry
-  const req = load('stencils.xml');
+  const req = requestUtils.load('stencils.xml');
   const root = req.getDocumentElement();
   let shape = root!.firstChild;
 

--- a/packages/html/stories/SwimLanes.stories.ts
+++ b/packages/html/stories/SwimLanes.stories.ts
@@ -62,7 +62,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   // The usage of the editor is currently disable for the following reasons
   // TODO get the keyhandler-commons.xml resource from mxGraph
   // TODO make possible to set the container of the graph, see https://github.com/maxGraph/maxGraph/issues/367
-  // const config = utils
+  // const config = requestUtils
   //   .load('editors/config/keyhandler-commons.xml')
   //   .getDocumentElement();
   // const editor = new Editor(config);

--- a/packages/html/stories/UserObject.stories.ts
+++ b/packages/html/stories/UserObject.stories.ts
@@ -29,7 +29,7 @@ import {
   CellAttributeChange,
   RubberBandHandler,
   ModelXmlSerializer,
-  popup,
+  guiUtils,
   type Cell,
   getDefaultPlugins,
 } from '@maxgraph/core';
@@ -183,7 +183,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   // Adds an option to view the XML of the graph
   const button = DomHelpers.button('View XML', function () {
     const xml = new ModelXmlSerializer(graph.getDataModel()).export();
-    popup(xml, true);
+    guiUtils.popup(xml, true);
   });
   button.style.marginTop = '1rem';
   buttons.appendChild(button);


### PR DESCRIPTION
Introduce `guiUtils` and `requestUtils` to hold functions that previously lived alone.
By convention, only the global configuration functions live outside a namespace.

BREAKING CHANGES: some functions are now accessible via a namespace:
- `get`, `getAll`, `load`, `post`, `submit` via `requestUtils`
- `error`, `popup` via `guiUtils`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new utility functions for making HTTP requests and displaying pop-up messages.
- **Refactor**
  - Enhanced modularity by reorganizing utility functions into dedicated namespaces for better access and management.
- **Documentation**
  - Updated release notes to reflect the new organization of user-facing functionalities and improved clarity on available methods.
- **Bug Fixes**
  - Adjusted import paths to ensure proper functionality after the reorganization of utility functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->