### PR TITLE
feat: simplify types used to register shapes

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -93,7 +93,7 @@ export * from './serialization/codecs/_other-codecs';
 export * from './serialization/register-model-codecs';
 export * from './serialization/register-other-codecs';
 
-export { default as ActorShape } from './view/geometry/ActorShape';
+export { default as ActorShape } from './view/geometry/node/ActorShape';
 export { default as LabelShape } from './view/geometry/node/LabelShape';
 export { default as Shape } from './view/geometry/Shape';
 export { default as SwimlaneShape } from './view/geometry/node/SwimlaneShape';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1368,3 +1368,8 @@ export type GraphFoldingOptions = {
    */
   collapseToPreferredSize: boolean;
 };
+
+/**
+ * @since 0.18.0
+ */
+export type ShapeConstructor = new (...arguments_: any) => Shape;

--- a/packages/core/src/view/cell/CellRenderer.ts
+++ b/packages/core/src/view/cell/CellRenderer.ts
@@ -46,7 +46,7 @@ import Cell from './Cell';
 import CellOverlay from './CellOverlay';
 import { getClientX, getClientY, getSource } from '../../util/EventUtils';
 import { isNode } from '../../util/domUtils';
-import { CellStateStyle } from '../../types';
+import type { CellStateStyle, ShapeConstructor } from '../../types';
 import type SelectionCellsHandler from '../plugins/SelectionCellsHandler';
 
 const placeholderStyleValues = ['inherit', 'swimlane', 'indicated'];
