### PR TITLE
refactor!: replace NODETYPE enum by NODE_TYPE value object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ _**Note:** Yet to be released breaking changes appear here._
   - `constants.RENDERING_HINT`: no replacement as it wasn't used
   - `constants.SHAPE` --> `ShapeValue`
   - `constants.TEXT_DIRECTION` --> `TextDirectionValue`
+- The `constants.NODETYPE` enum has been removed and replaced by the `constants.NODE_TYPE` value object.
+  The former `DOCUMENTTYPE` enum member has been renamed to `DOCUMENT_TYPE`.
 
 ## 0.19.0
 

--- a/packages/core/src/gui/MaxWindow.ts
+++ b/packages/core/src/gui/MaxWindow.ts
@@ -22,7 +22,7 @@ import EventSource from '../view/event/EventSource';
 import { fit, getCurrentStyle } from '../util/styleUtils';
 import InternalEvent from '../view/event/InternalEvent';
 import Client from '../Client';
-import { NODETYPE } from '../util/Constants';
+import { NODE_TYPE } from '../util/Constants';
 import { write } from '../util/domUtils';
 import { getClientX, getClientY } from '../util/EventUtils';
 
@@ -371,7 +371,7 @@ export default class MaxWindow extends EventSource {
     while (child != null) {
       const next = child.nextSibling;
 
-      if (child.nodeType === NODETYPE.TEXT) {
+      if (child.nodeType === NODE_TYPE.TEXT) {
         (<Element>child.parentNode).removeChild(child);
       }
 

--- a/packages/core/src/internal/utils.ts
+++ b/packages/core/src/internal/utils.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { NODETYPE } from '../util/Constants';
+import { NODE_TYPE } from '../util/Constants';
 import { UserObject } from './types';
 import { GlobalConfig } from '../util/config';
 
@@ -31,7 +31,7 @@ export const doEval = (expression: string): any => {
  * @private
  */
 export const isElement = (node?: Node | UserObject | null): node is Element =>
-  node?.nodeType === NODETYPE.ELEMENT;
+  node?.nodeType === NODE_TYPE.ELEMENT;
 
 /**
  * @private not part of the public API, can be removed or changed without prior notice

--- a/packages/core/src/util/Constants.ts
+++ b/packages/core/src/util/Constants.ts
@@ -68,21 +68,6 @@ export const SHADOW_OFFSET_Y = 3;
 /** Default value of {@link StyleDefaultsConfig.shadowOpacity}. */
 export const SHADOW_OPACITY = 1;
 
-export enum NODETYPE {
-  ELEMENT = 1,
-  ATTRIBUTE = 2,
-  TEXT = 3,
-  CDATA = 4,
-  ENTITY_REFERENCE = 5,
-  ENTITY = 6,
-  PROCESSING_INSTRUCTION = 7,
-  COMMENT = 8,
-  DOCUMENT = 9,
-  DOCUMENTTYPE = 10,
-  DOCUMENT_FRAGMENT = 11,
-  NOTATION = 12,
-}
-
 /**
  * Defines the vertical offset for the tooltip.
  * Default is 16.
@@ -438,3 +423,21 @@ export const DIRECTION_MASK = {
   /** All directions. */
   ALL: 15,
 };
+
+/**
+ * The values of {@link Node.nodeType}
+ */
+export const NODE_TYPE = {
+  ELEMENT: 1,
+  ATTRIBUTE: 2,
+  TEXT: 3,
+  CDATA: 4,
+  ENTITY_REFERENCE: 5,
+  ENTITY: 6,
+  PROCESSING_INSTRUCTION: 7,
+  COMMENT: 8,
+  DOCUMENT: 9,
+  DOCUMENT_TYPE: 10,
+  DOCUMENT_FRAGMENT: 11,
+  NOTATION: 12,
+} as const;

--- a/packages/core/src/util/StringUtils.ts
+++ b/packages/core/src/util/StringUtils.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { NODETYPE } from './Constants';
+import { NODE_TYPE } from './Constants';
 import { getTextContent } from './domUtils';
 
 import type { Properties } from '../types';
@@ -116,7 +116,7 @@ export const replaceTrailingNewlines = (str: string, pattern: string): string =>
 export const removeWhitespace = (node: HTMLElement, before: boolean) => {
   let tmp = before ? node.previousSibling : node.nextSibling;
 
-  while (tmp != null && tmp.nodeType === NODETYPE.TEXT) {
+  while (tmp != null && tmp.nodeType === NODE_TYPE.TEXT) {
     const next = before ? tmp.previousSibling : tmp.nextSibling;
     const text = getTextContent(<Text>tmp);
 

--- a/packages/core/src/util/domUtils.ts
+++ b/packages/core/src/util/domUtils.ts
@@ -268,8 +268,6 @@ export const getChildNodes = (
   node: Element,
   nodeType: number = NODE_TYPE.ELEMENT
 ): ChildNode[] => {
-  nodeType = nodeType || NODE_TYPE.ELEMENT;
-
   const children = [];
   let tmp = node.firstChild;
 

--- a/packages/core/src/util/domUtils.ts
+++ b/packages/core/src/util/domUtils.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { NODETYPE } from './Constants';
+import { NODE_TYPE } from './Constants';
 
 /**
  * Returns the text content of the specified node.
@@ -262,13 +262,13 @@ export const isAncestorNode = (ancestor: Element, child: Element | null) => {
  * Returns an array of child nodes that are of the given node type.
  *
  * @param node Parent DOM node to return the children from.
- * @param nodeType Optional node type to return. Default is {@link NODETYPE.ELEMENT}.
+ * @param nodeType Optional node type to return. Default is {@link NODE_TYPE.ELEMENT}.
  */
 export const getChildNodes = (
   node: Element,
-  nodeType: number = NODETYPE.ELEMENT
+  nodeType: number = NODE_TYPE.ELEMENT
 ): ChildNode[] => {
-  nodeType = nodeType || NODETYPE.ELEMENT;
+  nodeType = nodeType || NODE_TYPE.ELEMENT;
 
   const children = [];
   let tmp = node.firstChild;

--- a/packages/core/src/util/xmlUtils.ts
+++ b/packages/core/src/util/xmlUtils.ts
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { NODETYPE, NS_SVG } from './Constants';
+import { NODE_TYPE, NS_SVG } from './Constants';
 import Point from '../view/geometry/Point';
 import type Cell from '../view/cell/Cell';
 import type { AbstractGraph } from '../view/AbstractGraph';
@@ -147,7 +147,7 @@ export const getPrettyXml = (
       }
     }
 
-    if (node.nodeType === NODETYPE.DOCUMENT) {
+    if (node.nodeType === NODE_TYPE.DOCUMENT) {
       result.push(
         getPrettyXml(
           (<Document>(<unknown>node)).documentElement,
@@ -157,7 +157,7 @@ export const getPrettyXml = (
           ns
         )
       );
-    } else if (node.nodeType === NODETYPE.DOCUMENT_FRAGMENT) {
+    } else if (node.nodeType === NODE_TYPE.DOCUMENT_FRAGMENT) {
       let tmp = node.firstChild;
 
       if (tmp != null) {
@@ -166,19 +166,19 @@ export const getPrettyXml = (
           tmp = tmp.nextSibling;
         }
       }
-    } else if (node.nodeType === NODETYPE.COMMENT) {
+    } else if (node.nodeType === NODE_TYPE.COMMENT) {
       const value = getTextContent(<Text>(<unknown>node));
 
       if (value.length > 0) {
         result.push(`${indent}<!--${value}-->${newline}`);
       }
-    } else if (node.nodeType === NODETYPE.TEXT) {
+    } else if (node.nodeType === NODE_TYPE.TEXT) {
       const value = trim(getTextContent(<Text>(<unknown>node)));
 
       if (value && value.length > 0) {
         result.push(indent + htmlEntities(value, false) + newline);
       }
-    } else if (node.nodeType === NODETYPE.CDATA) {
+    } else if (node.nodeType === NODE_TYPE.CDATA) {
       const value = getTextContent(<Text>(<unknown>node));
 
       if (value.length > 0) {

--- a/packages/core/src/view/geometry/stencil/StencilShapeRegistry.ts
+++ b/packages/core/src/view/geometry/stencil/StencilShapeRegistry.ts
@@ -32,7 +32,7 @@ type Stencils = {
  * let shape = root.firstChild;
  *
  * while (shape) {
- *   if (shape.nodeType === constants.NODETYPE.ELEMENT) {
+ *   if (shape.nodeType === constants.NODE_TYPE.ELEMENT) {
  *    StencilShapeRegistry.addStencil(shape.getAttribute('name'), new StencilShape(shape));
  *  }
  *

--- a/packages/html/stories/shared/utils.ts
+++ b/packages/html/stories/shared/utils.ts
@@ -17,4 +17,4 @@ limitations under the License.
 import { constants } from '@maxgraph/core';
 
 export const isElement = (node: ChildNode): node is Element =>
-  node.nodeType === constants.NODETYPE.ELEMENT;
+  node.nodeType === constants.NODE_TYPE.ELEMENT;

--- a/packages/ts-example-selected-features/vite.config.js
+++ b/packages/ts-example-selected-features/vite.config.js
@@ -27,7 +27,7 @@ export default defineConfig(({ mode }) => {
           },
         },
       },
-      chunkSizeWarningLimit: 378, // @maxgraph/core
+      chunkSizeWarningLimit: 377, // @maxgraph/core
     },
   };
 });

--- a/packages/ts-example/vite.config.js
+++ b/packages/ts-example/vite.config.js
@@ -27,7 +27,7 @@ export default defineConfig(({ mode }) => {
           },
         },
       },
-      chunkSizeWarningLimit: 436, // @maxgraph/core
+      chunkSizeWarningLimit: 435, // @maxgraph/core
     },
   };
 });


### PR DESCRIPTION
BREAKING CHANGES: The `constants.NODETYPE` enum has been removed and replaced by the `constants.NODE_TYPE` value object.
The former `DOCUMENTTYPE` enum member has been renamed to `DOCUMENT_TYPE`.


## Notes

Covers #378



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated naming conventions for node type constants throughout the application for improved consistency.
  - Updated documentation to reflect changes in constant names.
  - Adjusted build configuration thresholds for chunk size warnings in example projects.

- **Style**
  - Improved code comments and examples to match updated constant names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->