### PR TITLE
test: improve the Graph tests

### DIFF
--- a/packages/core/__tests__/view/Graph.test.ts
+++ b/packages/core/__tests__/view/Graph.test.ts
@@ -122,7 +122,10 @@ describe('createEdgeHandler', () => {
   ])('Expect EdgeHandler for edgeStyle: %s', (_name, edgeStyle) => {
     const graph = new BaseGraph();
     const cellState = createCellState(graph, true);
-    expect(graph.createEdgeHandler(cellState, edgeStyle)).toBeInstanceOf(EdgeHandler);
+    const edgeHandler = graph.createEdgeHandler(cellState, edgeStyle);
+    expect(edgeHandler).toBeInstanceOf(EdgeHandler);
+    expect(edgeHandler).not.toBeInstanceOf(EdgeSegmentHandler);
+    expect(edgeHandler).not.toBeInstanceOf(ElbowEdgeHandler);
   });
 });
 

--- a/packages/core/__tests__/view/Graph.test.ts
+++ b/packages/core/__tests__/view/Graph.test.ts
@@ -17,6 +17,7 @@ limitations under the License.
 import { describe, expect, test } from '@jest/globals';
 import {
   AbstractGraph,
+  BaseGraph,
   Cell,
   CellState,
   EdgeHandler,
@@ -28,39 +29,41 @@ import {
   RectangleShape,
   VertexHandler,
 } from '../../src';
-import { createGraphWithoutPlugins } from '../utils';
 
 describe('isOrthogonal', () => {
   test('Style of the CellState, orthogonal: true', () => {
-    const graph = createGraphWithoutPlugins();
+    const graph = new BaseGraph();
     const cellState = new CellState(graph.view, null, { orthogonal: true });
     expect(graph.isOrthogonal(cellState)).toBeTruthy();
   });
 
   test('No style in the CellState', () => {
-    const graph = createGraphWithoutPlugins();
+    const graph = new BaseGraph();
     expect(graph.isOrthogonal(new CellState())).toBeFalsy();
   });
 
   test.each([undefined, null])('Style of the CellState, orthogonal: %s', (orthogonal) => {
-    const graph = createGraphWithoutPlugins();
+    const graph = new BaseGraph();
     const cellState = new CellState(graph.view, null, { orthogonal });
     expect(graph.isOrthogonal(cellState)).toBeFalsy();
   });
 
   test.each([
+    ['EntityRelation', EdgeStyle.EntityRelation],
     ['ElbowConnector', EdgeStyle.ElbowConnector],
     ['ManhattanConnector', EdgeStyle.ManhattanConnector],
     ['OrthogonalConnector', EdgeStyle.OrthConnector],
+    ['SegmentConnector', EdgeStyle.SegmentConnector],
     ['SideToSide', EdgeStyle.SideToSide],
+    ['TopToBottom', EdgeStyle.TopToBottom],
   ])('Style of the CellState, edgeStyle: %s', (_name, edgeStyle) => {
-    const graph = createGraphWithoutPlugins();
+    const graph = new BaseGraph();
     const cellState = new CellState(graph.view, null, { edgeStyle });
     expect(graph.isOrthogonal(cellState)).toBeTruthy();
   });
 
   test('Style of the CellState, edgeStyle: Loop', () => {
-    const graph = createGraphWithoutPlugins();
+    const graph = new BaseGraph();
     const cellState = new CellState(graph.view, null, {
       edgeStyle: EdgeStyle.Loop,
     });
@@ -85,7 +88,7 @@ describe('createEdgeHandler', () => {
     ['SideToSide', EdgeStyle.SideToSide],
     ['TopToBottom', EdgeStyle.TopToBottom],
   ])('Expect ElbowEdgeHandler for edgeStyle: %s', (_name, edgeStyle) => {
-    const graph = createGraphWithoutPlugins();
+    const graph = new BaseGraph();
     const cellState = createCellState(graph, true);
     expect(graph.createEdgeHandler(cellState, edgeStyle)).toBeInstanceOf(
       ElbowEdgeHandler
@@ -97,7 +100,7 @@ describe('createEdgeHandler', () => {
     ['OrthogonalConnector', EdgeStyle.OrthConnector],
     ['SegmentConnector', EdgeStyle.SegmentConnector],
   ])('Expect EdgeSegmentHandler for edgeStyle: %s', (_name, edgeStyle) => {
-    const graph = createGraphWithoutPlugins();
+    const graph = new BaseGraph();
     const cellState = createCellState(graph, true);
     expect(graph.createEdgeHandler(cellState, edgeStyle)).toBeInstanceOf(
       EdgeSegmentHandler
@@ -108,7 +111,7 @@ describe('createEdgeHandler', () => {
     ['EntityRelation', EdgeStyle.EntityRelation],
     ['null', null],
   ])('Expect EdgeHandler for edgeStyle: %s', (_name, edgeStyle) => {
-    const graph = createGraphWithoutPlugins();
+    const graph = new BaseGraph();
     const cellState = createCellState(graph, true);
     expect(graph.createEdgeHandler(cellState, edgeStyle)).toBeInstanceOf(EdgeHandler);
   });
@@ -116,13 +119,13 @@ describe('createEdgeHandler', () => {
 
 describe('createHandler', () => {
   test('Expect VertexHandler', () => {
-    const graph = createGraphWithoutPlugins();
+    const graph = new BaseGraph();
     const cellState = createCellState(graph, false);
     expect(graph.createHandler(cellState)).toBeInstanceOf(VertexHandler);
   });
 
   test('Expect EdgeHandler', () => {
-    const graph = createGraphWithoutPlugins();
+    const graph = new BaseGraph();
     const cellState = createCellState(graph, true);
     expect(graph.createHandler(cellState)).toBeInstanceOf(EdgeHandler);
   });

--- a/packages/core/__tests__/view/Graph.test.ts
+++ b/packages/core/__tests__/view/Graph.test.ts
@@ -23,12 +23,17 @@ import {
   EdgeHandler,
   EdgeSegmentHandler,
   EdgeStyle,
+  type EdgeStyleFunction,
   ElbowEdgeHandler,
   Point,
   Rectangle,
   RectangleShape,
   VertexHandler,
 } from '../../src';
+
+const customEdgeStyle: EdgeStyleFunction = () => {
+  // do nothing, we just need a custom implementation that is not registered by default
+};
 
 describe('isOrthogonal', () => {
   test('Style of the CellState, orthogonal: true', () => {
@@ -62,10 +67,13 @@ describe('isOrthogonal', () => {
     expect(graph.isOrthogonal(cellState)).toBeTruthy();
   });
 
-  test('Style of the CellState, edgeStyle: Loop', () => {
+  test.each([
+    ['custom', customEdgeStyle],
+    ['Loop', EdgeStyle.Loop],
+  ])('Style of the CellState, edgeStyle: %s', (_name, edgeStyle) => {
     const graph = new BaseGraph();
     const cellState = new CellState(graph.view, null, {
-      edgeStyle: EdgeStyle.Loop,
+      edgeStyle: edgeStyle,
     });
     expect(graph.isOrthogonal(cellState)).toBeFalsy();
   });
@@ -108,6 +116,7 @@ describe('createEdgeHandler', () => {
   });
 
   test.each([
+    ['custom', customEdgeStyle],
     ['EntityRelation', EdgeStyle.EntityRelation],
     ['null', null],
   ])('Expect EdgeHandler for edgeStyle: %s', (_name, edgeStyle) => {


### PR DESCRIPTION
- Replace `Graph` with `BaseGraph` in all tests
- This reveals that these methods don't use registered styles but contain
  hardcoded EdgeStyle implementations
- Prepares for future refactoring to use configuration instead of hardcoded
  edge style logic
- Also test all EdgeStyles with `isOrthogonal` for consistency


## Notes

Covers #767




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated graph-related tests to use direct graph instantiation.
  - Expanded test coverage for edge styles in orthogonality checks.
  - Enhanced edge handler tests with additional edge styles and improved handler type verifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->