### PR TITLE
fix: make `Graph.options` truly per-instance

### DIFF
--- a/packages/core/src/i18n/config.ts
+++ b/packages/core/src/i18n/config.ts
@@ -79,8 +79,7 @@ export const TranslationsConfig = {
    * See {@link Translations.getSpecialBundle} for handling identifiers with and without a dash.
    *
    * If internationalization is disabled, then the following variables should be overridden to reflect the current language of the system.
-   * These variables are cleared when i18n is disabled:
-   * - {@link CellRenderer.collapseExpandResource}
+   * These variables are cleared when i18n is disabled (the list may not be exhaustive):
    * - {@link Editor.askZoomResource}
    * - {@link Editor.currentFileResource}
    * - {@link Editor.helpResource}
@@ -90,6 +89,7 @@ export const TranslationsConfig = {
    * - {@link Editor.tasksResource}
    * - {@link ElbowEdgeHandler.doubleClickOrientationResource}
    * - {@link Graph.alreadyConnectedResource}.
+   * - {@link Graph.collapseExpandResource}
    * - {@link Graph.containsValidationErrorsResource} and
    * - {@link GraphSelectionModel.doneResource}
    * - {@link GraphSelectionModel.updatingSelectionResource}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -26,6 +26,7 @@ import type Point from './view/geometry/Point';
 import type Rectangle from './view/geometry/Rectangle';
 import type Shape from './view/geometry/Shape';
 import type ImageBox from './view/image/ImageBox';
+import type Image from './view/image/ImageBox';
 
 export type FilterFunction = (cell: Cell) => boolean;
 
@@ -1345,3 +1346,26 @@ export interface I18nProvider {
     callback?: Function | null
   ): void;
 }
+
+export type GraphFoldingOptions = {
+  /**
+   * Specifies if folding (collapse and expand via an image icon in the graph should be enabled).
+   * @default true
+   */
+  foldingEnabled: boolean;
+  /**
+   * Specifies the {@link Image} to indicate a collapsed state.
+   * @default `Client.imageBasePath + '/collapsed.gif'`
+   */
+  collapsedImage: Image;
+  /**
+   * Specifies the {@link Image} to indicate a expanded state.
+   * @default `Client.imageBasePath + '/expanded.gif'`
+   */
+  expandedImage: Image;
+  /**
+   * Specifies if the cell size should be changed to the preferred size when a cell is first collapsed.
+   * @default true
+   */
+  collapseToPreferredSize: boolean;
+};

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -26,7 +26,6 @@ import type Point from './view/geometry/Point';
 import type Rectangle from './view/geometry/Rectangle';
 import type Shape from './view/geometry/Shape';
 import type ImageBox from './view/image/ImageBox';
-import type Image from './view/image/ImageBox';
 
 export type FilterFunction = (cell: Cell) => boolean;
 
@@ -1354,15 +1353,15 @@ export type GraphFoldingOptions = {
    */
   foldingEnabled: boolean;
   /**
-   * Specifies the {@link Image} to indicate a collapsed state.
+   * Specifies the {@link ImageBox} to indicate a collapsed state.
    * @default `Client.imageBasePath + '/collapsed.gif'`
    */
-  collapsedImage: Image;
+  collapsedImage: ImageBox;
   /**
-   * Specifies the {@link Image} to indicate a expanded state.
+   * Specifies the {@link ImageBox} to indicate a expanded state.
    * @default `Client.imageBasePath + '/expanded.gif'`
    */
-  expandedImage: Image;
+  expandedImage: ImageBox;
   /**
    * Specifies if the cell size should be changed to the preferred size when a cell is first collapsed.
    * @default true

--- a/packages/core/src/view/Graph.ts
+++ b/packages/core/src/view/Graph.ts
@@ -47,6 +47,7 @@ import EdgeSegmentHandler from './handler/EdgeSegmentHandler';
 import ElbowEdgeHandler from './handler/ElbowEdgeHandler';
 import type {
   EdgeStyleFunction,
+  GraphFoldingOptions,
   GraphPlugin,
   GraphPluginConstructor,
   MouseListenerSet,
@@ -394,6 +395,14 @@ class Graph extends EventSource {
   containsValidationErrorsResource: string = isI18nEnabled()
     ? 'containsValidationErrors'
     : '';
+
+  /** Folding options. */
+  options: GraphFoldingOptions = {
+    foldingEnabled: true,
+    collapsedImage: new Image(`${Client.imageBasePath}/collapsed.gif`, 9, 9),
+    expandedImage: new Image(`${Client.imageBasePath}/expanded.gif`, 9, 9),
+    collapseToPreferredSize: true,
+  };
 
   // ===================================================================================================================
   // Group: "Create Class Instance" factory functions.

--- a/packages/core/src/view/mixins/FoldingMixin.ts
+++ b/packages/core/src/view/mixins/FoldingMixin.ts
@@ -37,10 +37,10 @@ type PartialGraph = Pick<
   | 'getSelectionCells'
   | 'stopEditing'
   | 'batchUpdate'
+  | 'options'
 >;
 type PartialFolding = Pick<
   Graph,
-  | 'options'
   | 'collapseExpandResource'
   | 'getCollapseExpandResource'
   | 'isFoldingEnabled'
@@ -56,13 +56,6 @@ type PartialType = PartialGraph & PartialFolding;
 
 // @ts-expect-error The properties of PartialGraph are defined elsewhere.
 export const FoldingMixin: PartialType = {
-  options: {
-    foldingEnabled: true,
-    collapsedImage: new Image(`${Client.imageBasePath}/collapsed.gif`, 9, 9),
-    expandedImage: new Image(`${Client.imageBasePath}/expanded.gif`, 9, 9),
-    collapseToPreferredSize: true,
-  },
-
   collapseExpandResource: isI18nEnabled() ? 'collapse-expand' : '',
 
   getCollapseExpandResource() {

--- a/packages/core/src/view/mixins/FoldingMixin.ts
+++ b/packages/core/src/view/mixins/FoldingMixin.ts
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import Image from '../image/ImageBox';
-import Client from '../../Client';
 import Cell from '../cell/Cell';
 import EventObject from '../event/EventObject';
 import InternalEvent from '../event/InternalEvent';

--- a/packages/core/src/view/mixins/FoldingMixin.type.ts
+++ b/packages/core/src/view/mixins/FoldingMixin.type.ts
@@ -16,37 +16,11 @@ limitations under the License.
 
 import type Cell from '../cell/Cell';
 import type CellState from '../cell/CellState';
-import type Image from '../image/ImageBox';
+import type ImageBox from '../image/ImageBox';
 import type Geometry from '../geometry/Geometry';
-
-export type GraphFoldingOptions = {
-  /**
-   * Specifies if folding (collapse and expand via an image icon in the graph should be enabled).
-   * @default true
-   */
-  foldingEnabled: boolean;
-  /**
-   * Specifies the {@link Image} to indicate a collapsed state.
-   * @default `Client.imageBasePath + '/collapsed.gif'`
-   */
-  collapsedImage: Image;
-  /**
-   * Specifies the {@link Image} to indicate a expanded state.
-   * @default `Client.imageBasePath + '/expanded.gif'`
-   */
-  expandedImage: Image;
-  /**
-   * Specifies if the cell size should be changed to the preferred size when a cell is first collapsed.
-   * @default true
-   */
-  collapseToPreferredSize: boolean;
-};
 
 declare module '../Graph' {
   interface Graph {
-    /** Folding options. */
-    options: GraphFoldingOptions;
-
     /**
      * Specifies the resource key for the tooltip on the collapse/expand icon.
      * If the resource for this key does not exist then the value is used as
@@ -75,11 +49,11 @@ declare module '../Graph' {
     isCellFoldable: (cell: Cell, collapse: boolean) => boolean;
 
     /**
-     * Returns the {@link Image} used to display the collapsed state of the specified cell state.
+     * Returns the {@link ImageBox} used to display the collapsed state of the specified cell state.
      *
      * This returns `null` for all edges.
      */
-    getFoldingImage: (state: CellState) => Image | null;
+    getFoldingImage: (state: CellState) => ImageBox | null;
 
     /**
      * Sets the collapsed state of the specified cells and all descendants if recurse is `true`.


### PR DESCRIPTION
Before, setting `Graph.options.foldingEnabled = false` on one `Graph` instance affected other instances too - because the `options` object was shared between them.
For example, switching to the Constituent story (which disables `Graph.options.foldingEnabled`) then back to another story relying on the default (`true`) would break folding: the folding icon disappeared and cells couldn't be collapsed anymore.
This could be seen with the `Collapse` and the `Folding` stories.

The bug exists at least as of version 0.14.0, but probably from the first version of maxGraph.

🔍 Root cause: `options` was defined via mixins as an object, but the internal `mixInto` function probably copies
object references, not values — effectively making `Graph.options` global.

✅ Fix: move the `options` property directly onto the `Graph` class.
It's the only object-typed prop in our mixins, and we're planning to turn `FoldingMixin` into a plugin anyway — so this fix is simple and future-proof.

ℹ️ No impact for users, just internal code structure changes.

In addition, migrate Constituent.stories.js to TypeScript to ease future maintenance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced graph folding with improved collapse/expand visuals for a more intuitive diagram experience.

- **Refactor**
	- Streamlined the configuration of graph folding options for consistent behavior.
	- Improved handling of graph interactions to ensure smoother selection and stability during user events.

- **Documentation**
	- Updated configuration guidelines for internationalization to provide clearer information on variable behavior when the feature is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->