### PR TITLE
feat!: improve tree-shaking of `Perimeter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ For more details on the contents of a release, see [the GitHub release page] (ht
 
 _**Note:** Yet to be released breaking changes appear here._
 
+**Breaking Changes**:
+- `Perimeter` has been changed from a value object to a namespace. This has minimal impact for most applications that only read perimeter values.
+  The only breaking change affects applications that modify Perimeter properties (add/update/remove values): this is no longer possible. Instead, create your own perimeter implementation and register it.
+
 ## 0.18.0
 
 Release date: `2025-04-26`

--- a/packages/core/src/view/style/builtin-style-elements.ts
+++ b/packages/core/src/view/style/builtin-style-elements.ts
@@ -15,7 +15,13 @@ limitations under the License.
 */
 
 export { EdgeStyle } from './edge';
-export { Perimeter } from './perimeter';
+
+/**
+ * Provides various perimeter functions to be used in a style as the value of {@link CellStateStyle.perimeter}.
+ *
+ * @category Perimeter
+ */
+export * as Perimeter from './perimeter';
 
 /**
  * Includes all builtins edge markers which can be registered in {@link MarkerShape}.

--- a/packages/core/src/view/style/perimeter/index.ts
+++ b/packages/core/src/view/style/perimeter/index.ts
@@ -16,40 +16,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { EllipsePerimeter as EllipsePerimeterFunction } from './EllipsePerimeter';
-import { HexagonPerimeter as HexagonPerimeterFunction } from './HexagonPerimeter';
-import { RectanglePerimeter as RectanglePerimeterFunction } from './RectanglePerimeter';
-import { RhombusPerimeter as RhombusPerimeterFunction } from './RhombusPerimeter';
-import { TrianglePerimeter as TrianglePerimeterFunction } from './TrianglePerimeter';
-
-/**
- * Provides various perimeter functions to be used in a style as the value of {@link CellStateStyle.perimeter}.
- *
- * @category Perimeter
- */
-export const Perimeter = {
-  /**
-   * Describes a rectangular perimeter.
-   */
-  RectanglePerimeter: RectanglePerimeterFunction,
-
-  /**
-   * Describes an elliptic perimeter.
-   */
-  EllipsePerimeter: EllipsePerimeterFunction,
-
-  /**
-   * Describes a rhombus (aka diamond) perimeter.
-   */
-  RhombusPerimeter: RhombusPerimeterFunction,
-
-  /**
-   * Describes a triangle perimeter.
-   */
-  TrianglePerimeter: TrianglePerimeterFunction,
-
-  /**
-   * Describes a hexagon perimeter.
-   */
-  HexagonPerimeter: HexagonPerimeterFunction,
-};
+export { EllipsePerimeter } from './EllipsePerimeter';
+export { HexagonPerimeter } from './HexagonPerimeter';
+export { RectanglePerimeter } from './RectanglePerimeter';
+export { RhombusPerimeter } from './RhombusPerimeter';
+export { TrianglePerimeter } from './TrianglePerimeter';

--- a/packages/core/src/view/style/register.ts
+++ b/packages/core/src/view/style/register.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { EDGESTYLE, PERIMETER } from '../../util/Constants';
 import { EdgeStyle } from './edge';
-import { Perimeter } from './perimeter';
+import { Perimeter } from './builtin-style-elements';
 import StyleRegistry from './StyleRegistry';
 import MarkerShape from './marker/EdgeMarkerRegistry';
 import { createArrow, createOpenArrow, diamond, oval } from './marker/edge-markers';

--- a/packages/ts-example-selected-features/vite.config.js
+++ b/packages/ts-example-selected-features/vite.config.js
@@ -27,7 +27,7 @@ export default defineConfig(({ mode }) => {
           },
         },
       },
-      chunkSizeWarningLimit: 369, // @maxgraph/core
+      chunkSizeWarningLimit: 382, // @maxgraph/core
     },
   };
 });


### PR DESCRIPTION
Previously, `Perimeter` was a value object. So, most bundlers included the whole object even if only some values was
used in the application (i.e. the only perimeters registered in StyleRegistry).
Notice that some bundlers, like Rollup, was able to only keep the values effectively used by the application.

`Perimeter` is no longer an object, but a namespace, so all bundlers should now able to only keep the perimeters really
used by the application.

BREAKING CHANGES: `Perimeter` has been changed from a value object to a namespace. This has minimal impact for most applications that only read perimeter values.
The only breaking change affects applications that modify Perimeter properties (add/update/remove values): this is no longer possible.
Instead, create your own perimeter implementation and register it.

## Notes

Covers #759


### Impact on application size

> [!NOTE]
> JS examples use Webpack, TS examples use Vite (Vite/Rollup does better tree-shaking!)
> - the JS and TS examples doesn't cover the same use case
> - the size mentioned here is the one of the whole application in the JS examples and the one of the maxGraph chunk in the TS examples


Example  | 0.18.0 | This PR
---- | ---- | ----
js-example | 476.1  kB | 475.92  kB
js-example-selected-features | 423.45 kB | 415.59 kB
js-example-without-default | 347.86  kB | 347.83  kB
ts-example | 439.30 kB | 439.15 kB
ts-example-selected-features | 381.15 kB | 381.14  kB
ts-example-without-default |  330.38 kB |  330.38 kB

#### Analysis

In the examples "without-default", this PR has no impact because Perimeter is not used, so it was already tree-shaked.

The PR has no impact on "ts-example-selected-features".
Vite uses rollup to bundle and it was already shrinking the unused properties of the Perimeter value object.
This has been confirmed on the rollup example of the https://github.com/maxGraph/maxGraph-integration-examples/ repository.

Here is what rollup bundled with the former implementation (when disabling minification to make the code readable):

```js
const RectanglePerimeter=...
const EllipsePerimeter=...

const Perimeter = {
  /**
   * Describes a rectangular perimeter.
   */
  RectanglePerimeter,
  /**
   * Describes an elliptic perimeter.
   */
  EllipsePerimeter
};

``` 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a "Breaking Changes" section to the changelog, highlighting updates to the Perimeter entity.
- **Refactor**
  - Simplified how perimeter functions are exported, moving from a grouped object to individual named exports.
  - Updated export style for Perimeter to use a namespace export with improved documentation.
  - Adjusted import paths to align with the new export structure.
- **Chores**
  - Increased the chunk size warning limit in the Vite configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->