### PR TITLE
feat(core): explicitly support undefined container in Graph constructor

### DIFF
--- a/packages/core/__tests__/utils.ts
+++ b/packages/core/__tests__/utils.ts
@@ -18,9 +18,9 @@ import { Cell, type CellStateStyle, Graph } from '../src';
 import { jest } from '@jest/globals';
 
 // no need for a container, we don't check the view here
-export const createGraphWithoutContainer = (): Graph => new Graph(null!);
+export const createGraphWithoutContainer = (): Graph => new Graph();
 
-export const createGraphWithoutPlugins = (): Graph => new Graph(null!, null!, []);
+export const createGraphWithoutPlugins = (): Graph => new Graph(undefined, undefined, []);
 
 export const createCellWithStyle = (style: CellStateStyle): Cell => {
   const cell = new Cell();

--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -1387,12 +1387,13 @@ export class Editor extends EventSource {
   }
 
   /**
-   * Creates the {@link graph} for the editor. The graph is created with no
-   * container and is initialized from {@link setGraphContainer}.
+   * Creates the {@link graph} for the editor.
+   *
+   * The graph is created with no container and is initialized from {@link setGraphContainer}.
    * @returns graph instance
    */
   createGraph(): Graph {
-    const graph = new Graph(undefined!);
+    const graph = new Graph();
 
     // Enables rubberband, tooltips, panning
     graph.setTooltips(true);

--- a/packages/core/src/serialization/codecs/GraphCodec.ts
+++ b/packages/core/src/serialization/codecs/GraphCodec.ts
@@ -37,9 +37,8 @@ import { Graph } from '../../view/Graph';
  */
 export class GraphCodec extends ObjectCodec {
   constructor() {
-    const __dummy: any = undefined;
-    // TODO: Register every possible plugin (i.e. all not being excluded via tree-shaking(?))
-    super(new Graph(__dummy), [
+    // TODO review the Graph initialization. Currently it registers all default plugins (check impact on tree-shaking)
+    super(new Graph(), [
       'graphListeners',
       'eventListeners',
       'view',

--- a/packages/core/src/view/Graph.ts
+++ b/packages/core/src/view/Graph.ts
@@ -494,7 +494,7 @@ class Graph extends EventSource {
   }
 
   constructor(
-    container: HTMLElement,
+    container?: HTMLElement,
     model?: GraphDataModel,
     plugins: GraphPluginConstructor[] = getDefaultPlugins(),
     stylesheet: Stylesheet | null = null


### PR DESCRIPTION
The Graph constructor already handled undefined container internally, but TypeScript type definitions weren't accurately reflecting this capability.

This change aligns types with implementation, supporting use cases in Editor, GraphCodec, and tests where undefined containers are passed.


### Notes

Covers #367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved handling of optional parameters when creating graphs, reducing the need for placeholder or dummy arguments.
	- Updated internal logic to create a default container if none is provided.
- **Documentation**
	- Enhanced JSDoc comments for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->