### PR TITLE
refactor!: remove `cellArrayUtils.filterCells`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ _**Note:** Yet to be released breaking changes appear here._
   - `get`, `getAll`, `load`, `post`, `submit` via `requestUtils`
   - `error`, `popup` via `guiUtils`
 - The `utils` namespace has been removed. The remaining properties associated to this namespace have been moved to the `guiUtils` namespace.
+- The `cellArrayUtils.filterCells` function has been removed. Use the `Array.filter` function instead.
 
 ## 0.16.0
 

--- a/packages/core/__tests__/view/GraphDataModel.test.ts
+++ b/packages/core/__tests__/view/GraphDataModel.test.ts
@@ -17,23 +17,49 @@ limitations under the License.
 import { describe, expect, test } from '@jest/globals';
 import { Cell, GraphDataModel } from '../../src';
 
+describe('filterCells', () => {
+  const model: GraphDataModel = new GraphDataModel();
+
+  test('Filter cells with a valid filter function', () => {
+    const cell1 = new Cell();
+    const cells = [cell1, new Cell()];
+    const filter = (cell: Cell) => cell === cell1;
+    const result = model.filterCells(cells, filter);
+    expect(result).toEqual([cell1]);
+  });
+
+  test('Filter cells with an empty array', () => {
+    const cells: Cell[] = [];
+    const filter = (_cell: Cell) => true;
+    const result = model.filterCells(cells, filter);
+    expect(result).toEqual([]);
+  });
+
+  test('Filter cells with a filter function that returns false for all cells', () => {
+    const cells = [new Cell(), new Cell()];
+    const filter = (_cell: Cell) => false;
+    const result = model.filterCells(cells, filter);
+    expect(result).toEqual([]);
+  });
+});
+
 describe('isLayer', () => {
-  const dm: GraphDataModel = new GraphDataModel();
+  const model: GraphDataModel = new GraphDataModel();
   const root: Cell = new Cell();
-  dm.setRoot(root);
+  model.setRoot(root);
 
   test('Child is null', () => {
-    expect(dm.isLayer(null)).toBe(false);
+    expect(model.isLayer(null)).toBe(false);
   });
 
   test('Child is not null and is not layer', () => {
-    expect(dm.isLayer(new Cell())).toBe(false);
+    expect(model.isLayer(new Cell())).toBe(false);
   });
 
   test('Child is not null and is layer', () => {
     const child = new Cell();
     root.children.push(child);
     child.setParent(root);
-    expect(dm.isLayer(child)).toBeTruthy();
+    expect(model.isLayer(child)).toBeTruthy();
   });
 });

--- a/packages/core/src/util/cellArrayUtils.ts
+++ b/packages/core/src/util/cellArrayUtils.ts
@@ -3,22 +3,6 @@ import Dictionary from './Dictionary';
 import ObjectIdentity from './ObjectIdentity';
 
 /**
- * Returns the cells from the given array where the given filter function
- * returns true.
- */
-export const filterCells = (filter: Function) => (cells: Cell[]) => {
-  const result = [] as Cell[];
-
-  for (let i = 0; i < cells.length; i += 1) {
-    if (filter(cells[i])) {
-      result.push(cells[i]);
-    }
-  }
-
-  return result;
-};
-
-/**
  * Returns all opposite vertices terminal for the given edges, only returning sources and/or targets as specified.
  * The result is returned as an array of {@link Cell}.
  *

--- a/packages/core/src/view/GraphDataModel.ts
+++ b/packages/core/src/view/GraphDataModel.ts
@@ -337,7 +337,7 @@ export class GraphDataModel extends EventSource {
   }
 
   filterCells(cells: Cell[], filter: FilterFunction) {
-    return filterCells(filter)(cells);
+    return cells.filter(filter);
   }
 
   getRoot(cell: Cell | null = null) {

--- a/packages/core/src/view/GraphDataModel.ts
+++ b/packages/core/src/view/GraphDataModel.ts
@@ -32,16 +32,14 @@ import TerminalChange from './undoable_changes/TerminalChange';
 import ValueChange from './undoable_changes/ValueChange';
 import VisibleChange from './undoable_changes/VisibleChange';
 import Geometry from './geometry/Geometry';
-import { cloneCells, filterCells } from '../util/cellArrayUtils';
-
 import type { CellStyle, FilterFunction } from '../types';
 
 /**
  * Extends {@link EventSource} to implement a graph model. The graph model acts as
  * a wrapper around the cells which are in charge of storing the actual graph
- * datastructure. The model acts as a transactional wrapper with event
+ * data structure. The model acts as a transactional wrapper with event
  * notification for all changes, whereas the cells contain the atomic
- * operations for updating the actual datastructure.
+ * operations for updating the actual data structure.
  *
  * ### Layers
  *


### PR DESCRIPTION
This function was intended to be private and can be easily replaced by the `Array.filter` function.

BREAKING CHANGES: The `cellArrayUtils.filterCells` function has been removed. Use the `Array.filter` function instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified the filtering process by replacing a custom utility with the native array filtering method, ensuring more consistent and maintainable behavior.

- **Tests**
  - Enhanced the testing suite with additional cases to validate the updated filtering logic and improve naming consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->