### PR TITLE
fix(story): add buttons to container, not to the document

### DIFF
--- a/packages/html/stories/HtmlLabel.stories.js
+++ b/packages/html/stories/HtmlLabel.stories.js
@@ -15,12 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*
-HTML label
-
-This example demonstrates using HTML labels that are connected to the state of the user object.
-*/
-
 import {
   xmlUtils,
   domUtils,
@@ -42,7 +36,7 @@ import {
 } from '@maxgraph/core';
 
 import { globalTypes, globalValues } from './shared/args.js';
-import { createGraphContainer } from './shared/configure.js';
+import { createGraphContainer, createMainDiv } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -57,7 +51,12 @@ export default {
 };
 
 const Template = ({ label, ...args }) => {
+  const div = createMainDiv(
+    `This example demonstrates using HTML labels that are connected to the state of the user object.<br>
+It also shows the usage of the undo/redo manager (<code>UndoManager</code>).`
+  );
   const container = createGraphContainer(args);
+  div.appendChild(container);
 
   // Disables the built-in context menu
   InternalEvent.disableContextMenu(container);
@@ -187,19 +186,21 @@ const Template = ({ label, ...args }) => {
   graph.getDataModel().addListener(InternalEvent.UNDO, listener);
   graph.getView().addListener(InternalEvent.UNDO, listener);
 
-  document.body.appendChild(
-    DomHelpers.button('Undo', function () {
-      undoManager.undo();
-    })
-  );
-
-  document.body.appendChild(
+  const buttons = document.createElement('div');
+  buttons.style.marginTop = '.75rem';
+  div.appendChild(buttons);
+  const buttonUndo = DomHelpers.button('Undo', function () {
+    undoManager.undo();
+  });
+  buttonUndo.style.marginRight = '0.5rem';
+  buttons.appendChild(buttonUndo);
+  buttons.appendChild(
     DomHelpers.button('Redo', function () {
       undoManager.redo();
     })
   );
 
-  return container;
+  return div;
 };
 
 export const Default = Template.bind({});

--- a/packages/html/stories/Scrollbars.stories.js
+++ b/packages/html/stories/Scrollbars.stories.js
@@ -15,11 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*
-Scrollbars
-This example demonstrates using a scrollable table with different sections in a cell label.
-*/
-
 import {
   Cell,
   CellRenderer,
@@ -49,7 +44,7 @@ import {
   globalValues,
   globalTypes,
 } from './shared/args.js';
-import { createGraphContainer } from './shared/configure.js';
+import { createGraphContainer, createMainDiv } from './shared/configure.js';
 // style required by RubberBand
 import '@maxgraph/core/css/common.css';
 
@@ -83,9 +78,6 @@ table.erd td {
   text-align: left;
   color: black;
 }
-button {
-  position:absolute;
-}
 `;
 
 // TODO apply this settings to the container used by the Graph
@@ -117,7 +109,11 @@ const Template = ({ label, ...args }) => {
   styleElm.innerText = CSS_TEMPLATE;
   document.head.appendChild(styleElm);
 
+  const div = createMainDiv(
+    `This example demonstrates using a scrollable table with different sections in a cell label.`
+  );
   const container = createGraphContainer(args);
+  div.appendChild(container);
 
   // Disables foreignObjects
   Client.NO_FO = true;
@@ -563,19 +559,21 @@ const Template = ({ label, ...args }) => {
     graph.insertEdge(parent, null, relation, v1, v2);
   });
 
-  let btn1 = DomHelpers.button('+', function () {
+  const buttons = document.createElement('div');
+  buttons.style.marginTop = '.75rem';
+  div.appendChild(buttons);
+  const buttonZoomIn = DomHelpers.button('+', function () {
     graph.zoomIn();
   });
-  btn1.style.marginLeft = '20px';
-
-  document.body.appendChild(btn1);
-  document.body.appendChild(
+  buttonZoomIn.style.marginRight = '.5rem';
+  buttons.appendChild(buttonZoomIn);
+  buttons.appendChild(
     DomHelpers.button('-', function () {
       graph.zoomOut();
     })
   );
 
-  return container;
+  return div;
 };
 
 export const Default = Template.bind({});


### PR DESCRIPTION
Adding the buttons to the document persisted them when displaying another story.
This was incorrectly done in the HtmlLabel and ScrollBars stories.
Also improve the rendering of the buttons in these stories, and display a description of what they demonstrate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the layout of interactive examples by grouping control buttons into dedicated sections.
	- Enhanced descriptive text within the demos to provide clearer context and a more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->