### PR TITLE
fix: correctly convert "arc" attributes to boolean in StencilShape

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -675,7 +675,17 @@ export type CellStateStyle = {
    */
   shadow?: boolean;
   /**
-   * The possible values are all names of the shapes registered with {@link CellRenderer.registerShape}.
+   * The name of the shape to be used for the cell.
+   *
+   * The actual implementation of the shape is determined by the {@link CellRenderer.createShape} method:
+   * - first, it looks for a shape in {@link StencilShapeRegistry},
+   * - if not found, it looks for a shape in the {@link CellRenderer} registry.
+   *
+   * If no shape is specified, the default shape is used:
+   * - for edges, this is {@link CellRenderer.defaultEdgeShape}
+   * - for vertices, this is {@link CellRenderer.defaultVertexShape}
+   *
+   * The possible values are all names of the shapes registered with {@link CellRenderer.registerShape} and {@link StencilShapeRegistry.addStencil}.
    * This includes {@link ShapeValue} values and custom names that have been registered.
    */
   shape?: StyleShapeValue;

--- a/packages/core/src/view/geometry/stencil/StencilShape.ts
+++ b/packages/core/src/view/geometry/stencil/StencilShape.ts
@@ -58,6 +58,8 @@ export const StencilShapeConfig = {
   defaultLocalized: false,
 };
 
+const toBoolean = (value: string | null) => value !== '0' && value !== 'false';
+
 /**
  * Implements a generic shape which is based on an XML node as a description.
  */
@@ -465,8 +467,8 @@ class StencilShape extends Shape {
           Number(node.getAttribute('rx')) * sx,
           Number(node.getAttribute('ry')) * sy,
           Number(node.getAttribute('x-axis-rotation')),
-          Boolean(node.getAttribute('large-arc-flag')),
-          Boolean(node.getAttribute('sweep-flag')),
+          toBoolean(node.getAttribute('large-arc-flag')),
+          toBoolean(node.getAttribute('sweep-flag')),
           x0 + Number(node.getAttribute('x')) * sx,
           y0 + Number(node.getAttribute('y')) * sy
         );

--- a/packages/core/src/view/geometry/stencil/StencilShape.ts
+++ b/packages/core/src/view/geometry/stencil/StencilShape.ts
@@ -58,10 +58,15 @@ export const StencilShapeConfig = {
   defaultLocalized: false,
 };
 
-const toBoolean = (value: string | null) => value !== '0' && value !== 'false';
+// To manage the following attribute described in stencils.xsd
+// <xs:attribute name="large-arc-flag" use="required" type="xs:decimal"/>
+// <xs:attribute name="sweep-flag" use="required" type="xs:decimal"/>
+const toBoolean = (value: string | null) => value !== '0';
 
 /**
  * Implements a generic shape which is based on an XML node as a description.
+ *
+ * The XSD for the stencil description is available in the `stencils.xsd` file.
  */
 class StencilShape extends Shape {
   constructor(desc: Element) {

--- a/packages/core/src/view/geometry/stencil/StencilShapeRegistry.ts
+++ b/packages/core/src/view/geometry/stencil/StencilShapeRegistry.ts
@@ -25,19 +25,21 @@ type Stencils = {
 /**
  * A singleton class that provides a registry for stencils and the methods for painting those stencils onto a canvas or into a DOM.
  *
- * Code to add stencils:
+ * Here is an example showing how to add stencils:
  * ```javascript
- * const response = load('test/stencils.xml');
- * const root = response.getDocumentElement();
+ * const response = requestUtils.load('test/stencils.xml');
+ * const root = response.getDocumentElement(); // <shapes> node
  * let shape = root.firstChild;
  *
  * while (shape) {
- *   if (shape.nodeType === mxConstants.NODETYPE_ELEMENT) {
- *    StencilShapeRegistry.addStencil(shape.getAttribute('name'), new mxStencil(shape));
+ *   if (shape.nodeType === constants.NODETYPE.ELEMENT) {
+ *    StencilShapeRegistry.addStencil(shape.getAttribute('name'), new StencilShape(shape));
  *  }
  *
  *  shape = shape.nextSibling;
  * }
+ *
+ * The XSD for the stencil description is available in the `stencils.xsd` file.
  * ```
  */
 class StencilShapeRegistry {

--- a/packages/core/src/view/mixins/PanningMixin.type.ts
+++ b/packages/core/src/view/mixins/PanningMixin.type.ts
@@ -109,7 +109,7 @@ declare module '../AbstractGraph' {
     /**
      * Specifies if panning should be enabled. This implementation updates {@link PanningHandler.panningEnabled}.
      *
-     **IMPORTANT**: only has an effect if the {@link PanningHandler} plugin is available.
+     * **IMPORTANT**: only has an effect if the {@link PanningHandler} plugin is available.
      *
      * @param enabled Boolean indicating if panning should be enabled.
      */

--- a/packages/html/stories/Stencils.stories.ts
+++ b/packages/html/stories/Stencils.stories.ts
@@ -21,7 +21,6 @@ import {
   CellRenderer,
   type CellState,
   ConnectionHandler,
-  constants,
   DomHelpers,
   EdgeHandler,
   getDefaultPlugins,
@@ -48,6 +47,7 @@ import {
   rubberBandValues,
 } from './shared/args.js';
 import { createGraphContainer } from './shared/configure.js';
+import { isElement } from './shared/utils.ts';
 import '@maxgraph/core/css/common.css'; // style required by RubberBand
 
 export default {
@@ -172,10 +172,6 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   const req = requestUtils.load('stencils.xml');
   const root = req.getDocumentElement();
   let shape = root!.firstChild;
-
-  function isElement(node: ChildNode): node is Element {
-    return node.nodeType === constants.NODETYPE.ELEMENT;
-  }
 
   while (shape != null) {
     if (isElement(shape)) {

--- a/packages/html/stories/Stencils.stories.ts
+++ b/packages/html/stories/Stencils.stories.ts
@@ -171,7 +171,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   // Loads the stencils into the registry
   const req = requestUtils.load('stencils.xml');
   const root = req.getDocumentElement();
-  let shape = root!.firstChild;
+  let shape = root!.firstChild; // <shapes> node
 
   while (shape != null) {
     if (isElement(shape)) {

--- a/packages/html/stories/StencilsViewer.stories.ts
+++ b/packages/html/stories/StencilsViewer.stories.ts
@@ -1,0 +1,140 @@
+/*
+Copyright 2021-present The maxGraph project Contributors
+Copyright (c) 2006-2020, JGraph Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {
+  BaseGraph,
+  DomHelpers,
+  FitPlugin,
+  InternalEvent,
+  StencilShape,
+  StencilShapeRegistry,
+  xmlUtils,
+} from '@maxgraph/core';
+import {
+  contextMenuTypes,
+  contextMenuValues,
+  globalTypes,
+  globalValues,
+  rubberBandTypes,
+  rubberBandValues,
+} from './shared/args.js';
+import { createGraphContainer } from './shared/configure.js';
+import { isElement } from './shared/utils.ts';
+import '@maxgraph/core/css/common.css';
+
+export default {
+  title: 'Shapes/StencilsViewer',
+  argTypes: {
+    ...contextMenuTypes,
+    ...globalTypes,
+    ...rubberBandTypes,
+  },
+  args: {
+    ...contextMenuValues,
+    ...globalValues,
+    ...rubberBandValues,
+  },
+};
+
+// In the future, it will be possible to edit the stencil in a textarea provided by the story.
+const stencil = `<shape aspect="fixed" h="100" name="WebServerUrlInfo" strokewidth="inherit" w="100">
+    <connections />
+    <foreground>
+      <ellipse h="100" w="100" x="0" y="0" />
+      <fillstroke />
+      <path />
+      <fillstroke />
+      <path>
+        <move x="50" y="0" />
+        <line x="50" y="100" />
+        <move x="100" y="50" />
+        <line x="0" y="50" />
+        <move x="50" y="0" />
+        <arc large-arc-flag="0" rx="60" ry="60" sweep-flag="1" x="50" x-axis-rotation="0" y="100" />
+        <arc large-arc-flag="0" rx="60" ry="60" sweep-flag="1" x="50" x-axis-rotation="0" y="0" />
+        <close />
+        <move x="15" y="85" />
+        <arc large-arc-flag="0" rx="60" ry="60" sweep-flag="1" x="85" x-axis-rotation="0" y="85" />
+        <move x="15" y="15" />
+        <arc large-arc-flag="0" rx="60" ry="60" sweep-flag="0" x="85" x-axis-rotation="0" y="15" />
+      </path>
+      <stroke />
+    </foreground>
+  </shape>`;
+
+const Template = ({ label, ...args }: Record<string, string>) => {
+  const div = document.createElement('div');
+  const container = createGraphContainer(args);
+  div.appendChild(container);
+
+  // Loads the stencils into the registry
+  const doc = xmlUtils.parseXml(stencil);
+  // For a more robust solution, ensure the first node is named "shape"
+  const shape = doc.documentElement;
+
+  if (isElement(shape)) {
+    const name = shape.getAttribute('name')!;
+    StencilShapeRegistry.addStencil(
+      name, // the "name" attribute is always set
+      new StencilShape(shape)
+    );
+  }
+
+  if (!args.contextMenu) InternalEvent.disableContextMenu(container);
+
+  // Creates the graph inside the given container
+  const graph = new BaseGraph({ container, plugins: [FitPlugin] });
+
+  // Adds cells to the model in a single step
+  graph.batchUpdate(() => {
+    graph.insertVertex({
+      position: [200, 20],
+      size: [200, 200],
+      style: {
+        shape: 'WebServerUrlInfo', // for a more robust solution, use the "name" attribute
+      },
+    });
+  });
+
+  const buttons = document.createElement('div');
+  div.appendChild(buttons);
+
+  buttons.appendChild(
+    DomHelpers.button('Fit Center', function () {
+      graph.getPlugin<FitPlugin>('fit')?.fitCenter();
+    })
+  );
+
+  for (let i = 0; i < 4; i++) {
+    buttons.appendChild(document.createTextNode('\u00a0'));
+  }
+
+  buttons.appendChild(
+    DomHelpers.button('+', function () {
+      graph.zoomIn();
+    })
+  );
+  buttons.appendChild(
+    DomHelpers.button('-', function () {
+      graph.zoomOut();
+    })
+  );
+
+  return div;
+};
+
+export const Default = Template.bind({});

--- a/packages/html/stories/StencilsViewer.stories.ts
+++ b/packages/html/stories/StencilsViewer.stories.ts
@@ -20,6 +20,7 @@ import {
   DomHelpers,
   FitPlugin,
   InternalEvent,
+  PanningHandler,
   StencilShape,
   StencilShapeRegistry,
   xmlUtils,
@@ -51,7 +52,11 @@ export default {
 };
 
 // In the future, it will be possible to edit the stencil in a textarea provided by the story.
-const stencil = `<shape aspect="fixed" h="100" name="WebServerUrlInfo" strokewidth="inherit" w="100">
+// The design could be similar to the screenshot provided in https://github.com/maxGraph/maxGraph/issues/786
+// The XML content could be validated against the XSD schema (stencils.xsd), and the user could be notified if there are any errors.
+
+const stencil = `<!-- Taken from https://github.com/maxGraph/maxGraph/issues/786 to demonstrate usage of "arc" -->
+  <shape aspect="fixed" h="100" name="WebServerUrlInfo" strokewidth="inherit" w="100">
     <connections />
     <foreground>
       <ellipse h="100" w="100" x="0" y="0" />
@@ -97,7 +102,8 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   if (!args.contextMenu) InternalEvent.disableContextMenu(container);
 
   // Creates the graph inside the given container
-  const graph = new BaseGraph({ container, plugins: [FitPlugin] });
+  const graph = new BaseGraph({ container, plugins: [FitPlugin, PanningHandler] });
+  graph.setPanning(true);
 
   // Adds cells to the model in a single step
   graph.batchUpdate(() => {

--- a/packages/html/stories/shared/utils.ts
+++ b/packages/html/stories/shared/utils.ts
@@ -1,0 +1,20 @@
+/*
+Copyright 2024-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { constants } from '@maxgraph/core';
+
+export const isElement = (node: ChildNode): node is Element =>
+  node.nodeType === constants.NODETYPE.ELEMENT;


### PR DESCRIPTION
When set, the `large-arc-flag` and `sweep-flag` attributes were always considered as true, so the rendering was incorrect.
This is a regression introduced during the migration from `mxGraph`.

A new story has been added to confirm that the problem is now fixed.


## Notes

Closes #786



## Screenshots

Using the new story, 

before | now
---- | ----
![StencilsViewer story - before the fix](https://github.com/user-attachments/assets/9c5689c3-fde5-4e20-b684-a63840822afc) | ![StencilsViewer story - with the fix](https://github.com/user-attachments/assets/d977e7af-c88b-4c16-ab67-95d54ffc1b75)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a new Storybook story for visualizing and interacting with custom stencil shapes, including zoom and fit controls.
  - Introduced a utility function for improved node type checking in stories.

- **Bug Fixes**
  - Improved the interpretation of arc-related flags in stencil shapes, ensuring correct handling of string values for boolean attributes.

- **Chores**
  - Refactored code to use shared utilities and removed unnecessary dependencies in story files.
  - Enhanced documentation comments for shape properties and stencil registry usage for better clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->