### PR TITLE
refactor(type)!: make DIRECTION_MASK read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ _**Note:** Yet to be released breaking changes appear here._
   - `constants.TEXT_DIRECTION` --> `TextDirectionValue`
 - The `constants.NODETYPE` enum has been removed and replaced by the `constants.NODE_TYPE` value object.
   The former `DOCUMENTTYPE` enum member has been renamed to `DOCUMENT_TYPE`.
+- `constants.DIRECTION_MASK` is now read-only (types only).
 
 ## 0.19.0
 

--- a/packages/core/src/util/Constants.ts
+++ b/packages/core/src/util/Constants.ts
@@ -422,7 +422,7 @@ export const DIRECTION_MASK = {
   EAST: 8,
   /** All directions. */
   ALL: 15,
-};
+} as const;
 
 /**
  * The values of {@link Node.nodeType}

--- a/packages/core/src/view/style/edge/Orthogonal.ts
+++ b/packages/core/src/view/style/edge/Orthogonal.ts
@@ -218,7 +218,7 @@ export const OrthogonalConnector: EdgeStyleFunction = (
   // Determine the side(s) of the source and target vertices
   // that the edge may connect to
   // portConstraint [source, target]
-  const portConstraint = [DIRECTION_MASK.ALL, DIRECTION_MASK.ALL];
+  const portConstraint: number[] = [DIRECTION_MASK.ALL, DIRECTION_MASK.ALL];
   let rotation = 0;
 
   if (source != null) {


### PR DESCRIPTION

## Notes

Covers #378



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog to note that the direction mask constant is now read-only at the type level.

- **Refactor**
  - Made the direction mask constant read-only, ensuring its values cannot be modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->