### PR TITLE
fix: use the right list of excluded fields in GraphCodec

### DIFF
--- a/packages/core/__tests__/serialization/codecs/graph-and-constituents.test.ts
+++ b/packages/core/__tests__/serialization/codecs/graph-and-constituents.test.ts
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { afterEach, beforeAll, beforeEach, describe, expect, test } from '@jest/globals';
-import { createGraphWithoutContainer, createGraphWithoutPlugins } from '../../utils';
+import { afterEach, beforeAll, beforeEach, expect, test } from '@jest/globals';
+import { createGraphWithoutContainer } from '../../utils';
 import Codec from '../../../src/serialization/Codec';
 import { getPrettyXml, parseXml } from '../../../src/util/xmlUtils';
 import {

--- a/packages/core/__tests__/serialization/codecs/graph-and-constituents.test.ts
+++ b/packages/core/__tests__/serialization/codecs/graph-and-constituents.test.ts
@@ -1,0 +1,102 @@
+/*
+Copyright 2024-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { afterEach, beforeAll, beforeEach, describe, expect, test } from '@jest/globals';
+import { createGraphWithoutContainer, createGraphWithoutPlugins } from '../../utils';
+import Codec from '../../../src/serialization/Codec';
+import { getPrettyXml, parseXml } from '../../../src/util/xmlUtils';
+import {
+  type AbstractGraph,
+  ImageBox,
+  Rectangle,
+  registerCoreCodecs,
+  unregisterAllCodecs,
+} from '../../../src';
+
+function exportGraph(graph: AbstractGraph): string {
+  const encodedNode = new Codec().encode(graph);
+  return getPrettyXml(encodedNode);
+}
+
+function importGraph(graph: AbstractGraph, input: string): void {
+  const doc = parseXml(input);
+  new Codec(doc).decode(doc.documentElement, graph);
+}
+
+// Prevents side effects between tests
+beforeAll(() => {
+  unregisterAllCodecs();
+});
+beforeEach(() => {
+  registerCoreCodecs();
+});
+afterEach(() => {
+  unregisterAllCodecs();
+});
+
+const graphAsXml = `<Graph>
+  <Array as="cells" />
+  <Array as="imageBundles" />
+  <Array as="mouseListeners">
+    <Object />
+    <Object />
+  </Array>
+  <Array as="multiplicities" />
+  <GraphDataModel as="model">
+    <root>
+      <Cell id="0">
+        <Object as="style" />
+      </Cell>
+      <Cell id="1" parent="0">
+        <Object as="style" />
+      </Cell>
+    </root>
+  </GraphDataModel>
+  <Stylesheet as="stylesheet" />
+  <Rectangle _x="123" _y="453" _width="60" _height="60" as="pageFormat" />
+  <ImageBox src="./warning.gif" width="16" height="16" as="warningImage" />
+  <Object foldingEnabled="1" collapseToPreferredSize="1" as="options">
+    <ImageBox src="./collapsed-new.gif" width="10" height="10" as="collapsedImage" />
+    <ImageBox src="./expanded.gif" width="9" height="9" as="expandedImage" />
+  </Object>
+</Graph>
+`;
+
+test('Export Graph with default plugins', () => {
+  // This graph uses default plugins
+  const graph = createGraphWithoutContainer();
+  // override defaults to ensure it is taken into account
+  graph.pageFormat = new Rectangle(123, 453, 60, 60);
+  graph.options.collapsedImage = new ImageBox('./collapsed-new.gif', 10, 10);
+
+  expect(exportGraph(graph)).toBe(graphAsXml);
+});
+
+test('Import Graph', () => {
+  // This graph uses default plugins
+  const graph = createGraphWithoutContainer();
+  // check default values that will be overridden by the import
+  expect(graph.pageFormat).toEqual(new Rectangle(0, 0, 827, 1169));
+  expect(graph.options.collapsedImage).toEqual(new ImageBox('./collapsed.gif', 9, 9));
+
+  importGraph(graph, graphAsXml);
+
+  // new values due to import
+  expect(graph.pageFormat).toEqual(new Rectangle(123, 453, 60, 60));
+  expect(graph.options.collapsedImage).toEqual(
+    new ImageBox('./collapsed-new.gif', 10, 10)
+  );
+});

--- a/packages/core/__tests__/serialization/serialization.xml.mxGraph.test.ts
+++ b/packages/core/__tests__/serialization/serialization.xml.mxGraph.test.ts
@@ -14,9 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { describe, test } from '@jest/globals';
+import { afterEach, beforeAll, describe, test } from '@jest/globals';
 import { ModelChecker } from './utils';
-import { Geometry, GraphDataModel, ModelXmlSerializer, Point } from '../../src';
+import {
+  Geometry,
+  GraphDataModel,
+  ModelXmlSerializer,
+  Point,
+  unregisterAllCodecs,
+} from '../../src';
+
+// Prevents side effects between tests
+beforeAll(() => {
+  unregisterAllCodecs();
+});
+afterEach(() => {
+  unregisterAllCodecs();
+});
 
 describe('import mxGraph model', () => {
   test('Model with geometry', () => {

--- a/packages/core/__tests__/serialization/serialization.xml.test.ts
+++ b/packages/core/__tests__/serialization/serialization.xml.test.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { describe, expect, test } from '@jest/globals';
+import { afterEach, beforeAll, describe, expect, test } from '@jest/globals';
 import { ModelChecker } from './utils';
 import { createGraphWithoutContainer } from '../utils';
 import {
@@ -24,6 +24,7 @@ import {
   GraphDataModel,
   ModelXmlSerializer,
   Point,
+  unregisterAllCodecs,
 } from '../../src';
 
 // inspired by VertexMixin.createVertex
@@ -96,6 +97,14 @@ const xmlWithVerticesAndEdges = `<GraphDataModel>
   </root>
 </GraphDataModel>
 `;
+
+// Prevents side effects between tests
+beforeAll(() => {
+  unregisterAllCodecs();
+});
+afterEach(() => {
+  unregisterAllCodecs();
+});
 
 test('Check the content of an empty GraphDataModel', () => {
   const modelChecker = new ModelChecker(new GraphDataModel());

--- a/packages/core/src/serialization/codecs/GraphCodec.ts
+++ b/packages/core/src/serialization/codecs/GraphCodec.ts
@@ -31,21 +31,24 @@ import { Graph } from '../../view/Graph';
  * - container
  * - cellRenderer
  * - editor
- * - selection
+ * - selectionModel
+ * - plugins
  *
  * @category Serialization with Codecs
  */
 export class GraphCodec extends ObjectCodec {
   constructor() {
-    // TODO review the Graph initialization. Currently it registers all default plugins (check impact on tree-shaking)
-    super(new Graph(), [
+    // Do not  load default plugins, plugins are not serialized
+    super(new Graph(undefined, undefined, []), [
       'graphListeners',
       'eventListeners',
       'view',
       'container',
       'cellRenderer',
       'editor',
-      'selection',
+      'selectionModel',
+      'plugins',
     ]);
+    this.setName('Graph');
   }
 }

--- a/packages/core/src/serialization/codecs/GraphViewCodec.ts
+++ b/packages/core/src/serialization/codecs/GraphViewCodec.ts
@@ -32,8 +32,8 @@ import Point from '../../view/geometry/Point';
  */
 export class GraphViewCodec extends ObjectCodec {
   constructor() {
-    const __dummy: any = undefined;
-    super(new GraphView(__dummy));
+    super(new GraphView(undefined!));
+    this.setName('GraphView');
   }
 
   /**
@@ -41,7 +41,7 @@ export class GraphViewCodec extends ObjectCodec {
    * top-level graph node of the recursive encoding.
    */
   encode(enc: any, view: GraphView) {
-    return this.encodeCell(enc, view, <Cell>view.graph.getDataModel().getRoot());
+    return this.encodeCell(enc, view, view.graph.getDataModel().getRoot()!);
   }
 
   /**

--- a/packages/core/src/serialization/register-model-codecs.ts
+++ b/packages/core/src/serialization/register-model-codecs.ts
@@ -23,14 +23,11 @@ import {
 } from './codecs/_model-codecs';
 import Geometry from '../view/geometry/Geometry';
 import Point from '../view/geometry/Point';
-import ObjectCodec from './ObjectCodec';
-import { CodecRegistrationStates, registerBaseCodecs } from './register-shared';
-
-const createObjectCodec = (template: any, name: string): ObjectCodec => {
-  const objectCodec = new ObjectCodec(template);
-  objectCodec.setName(name);
-  return objectCodec;
-};
+import {
+  CodecRegistrationStates,
+  createObjectCodec,
+  registerBaseCodecs,
+} from './register-shared';
 
 /**
  * Register model codecs i.e. codecs used to import/export the Graph Model, see {@link GraphDataModel}.

--- a/packages/core/src/serialization/register-other-codecs.ts
+++ b/packages/core/src/serialization/register-other-codecs.ts
@@ -28,13 +28,19 @@ import {
   StylesheetCodec,
   TerminalChangeCodec,
 } from './codecs/_other-codecs';
+import Rectangle from '../view/geometry/Rectangle';
+import ImageBox from '../view/image/ImageBox';
 import CellAttributeChange from '../view/undoable_changes/CellAttributeChange';
 import CollapseChange from '../view/undoable_changes/CollapseChange';
 import GeometryChange from '../view/undoable_changes/GeometryChange';
 import StyleChange from '../view/undoable_changes/StyleChange';
 import ValueChange from '../view/undoable_changes/ValueChange';
 import VisibleChange from '../view/undoable_changes/VisibleChange';
-import { CodecRegistrationStates, registerBaseCodecs } from './register-shared';
+import {
+  CodecRegistrationStates,
+  createObjectCodec,
+  registerBaseCodecs,
+} from './register-shared';
 import { registerModelCodecs } from './register-model-codecs';
 
 const registerGenericChangeCodecs = () => {
@@ -77,6 +83,10 @@ export const registerCoreCodecs = (force = false) => {
     CodecRegistry.register(new StylesheetCodec());
     CodecRegistry.register(new TerminalChangeCodec());
     registerGenericChangeCodecs();
+
+    // Needed at least by Graph
+    CodecRegistry.register(createObjectCodec(new Rectangle(), 'Rectangle'));
+    CodecRegistry.register(createObjectCodec(new ImageBox(undefined!, 0, 0), 'ImageBox'));
 
     registerModelCodecs(force);
 

--- a/packages/core/src/serialization/register-shared.ts
+++ b/packages/core/src/serialization/register-shared.ts
@@ -40,3 +40,9 @@ export const registerBaseCodecs = (force = false) => {
     CodecRegistrationStates.base = true;
   }
 };
+
+export const createObjectCodec = (template: any, name: string): ObjectCodec => {
+  const objectCodec = new ObjectCodec(template);
+  objectCodec.setName(name);
+  return objectCodec;
+};


### PR DESCRIPTION
Doing an export/encode of a Graph generated an error "Maximum call stack size exceeded. RangeError: Maximum call stack size exceeded".

In `GraphCodec`, the list of excluded fields was incorrect:
- `selection` was in the list, but this field doesn't exist, it is named `selectionModel`.
  The bug already existed in mxGraph https://github.com/jgraph/mxgraph/blob/v4.2.2/javascript/src/js/io/mxGraphCodec.js#L26
- `plugins` was missing. There is currently no codec for Plugin so it is not supported for now

Tests have been added to validate that the Graph import/export works.

In all existing tests involving Codecs, unregister all codecs before and after to ensure there is no side effects between tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added tests for serialization and deserialization of graphs and their constituents, ensuring accurate XML import/export.

- **Bug Fixes**
  - Improved test reliability by resetting codec registrations before and after tests to prevent side effects.

- **Refactor**
  - Centralized codec creation logic for better maintainability and code reuse.
  - Simplified and clarified codec constructors and encoding logic for graph and view serialization.

- **Chores**
  - Registered codecs for additional core types to support broader serialization scenarios.
  - Introduced a shared utility for creating object codecs to streamline codec registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->