### PR TITLE
fix(story): ensure that the Model Codecs are always registered

### DIFF
--- a/packages/html/.storybook/preview.ts
+++ b/packages/html/.storybook/preview.ts
@@ -5,6 +5,7 @@ import {
   GlobalConfig,
   NoOpLogger,
   ObjectCodec,
+  registerModelCodecs,
   resetEdgeHandlerConfig,
   resetEntityRelationConnectorConfig,
   resetHandleConfig,
@@ -54,9 +55,13 @@ const resetMaxGraphConfigs = (): void => {
   // Reset registries to remove additional elements registered in a story
   // The objects storing the registered elements are currently public, but they should not be part of the public API.
   // They will be marked as private in the future and clear functions will probably provide instead.
+
   // Codec resets
   CodecRegistry.aliases = {};
   CodecRegistry.codecs = {};
+  // This is done automatically by ModelSerializer but only once, even if the codec registry is cleaned. So force reload manually here.
+  // This is a workaround. If we had a unregisteredCodecs function, we could reset the global codecs loading status and the codecs would be automatically registered again.
+  registerModelCodecs(true);
   ObjectCodec.allowEval = originalAllowEvalConfig.objectCodec;
   StylesheetCodec.allowEval = originalAllowEvalConfig.stylesheetCodec;
 


### PR DESCRIPTION
Manually cleaning the codecs introduced side effects, and the Codecs were unavailable once a story was visited.
For example, display a story using the Model Codecs like Monitor story, then going to another story and displaying
the Monitor story again. In the latter, the model wasn't fill.

This was because `ModelSerializer` registers the Codecs but only once. If we unregistered the Codecs manually as we do
for stories, the `ModelSerializer` is currently unable to know it has to register the Codecs again (by forcing the registration).
The workaround is to force registration of Model Codecs before loading every story.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the configuration reset process to ensure that all system components are reliably refreshed, providing a more stable and consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->