### PR TITLE
refactor: reorganize builtin style elements

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -157,20 +157,10 @@ export { default as ObjectIdentity } from './util/ObjectIdentity';
 export { default as Point } from './view/geometry/Point';
 export { default as Rectangle } from './view/geometry/Rectangle';
 
+export * from './view/style/builtin-style-elements';
 export * from './view/style/config';
 export * from './view/style/register';
-export { default as MarkerShape } from './view/style/EdgeMarkerRegistry';
-/**
- * Includes all builtins edge markers which can be registered in {@link MarkerShape}.
- *
- * They are registered by default when instantiating {@link Graph} or they can all be registered by calling {@link registerDefaultEdgeMarkers}.
- *
- * @since 0.18.0
- * @category Style
- */
-export * as EdgeMarker from './view/style/edge-markers';
-export { default as EdgeStyle } from './view/style/EdgeStyle';
-export { default as Perimeter } from './view/style/Perimeter';
+export { default as MarkerShape } from './view/style/marker/EdgeMarkerRegistry';
 export { default as StyleRegistry } from './view/style/StyleRegistry';
 export { Stylesheet } from './view/style/Stylesheet';
 

--- a/packages/core/src/view/Graph.ts
+++ b/packages/core/src/view/Graph.ts
@@ -40,7 +40,7 @@ import TerminalChange from './undoable_changes/TerminalChange';
 import ValueChange from './undoable_changes/ValueChange';
 import CellState from './cell/CellState';
 import { isNode } from '../util/domUtils';
-import EdgeStyle from './style/EdgeStyle';
+import { EdgeStyle } from './style/edge';
 import EdgeHandler from './handler/EdgeHandler';
 import VertexHandler from './handler/VertexHandler';
 import EdgeSegmentHandler from './handler/EdgeSegmentHandler';

--- a/packages/core/src/view/geometry/edge/ConnectorShape.ts
+++ b/packages/core/src/view/geometry/edge/ConnectorShape.ts
@@ -18,7 +18,7 @@ limitations under the License.
 
 import { DEFAULT_MARKERSIZE, NONE } from '../../../util/Constants';
 import PolylineShape from './PolylineShape';
-import MarkerShape from '../../style/EdgeMarkerRegistry';
+import MarkerShape from '../../style/marker/EdgeMarkerRegistry';
 import Point from '../Point';
 import AbstractCanvas2D from '../../canvas/AbstractCanvas2D';
 import Rectangle from '../Rectangle';

--- a/packages/core/src/view/handler/EdgeHandler.ts
+++ b/packages/core/src/view/handler/EdgeHandler.ts
@@ -45,7 +45,7 @@ import InternalEvent from '../event/InternalEvent';
 import ConstraintHandler from './ConstraintHandler';
 import Rectangle from '../geometry/Rectangle';
 import Client from '../../Client';
-import EdgeStyle from '../style/EdgeStyle';
+import { EdgeStyle } from '../style/edge';
 import {
   getClientX,
   getClientY,

--- a/packages/core/src/view/style/builtin-style-elements.ts
+++ b/packages/core/src/view/style/builtin-style-elements.ts
@@ -1,0 +1,28 @@
+/*
+Copyright 2025-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export { EdgeStyle } from './edge';
+export { Perimeter } from './perimeter';
+
+/**
+ * Includes all builtins edge markers which can be registered in {@link MarkerShape}.
+ *
+ * They are registered by default when instantiating {@link Graph} or they can all be registered by calling {@link registerDefaultEdgeMarkers}.
+ *
+ * @since 0.18.0
+ * @category Style
+ */
+export * as EdgeMarker from './marker/edge-markers';

--- a/packages/core/src/view/style/edge/index.ts
+++ b/packages/core/src/view/style/edge/index.ts
@@ -16,14 +16,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ElbowConnector as ElbowConnectorFunction } from './edge/Elbow';
-import { EntityRelation as EntityRelationFunction } from './edge/EntityRelation';
-import { Loop as LoopFunction } from './edge/Loop';
-import { ManhattanConnector as ManhattanConnectorFunction } from './edge/Manhattan';
-import { OrthogonalConnector as OrthogonalConnectorFunction } from './edge/Orthogonal';
-import { SegmentConnector as SegmentConnectorFunction } from './edge/Segment';
-import { SideToSide as SideToSideFunction } from './edge/SideToSide';
-import { TopToBottom as TopToBottomFunction } from './edge/TopToBottom';
+import { ElbowConnector as ElbowConnectorFunction } from './Elbow';
+import { EntityRelation as EntityRelationFunction } from './EntityRelation';
+import { Loop as LoopFunction } from './Loop';
+import { ManhattanConnector as ManhattanConnectorFunction } from './Manhattan';
+import { OrthogonalConnector as OrthogonalConnectorFunction } from './Orthogonal';
+import { SegmentConnector as SegmentConnectorFunction } from './Segment';
+import { SideToSide as SideToSideFunction } from './SideToSide';
+import { TopToBottom as TopToBottomFunction } from './TopToBottom';
 
 /**
  * Provides various edge styles to be used as the values for `edgeStyle` in a cell style.
@@ -81,7 +81,7 @@ import { TopToBottom as TopToBottomFunction } from './edge/TopToBottom';
  *
  * @category EdgeStyle
  */
