### PR TITLE
feat: let serialize `BaseGraph` with Codecs

### DIFF
--- a/packages/core/src/serialization/codecs/BaseGraphCodec.ts
+++ b/packages/core/src/serialization/codecs/BaseGraphCodec.ts
@@ -1,7 +1,5 @@
 /*
-Copyright 2024-present The maxGraph project Contributors
-Copyright (c) 2006-2015, JGraph Ltd
-Copyright (c) 2006-2015, Gaudenz Alder
+Copyright 2025-present The maxGraph project Contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,23 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { BaseGraph } from '../../view/BaseGraph';
 import ObjectCodec from '../ObjectCodec';
-import { Graph } from '../../view/Graph';
-
-export const excludedFields = [
-  'graphListeners',
-  'eventListeners',
-  'view',
-  'container',
-  'cellRenderer',
-  'editor',
-  'selectionModel',
-  'plugins',
-];
+import { excludedFields } from './GraphCodec';
 
 /**
- * Codec for {@link Graph}s.
- * This class is created and registered dynamically at load time and used implicitly via {@link Codec} and the {@link CodecRegistry}.
+ * Codec for {@link BaseGraph}s.
  *
  * Transient Fields:
  *
@@ -47,10 +34,9 @@ export const excludedFields = [
  *
  * @category Serialization with Codecs
  */
-export class GraphCodec extends ObjectCodec {
+export class BaseGraphCodec extends ObjectCodec {
   constructor() {
-    // Do not  load default plugins, plugins are not serialized
-    super(new Graph(undefined, undefined, []), excludedFields);
-    this.setName('Graph');
+    super(new BaseGraph(), excludedFields);
+    this.setName('BaseGraph');
   }
 }

--- a/packages/core/src/serialization/codecs/_other-codecs.ts
+++ b/packages/core/src/serialization/codecs/_other-codecs.ts
@@ -15,9 +15,10 @@ limitations under the License.
 */
 
 export * from './editor';
+export * from './BaseGraphCodec';
 export * from './ChildChangeCodec';
 export * from './GenericChangeCodec';
-export * from './GraphCodec';
+export { GraphCodec } from './GraphCodec';
 export * from './GraphViewCodec';
 export * from './RootChangeCodec';
 export * from './StylesheetCodec';

--- a/packages/core/src/serialization/register-other-codecs.ts
+++ b/packages/core/src/serialization/register-other-codecs.ts
@@ -16,6 +16,7 @@ limitations under the License.
 
 import CodecRegistry from './CodecRegistry';
 import {
+  BaseGraphCodec,
   ChildChangeCodec,
   EditorCodec,
   EditorKeyHandlerCodec,
@@ -77,6 +78,7 @@ const registerGenericChangeCodecs = () => {
 export const registerCoreCodecs = (force = false) => {
   if (!CodecRegistrationStates.core || force) {
     CodecRegistry.register(new ChildChangeCodec());
+    CodecRegistry.register(new BaseGraphCodec());
     CodecRegistry.register(new GraphCodec());
     CodecRegistry.register(new GraphViewCodec());
     CodecRegistry.register(new RootChangeCodec());


### PR DESCRIPTION
Covers #760

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for serializing and deserializing BaseGraph instances.
- **Refactor**
  - Improved test coverage by consolidating and parameterizing graph serialization tests.
  - Streamlined the management of excluded fields in graph serialization codecs for better maintainability.
- **Chores**
  - Updated internal exports and registration logic to include the new BaseGraph serialization codec.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->