@@ -73,12 +73,27 @@ const placeholderStyleProperties: (keyof CellStateStyle)[] = [
  */
 class CellRenderer {
   /**
-   * Static array that contains the globally registered shapes which are
-   * known to all instances of this class. For adding new shapes you should
-   * use the static {@link CellRenderer#registerShape} function.
+   * Static array that contains the globally registered shapes which are known to all instances of this class.
    *
-   * Built-in shapes: arrow, rectangle, ellipse, rhombus, image, line, label, cylinder,
-   * swimlane, connector, actor and cloud.
+   * For adding new shapes you should use {@link CellRenderer.registerShape}.
+   *
+   * Built-in shapes:
+   * - actor
+   * - arrow
+   * - arrow connector (for edges)
+   * - cloud
+   * - connector (for edges)
+   * - cylinder
+   * - double ellipse
+   * - ellipse
+   * - hexagon
+   * - image
+   * - label
+   * - line (for edges)
+   * - rectangle
+   * - rhombus
+   * - swimlane
+   * - triangle
    */
   static defaultShapes: { [key: string]: typeof Shape } = {};
 
@@ -86,14 +101,13 @@ class CellRenderer {
    * Defines the default shape for edges.
    * @default {@link ConnectorShape}
    */
-  // @ts-expect-error The constructors for Shape and Connector are different.
-  defaultEdgeShape: typeof Shape = ConnectorShape;
+  defaultEdgeShape: ShapeConstructor = ConnectorShape;
 
   /**
    * Defines the default shape for vertices.
    * @default {@link RectangleShape}.
    */
-  defaultVertexShape: typeof RectangleShape = RectangleShape;
+  defaultVertexShape: ShapeConstructor = RectangleShape;
 
   /**
    * Defines the default shape for labels.
@@ -133,15 +147,16 @@ class CellRenderer {
 
   /**
    * Registers the given constructor under the specified key in this instance of the renderer.
-   * @example
-   * ```
-   * CellRenderer.registerShape(Constants.SHAPE_RECTANGLE, RectangleShape);
+   *
+   * For example:
+   * ```javascript
+   * CellRenderer.registerShape('rectangle', RectangleShape);
    * ```
    *
    * @param key the shape name.
    * @param shape constructor of the {@link Shape} subclass.
    */
-  static registerShape(key: string, shape: typeof Shape): void {
+  static registerShape(key: string, shape: ShapeConstructor): void {
     CellRenderer.defaultShapes[key] = shape;
   }
 
@@ -188,22 +203,21 @@ class CellRenderer {
   /**
    * Returns the shape for the given name from {@link defaultShapes}.
    */
-  getShape(name: string | null): typeof Shape | null {
+  getShape(name?: string | null): ShapeConstructor | null {
     return name ? CellRenderer.defaultShapes[name] : null;
   }
 
   /**
    * Returns the constructor to be used for creating the shape.
    */
-  getShapeConstructor(state: CellState): typeof Shape {
-    let ctor = this.getShape(state.style.shape || null);
+  getShapeConstructor(state: CellState): ShapeConstructor {
+    let ctor = this.getShape(state.style.shape);
 
     if (!ctor) {
-      // @ts-expect-error The various Shape constructors are not compatible.
       ctor = state.cell.isEdge() ? this.defaultEdgeShape : this.defaultVertexShape;
     }
 
-    return ctor as typeof Shape;
+    return ctor;
   }
 
   /**

--- a/packages/core/src/view/cell/register-shapes.ts
+++ b/packages/core/src/view/cell/register-shapes.ts
@@ -15,13 +15,13 @@ limitations under the License.
 */
 
 import CellRenderer from './CellRenderer';
-import type Shape from '../geometry/Shape';
+import type { ShapeConstructor } from '../../types';
 import RectangleShape from '../geometry/node/RectangleShape';
 import EllipseShape from '../geometry/node/EllipseShape';
 import RhombusShape from '../geometry/node/RhombusShape';
 import CylinderShape from '../geometry/node/CylinderShape';
 import ConnectorShape from '../geometry/edge/ConnectorShape';
-import ActorShape from '../geometry/ActorShape';
+import ActorShape from '../geometry/node/ActorShape';
 import TriangleShape from '../geometry/node/TriangleShape';
 import HexagonShape from '../geometry/node/HexagonShape';
 import CloudShape from '../geometry/node/CloudShape';
@@ -45,12 +45,12 @@ let isDefaultElementsRegistered = false;
  */
 export function registerDefaultShapes() {
   if (!isDefaultElementsRegistered) {
-    const shapesToRegister: [string, new (...arguments_: any) => Shape][] = [
+    const shapesToRegister: [string, ShapeConstructor][] = [
       [SHAPE.ACTOR, ActorShape],
       [SHAPE.ARROW, ArrowShape],
       [SHAPE.ARROW_CONNECTOR, ArrowConnectorShape],
-      [SHAPE.CONNECTOR, ConnectorShape],
       [SHAPE.CLOUD, CloudShape],
+      [SHAPE.CONNECTOR, ConnectorShape],
       [SHAPE.CYLINDER, CylinderShape],
       [SHAPE.DOUBLE_ELLIPSE, DoubleEllipseShape],
       [SHAPE.ELLIPSE, EllipseShape],

--- a/packages/core/src/view/geometry/node/ActorShape.ts
+++ b/packages/core/src/view/geometry/node/ActorShape.ts
@@ -16,11 +16,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import Rectangle from './Rectangle';
-import Shape from './Shape';
-import type AbstractCanvas2D from '../canvas/AbstractCanvas2D';
-import { ColorValue } from '../../types';
-import { NONE } from '../../util/Constants';
+import type Rectangle from '../Rectangle';
+import Shape from '../Shape';
+import type AbstractCanvas2D from '../../canvas/AbstractCanvas2D';
+import { ColorValue } from '../../../types';
+import { NONE } from '../../../util/Constants';
 
 /**
  * Extends {@link Shape} to implement an actor shape.

--- a/packages/core/src/view/geometry/node/CloudShape.ts
+++ b/packages/core/src/view/geometry/node/CloudShape.ts
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import ActorShape from '../ActorShape';
+import ActorShape from './ActorShape';
 import AbstractCanvas2D from '../../canvas/AbstractCanvas2D';
 import Rectangle from '../Rectangle';
 

--- a/packages/core/src/view/geometry/node/HexagonShape.ts
+++ b/packages/core/src/view/geometry/node/HexagonShape.ts
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import ActorShape from '../ActorShape';
+import ActorShape from './ActorShape';
 import Point from '../Point';
 import { LINE_ARCSIZE } from '../../../util/Constants';
 import AbstractCanvas2D from '../../canvas/AbstractCanvas2D';

--- a/packages/core/src/view/geometry/node/TriangleShape.ts
+++ b/packages/core/src/view/geometry/node/TriangleShape.ts
@@ -17,7 +17,7 @@ limitations under the License.
 */
 
 import Point from '../Point';
-import ActorShape from '../ActorShape';
+import ActorShape from './ActorShape';
 import { LINE_ARCSIZE } from '../../../util/Constants';
 import AbstractCanvas2D from '../../canvas/AbstractCanvas2D';
 

--- a/packages/html/stories/Handles.stories.ts
+++ b/packages/html/stories/Handles.stories.ts
@@ -106,7 +106,6 @@ const Template = ({ label, ...args }: Record<string, string>) => {
       }
     }
   }
-  // @ts-ignore
   CellRenderer.registerShape('myShape', MyShape);
 
   // Enable rotation handle

--- a/packages/html/stories/Markers.stories.ts
+++ b/packages/html/stories/Markers.stories.ts
@@ -96,7 +96,6 @@ const Template = ({ label, ...args }: Record<string, string>) => {
       }
     }
   }
-  // @ts-ignore -- as for core shapes
   CellRenderer.registerShape('message', MessageShape);
 
   // Defines custom edge shape
@@ -142,7 +141,6 @@ const Template = ({ label, ...args }: Record<string, string>) => {
       c.stroke();
     }
   }
-  // @ts-ignore -- as for core shapes
   CellRenderer.registerShape('link', LinkShape);
 
   // Creates the graph

--- a/packages/ts-example/src/custom-shapes.ts
+++ b/packages/ts-example/src/custom-shapes.ts
@@ -18,9 +18,7 @@ import type { AbstractCanvas2D, ColorValue, Rectangle } from '@maxgraph/core';
 import { CellRenderer, EllipseShape, RectangleShape } from '@maxgraph/core';
 
 export const registerCustomShapes = (): void => {
-  // @ts-ignore TODO fix CellRenderer. Calls to this function are also marked as 'ts-ignore' in CellRenderer
   CellRenderer.registerShape('customRectangle', CustomRectangleShape);
-  // @ts-ignore
   CellRenderer.registerShape('customEllipse', CustomEllipseShape);
 };
 


### PR DESCRIPTION
Previously, there were TSC errors when registering some builtin or custom shape because their constructor didn't match
the signature of the `Shape` constructor.
The type of various `CellRenderer` properties and methods has been updated to fix this, so it is no longer necessary to
add some 'ts-ignore' to silently ignore these false errors.

In addition:
- Various improvements in the JSDoc of `CellRenderer`
- `CellRenderer.getShape` allows `undefined` parameter
- Move `ActorShape` to the directory storing vertex shapes for consistency


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new type for shape constructors, improving type safety when creating custom shapes.

- **Refactor**
  - Updated and standardized import paths for shape modules.
  - Improved type annotations and clarity around shape registration and usage.

- **Style**
  - Removed unnecessary TypeScript ignore comments from sample and story files for cleaner code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->