-class EdgeStyle {
+export class EdgeStyle {
   /**
    * Implements an entity relation style for edges (as used in database
    * schema diagrams). At the time the function is called, the result
@@ -153,5 +153,3 @@ class EdgeStyle {
    */
   static ManhattanConnector = ManhattanConnectorFunction;
 }
-
-export default EdgeStyle;

--- a/packages/core/src/view/style/marker/EdgeMarkerRegistry.ts
+++ b/packages/core/src/view/style/marker/EdgeMarkerRegistry.ts
@@ -16,10 +16,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { MarkerFactoryFunction, StyleArrowValue } from '../../types';
-import type AbstractCanvas2D from '../canvas/AbstractCanvas2D';
-import type Point from '../geometry/Point';
-import type Shape from '../geometry/Shape';
+import type { MarkerFactoryFunction, StyleArrowValue } from '../../../types';
+import type AbstractCanvas2D from '../../canvas/AbstractCanvas2D';
+import type Point from '../../geometry/Point';
+import type Shape from '../../geometry/Shape';
 
 /**
  * A registry that stores the factory functions that create edge markers.

--- a/packages/core/src/view/style/marker/edge-markers.ts
+++ b/packages/core/src/view/style/marker/edge-markers.ts
@@ -16,11 +16,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type { StyleArrowValue } from '../../types';
-import type AbstractCanvas2D from '../canvas/AbstractCanvas2D';
-import type Shape from '../geometry/Shape';
-import type Point from '../geometry/Point';
-import { ARROW } from '../../util/Constants';
+import type { StyleArrowValue } from '../../../types';
+import type AbstractCanvas2D from '../../canvas/AbstractCanvas2D';
+import type Shape from '../../geometry/Shape';
+import type Point from '../../geometry/Point';
+import { ARROW } from '../../../util/Constants';
 
 /**
  * Generally used to create the "classic" and "block" marker factory methods.

--- a/packages/core/src/view/style/perimeter/index.ts
+++ b/packages/core/src/view/style/perimeter/index.ts
@@ -16,18 +16,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { EllipsePerimeter as EllipsePerimeterFunction } from './perimeter/EllipsePerimeter';
-import { HexagonPerimeter as HexagonPerimeterFunction } from './perimeter/HexagonPerimeter';
-import { RectanglePerimeter as RectanglePerimeterFunction } from './perimeter/RectanglePerimeter';
-import { RhombusPerimeter as RhombusPerimeterFunction } from './perimeter/RhombusPerimeter';
-import { TrianglePerimeter as TrianglePerimeterFunction } from './perimeter/TrianglePerimeter';
+import { EllipsePerimeter as EllipsePerimeterFunction } from './EllipsePerimeter';
+import { HexagonPerimeter as HexagonPerimeterFunction } from './HexagonPerimeter';
+import { RectanglePerimeter as RectanglePerimeterFunction } from './RectanglePerimeter';
+import { RhombusPerimeter as RhombusPerimeterFunction } from './RhombusPerimeter';
+import { TrianglePerimeter as TrianglePerimeterFunction } from './TrianglePerimeter';
 
 /**
  * Provides various perimeter functions to be used in a style as the value of {@link CellStateStyle.perimeter}.
  *
  * @category Perimeter
  */
-const Perimeter = {
+export const Perimeter = {
   /**
    * Describes a rectangular perimeter.
    */
@@ -53,5 +53,3 @@ const Perimeter = {
    */
   HexagonPerimeter: HexagonPerimeterFunction,
 };
-
-export default Perimeter;

--- a/packages/core/src/view/style/register.ts
+++ b/packages/core/src/view/style/register.ts
@@ -15,11 +15,16 @@ limitations under the License.
 */
 
 import { EDGESTYLE, PERIMETER } from '../../util/Constants';
-import EdgeStyle from './EdgeStyle';
-import Perimeter from './Perimeter';
+import { EdgeStyle } from './edge';
+import { Perimeter } from './perimeter';
 import StyleRegistry from './StyleRegistry';
-import MarkerShape from './EdgeMarkerRegistry';
-import { createArrow, createOpenArrow, diamond, oval } from './edge-markers';
+import MarkerShape from './marker/EdgeMarkerRegistry';
+import { createArrow, createOpenArrow, diamond, oval } from './marker/edge-markers';
+import type {
+  EdgeStyleFunction,
+  MarkerFactoryFunction,
+  PerimeterFunction,
+} from '../../types';
 
 let isDefaultEdgeStylesRegistered = false;
 
@@ -32,14 +37,19 @@ let isDefaultEdgeStylesRegistered = false;
  */
 export const registerDefaultEdgeStyles = (): void => {
   if (!isDefaultEdgeStylesRegistered) {
-    StyleRegistry.putValue(EDGESTYLE.ELBOW, EdgeStyle.ElbowConnector);
-    StyleRegistry.putValue(EDGESTYLE.ENTITY_RELATION, EdgeStyle.EntityRelation);
-    StyleRegistry.putValue(EDGESTYLE.LOOP, EdgeStyle.Loop);
-    StyleRegistry.putValue(EDGESTYLE.MANHATTAN, EdgeStyle.ManhattanConnector);
-    StyleRegistry.putValue(EDGESTYLE.ORTHOGONAL, EdgeStyle.OrthConnector);
-    StyleRegistry.putValue(EDGESTYLE.SEGMENT, EdgeStyle.SegmentConnector);
-    StyleRegistry.putValue(EDGESTYLE.SIDETOSIDE, EdgeStyle.SideToSide);
-    StyleRegistry.putValue(EDGESTYLE.TOPTOBOTTOM, EdgeStyle.TopToBottom);
+    const edgeStylesToRegister: [string, EdgeStyleFunction][] = [
+      [EDGESTYLE.ELBOW, EdgeStyle.ElbowConnector],
+      [EDGESTYLE.ENTITY_RELATION, EdgeStyle.EntityRelation],
+      [EDGESTYLE.LOOP, EdgeStyle.Loop],
+      [EDGESTYLE.MANHATTAN, EdgeStyle.ManhattanConnector],
+      [EDGESTYLE.ORTHOGONAL, EdgeStyle.OrthConnector],
+      [EDGESTYLE.SEGMENT, EdgeStyle.SegmentConnector],
+      [EDGESTYLE.SIDETOSIDE, EdgeStyle.SideToSide],
+      [EDGESTYLE.TOPTOBOTTOM, EdgeStyle.TopToBottom],
+    ];
+    for (const [name, edgeStyle] of edgeStylesToRegister) {
+      StyleRegistry.putValue(name, edgeStyle);
+    }
 
     isDefaultEdgeStylesRegistered = true;
   }
@@ -56,11 +66,16 @@ let isDefaultPerimetersRegistered = false;
  */
 export const registerDefaultPerimeters = (): void => {
   if (!isDefaultPerimetersRegistered) {
-    StyleRegistry.putValue(PERIMETER.ELLIPSE, Perimeter.EllipsePerimeter);
-    StyleRegistry.putValue(PERIMETER.HEXAGON, Perimeter.HexagonPerimeter);
-    StyleRegistry.putValue(PERIMETER.RECTANGLE, Perimeter.RectanglePerimeter);
-    StyleRegistry.putValue(PERIMETER.RHOMBUS, Perimeter.RhombusPerimeter);
-    StyleRegistry.putValue(PERIMETER.TRIANGLE, Perimeter.TrianglePerimeter);
+    const perimetersToRegister: [string, PerimeterFunction][] = [
+      [PERIMETER.ELLIPSE, Perimeter.EllipsePerimeter],
+      [PERIMETER.HEXAGON, Perimeter.HexagonPerimeter],
+      [PERIMETER.RECTANGLE, Perimeter.RectanglePerimeter],
+      [PERIMETER.RHOMBUS, Perimeter.RhombusPerimeter],
+      [PERIMETER.TRIANGLE, Perimeter.TrianglePerimeter],
+    ];
+    for (const [name, edgeStyle] of perimetersToRegister) {
+      StyleRegistry.putValue(name, edgeStyle);
+    }
 
     isDefaultPerimetersRegistered = true;
   }
@@ -93,18 +108,20 @@ let isDefaultMarkersRegistered = false;
  */
 export const registerDefaultEdgeMarkers = (): void => {
   if (!isDefaultMarkersRegistered) {
-    MarkerShape.addMarker('classic', createArrow(2));
-    MarkerShape.addMarker('classicThin', createArrow(3));
-    MarkerShape.addMarker('block', createArrow(2));
-    MarkerShape.addMarker('blockThin', createArrow(3));
-
-    MarkerShape.addMarker('open', createOpenArrow(2));
-    MarkerShape.addMarker('openThin', createOpenArrow(3));
-
-    MarkerShape.addMarker('oval', oval);
-
-    MarkerShape.addMarker('diamond', diamond);
-    MarkerShape.addMarker('diamondThin', diamond);
+    const markersToRegister: [string, MarkerFactoryFunction][] = [
+      ['classic', createArrow(2)],
+      ['classicThin', createArrow(3)],
+      ['block', createArrow(2)],
+      ['blockThin', createArrow(3)],
+      ['open', createOpenArrow(2)],
+      ['openThin', createOpenArrow(3)],
+      ['oval', oval],
+      ['diamond', diamond],
+      ['diamondThin', diamond],
+    ];
+    for (const [type, factory] of markersToRegister) {
+      MarkerShape.addMarker(type, factory);
+    }
 
     isDefaultMarkersRegistered = true;
   }

--- a/packages/core/src/view/style/register.ts
+++ b/packages/core/src/view/style/register.ts
@@ -73,8 +73,8 @@ export const registerDefaultPerimeters = (): void => {
       [PERIMETER.RHOMBUS, Perimeter.RhombusPerimeter],
       [PERIMETER.TRIANGLE, Perimeter.TrianglePerimeter],
     ];
-    for (const [name, edgeStyle] of perimetersToRegister) {
-      StyleRegistry.putValue(name, edgeStyle);
+    for (const [name, perimeter] of perimetersToRegister) {
+      StyleRegistry.putValue(name, perimeter);
     }
 
     isDefaultPerimetersRegistered = true;

--- a/packages/ts-example-without-defaults/vite.config.js
+++ b/packages/ts-example-without-defaults/vite.config.js
@@ -27,7 +27,7 @@ export default defineConfig(({ mode }) => {
           },
         },
       },
-      chunkSizeWarningLimit: 436, // @maxgraph/core
+      chunkSizeWarningLimit: 435, // @maxgraph/core
     },
   };
 });

--- a/packages/ts-example/vite.config.js
+++ b/packages/ts-example/vite.config.js
@@ -27,7 +27,7 @@ export default defineConfig(({ mode }) => {
           },
         },
       },
-      chunkSizeWarningLimit: 440, // @maxgraph/core
+      chunkSizeWarningLimit: 439, // @maxgraph/core
     },
   };
 });


### PR DESCRIPTION
Introduce the "builtin-style-elements.ts" that export all builtin styles to simplify the root "index.ts" file.
This simplifies the maintenance and will reduce the impact of the future refactoring on `EdgeStyle` and `Perimeter`.

Simplify default builtins registration using a loop as this is already done to register Shapes.


## Notes

Covers #759



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined and reorganized style-related exports for improved clarity and consistency.
  - Introduced a new module providing built-in style elements for edge styles, perimeters, and markers.
  - Updated export and import paths for style entities, replacing default exports with named exports.
  - Simplified registration of edge styles, perimeters, and markers using consolidated loops.

- **Chores**
  - Updated internal documentation and licensing headers for new and reorganized modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->