### PR TITLE
refactor!: replace FONT enum by FONT_STYLE_MASK value object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ _**Note:** Yet to be released breaking changes appear here._
   - `constants.TEXT_DIRECTION` --> `TextDirectionValue`
 - The `constants.NODETYPE` enum has been removed and replaced by the `constants.NODE_TYPE` value object.
   The former `DOCUMENTTYPE` enum member has been renamed to `DOCUMENT_TYPE`.
+- The `constants.FONT` enum has been removed and replaced by the `constants.FONT_STYLE_FLAG` value object.
 
 ## 0.19.0
 

--- a/packages/core/__tests__/internal/utils.test.ts
+++ b/packages/core/__tests__/internal/utils.test.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { describe, expect, test } from '@jest/globals';
-import { FONT_STYLE_MASK } from '../../src/util/Constants';
+import { DIRECTION_MASK, FONT_STYLE_MASK } from '../../src/util/Constants';
 import { matchBinaryMask } from '../../src/internal/utils';
 
 describe('matchBinaryMask', () => {
@@ -26,11 +26,20 @@ describe('matchBinaryMask', () => {
   });
   test('match', () => {
     expect(matchBinaryMask(9465, FONT_STYLE_MASK.BOLD)).toBeTruthy();
+    expect(9465 & FONT_STYLE_MASK.BOLD).toBeTruthy(); // equivalent implementation returning a number (matchBinaryMask returns a boolean)
   });
   test('match another', () => {
     expect(matchBinaryMask(19484, FONT_STYLE_MASK.UNDERLINE)).toBeTruthy();
   });
   test('no match', () => {
     expect(matchBinaryMask(46413, FONT_STYLE_MASK.ITALIC)).toBeFalsy();
+    expect(46413 & FONT_STYLE_MASK.ITALIC).toBeFalsy(); // equivalent implementation returning a number (matchBinaryMask returns a boolean)
+  });
+
+  test.each([null, undefined])('no match when value is nullish: %s', (value) => {
+    expect(matchBinaryMask(value, DIRECTION_MASK.EAST)).toBeFalsy();
+  });
+  test.each([null, undefined])('match for zero when value is nullish: %s', (value) => {
+    expect(matchBinaryMask(value, 0)).toBeTruthy();
   });
 });

--- a/packages/core/__tests__/internal/utils.test.ts
+++ b/packages/core/__tests__/internal/utils.test.ts
@@ -15,22 +15,22 @@ limitations under the License.
 */
 
 import { describe, expect, test } from '@jest/globals';
-import { FONT_STYLE_FLAG } from '../../src/util/Constants';
+import { FONT_STYLE_MASK } from '../../src/util/Constants';
 import { matchBinaryMask } from '../../src/internal/utils';
 
 describe('matchBinaryMask', () => {
   test('match self', () => {
     expect(
-      matchBinaryMask(FONT_STYLE_FLAG.STRIKETHROUGH, FONT_STYLE_FLAG.STRIKETHROUGH)
+      matchBinaryMask(FONT_STYLE_MASK.STRIKETHROUGH, FONT_STYLE_MASK.STRIKETHROUGH)
     ).toBeTruthy();
   });
   test('match', () => {
-    expect(matchBinaryMask(9465, FONT_STYLE_FLAG.BOLD)).toBeTruthy();
+    expect(matchBinaryMask(9465, FONT_STYLE_MASK.BOLD)).toBeTruthy();
   });
   test('match another', () => {
-    expect(matchBinaryMask(19484, FONT_STYLE_FLAG.UNDERLINE)).toBeTruthy();
+    expect(matchBinaryMask(19484, FONT_STYLE_MASK.UNDERLINE)).toBeTruthy();
   });
   test('no match', () => {
-    expect(matchBinaryMask(46413, FONT_STYLE_FLAG.ITALIC)).toBeFalsy();
+    expect(matchBinaryMask(46413, FONT_STYLE_MASK.ITALIC)).toBeFalsy();
   });
 });

--- a/packages/core/__tests__/internal/utils.test.ts
+++ b/packages/core/__tests__/internal/utils.test.ts
@@ -15,20 +15,22 @@ limitations under the License.
 */
 
 import { describe, expect, test } from '@jest/globals';
-import { FONT } from '../../src/util/Constants';
+import { FONT_STYLE_FLAG } from '../../src/util/Constants';
 import { matchBinaryMask } from '../../src/internal/utils';
 
 describe('matchBinaryMask', () => {
   test('match self', () => {
-    expect(matchBinaryMask(FONT.STRIKETHROUGH, FONT.STRIKETHROUGH)).toBeTruthy();
+    expect(
+      matchBinaryMask(FONT_STYLE_FLAG.STRIKETHROUGH, FONT_STYLE_FLAG.STRIKETHROUGH)
+    ).toBeTruthy();
   });
   test('match', () => {
-    expect(matchBinaryMask(9465, FONT.BOLD)).toBeTruthy();
+    expect(matchBinaryMask(9465, FONT_STYLE_FLAG.BOLD)).toBeTruthy();
   });
   test('match another', () => {
-    expect(matchBinaryMask(19484, FONT.UNDERLINE)).toBeTruthy();
+    expect(matchBinaryMask(19484, FONT_STYLE_FLAG.UNDERLINE)).toBeTruthy();
   });
   test('no match', () => {
-    expect(matchBinaryMask(46413, FONT.ITALIC)).toBeFalsy();
+    expect(matchBinaryMask(46413, FONT_STYLE_FLAG.ITALIC)).toBeFalsy();
   });
 });

--- a/packages/core/__tests__/util/styleUtils.test.ts
+++ b/packages/core/__tests__/util/styleUtils.test.ts
@@ -21,7 +21,7 @@ import {
   setCellStyleFlags,
   setCellStyles,
 } from '../../src/util/styleUtils';
-import { FONT } from '../../src/util/Constants';
+import { FONT_STYLE_FLAG } from '../../src/util/Constants';
 import { type CellStyle, BaseGraph } from '../../src';
 import { createGraphWithoutPlugins } from '../utils';
 
@@ -45,10 +45,14 @@ describe('parseCssNumber', () => {
 
 describe('setStyleFlag', () => {
   test('preserves other style properties', () => {
-    const style = { fontStyle: FONT.BOLD, fillColor: 'red', strokeColor: 'blue' };
-    setStyleFlag(style, 'fontStyle', FONT.ITALIC, true);
+    const style = {
+      fontStyle: FONT_STYLE_FLAG.BOLD,
+      fillColor: 'red',
+      strokeColor: 'blue',
+    };
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.ITALIC, true);
     expect(style).toEqual({
-      fontStyle: FONT.BOLD | FONT.ITALIC,
+      fontStyle: FONT_STYLE_FLAG.BOLD | FONT_STYLE_FLAG.ITALIC,
       fillColor: 'red',
       strokeColor: 'blue',
     });
@@ -56,68 +60,70 @@ describe('setStyleFlag', () => {
 
   test('multiple flags can be combined', () => {
     const style: CellStyle = {};
-    setStyleFlag(style, 'fontStyle', FONT.BOLD, true);
-    setStyleFlag(style, 'fontStyle', FONT.ITALIC, true);
-    setStyleFlag(style, 'fontStyle', FONT.UNDERLINE, true);
-    expect(style.fontStyle).toBe(FONT.BOLD | FONT.ITALIC | FONT.UNDERLINE);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.BOLD, true);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.ITALIC, true);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.UNDERLINE, true);
+    expect(style.fontStyle).toBe(
+      FONT_STYLE_FLAG.BOLD | FONT_STYLE_FLAG.ITALIC | FONT_STYLE_FLAG.UNDERLINE
+    );
   });
 
   test('fontStyle undefined, set bold, no value', () => {
     const style: CellStyle = {};
-    setStyleFlag(style, 'fontStyle', FONT.BOLD);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.BOLD);
     expect(style.fontStyle).toBe(1);
   });
   test('fontStyle undefined, set bold, value is false', () => {
     const style: CellStyle = {};
-    setStyleFlag(style, 'fontStyle', FONT.BOLD, false);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.BOLD, false);
     expect(style.fontStyle).toBe(0);
   });
   test('fontStyle undefined, set italic, value is false', () => {
     const style: CellStyle = {};
-    setStyleFlag(style, 'fontStyle', FONT.ITALIC, false);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.ITALIC, false);
     expect(style.fontStyle).toBe(0);
   });
   test('fontStyle undefined, set underline, value is true', () => {
     const style: CellStyle = {};
-    setStyleFlag(style, 'fontStyle', FONT.UNDERLINE, true);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.UNDERLINE, true);
     expect(style.fontStyle).toBe(4);
   });
   test('fontStyle undefined, set strike-through, value is true', () => {
     const style: CellStyle = {};
-    setStyleFlag(style, 'fontStyle', FONT.STRIKETHROUGH, true);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.STRIKETHROUGH, true);
     expect(style.fontStyle).toBe(8);
   });
 
   test('fontStyle set without bold, toggle bold', () => {
     const style: CellStyle = { fontStyle: 2 };
-    setStyleFlag(style, 'fontStyle', FONT.BOLD);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.BOLD);
     expect(style.fontStyle).toBe(3);
   });
   test('fontStyle set with bold, toggle bold', () => {
     const style: CellStyle = { fontStyle: 9 };
-    setStyleFlag(style, 'fontStyle', FONT.BOLD);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.BOLD);
     expect(style.fontStyle).toBe(8);
   });
 
   test('fontStyle set without strike-through, set strike-through', () => {
     const style: CellStyle = { fontStyle: 7 };
-    setStyleFlag(style, 'fontStyle', FONT.STRIKETHROUGH, true);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.STRIKETHROUGH, true);
     expect(style.fontStyle).toBe(15);
   });
   test('fontStyle set without strike-through, unset strike-through', () => {
     const style: CellStyle = { fontStyle: 7 };
-    setStyleFlag(style, 'fontStyle', FONT.STRIKETHROUGH, false);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.STRIKETHROUGH, false);
     expect(style.fontStyle).toBe(7);
   });
 
   test('fontStyle set with underline, set underline', () => {
     const style: CellStyle = { fontStyle: 6 };
-    setStyleFlag(style, 'fontStyle', FONT.UNDERLINE, true);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.UNDERLINE, true);
     expect(style.fontStyle).toBe(6);
   });
   test('fontStyle set with underline, unset underline', () => {
     const style: CellStyle = { fontStyle: 6 };
-    setStyleFlag(style, 'fontStyle', FONT.UNDERLINE, false);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.UNDERLINE, false);
     expect(style.fontStyle).toBe(2);
   });
 });
@@ -137,7 +143,13 @@ test.each([
   });
   expect(cell.style).toStrictEqual(style);
 
-  setCellStyleFlags(graph.getDataModel(), [cell], 'fontStyle', FONT.BOLD, true);
+  setCellStyleFlags(
+    graph.getDataModel(),
+    [cell],
+    'fontStyle',
+    FONT_STYLE_FLAG.BOLD,
+    true
+  );
   expect(cell.style.fontStyle).toBe(5);
   expect(graph.getView().getState(cell)?.style?.fontStyle).toBe(5);
 });

--- a/packages/core/__tests__/util/styleUtils.test.ts
+++ b/packages/core/__tests__/util/styleUtils.test.ts
@@ -21,7 +21,7 @@ import {
   setCellStyleFlags,
   setCellStyles,
 } from '../../src/util/styleUtils';
-import { FONT_STYLE_FLAG } from '../../src/util/Constants';
+import { FONT_STYLE_MASK } from '../../src/util/Constants';
 import { type CellStyle, BaseGraph } from '../../src';
 import { createGraphWithoutPlugins } from '../utils';
 
@@ -46,13 +46,13 @@ describe('parseCssNumber', () => {
 describe('setStyleFlag', () => {
   test('preserves other style properties', () => {
     const style = {
-      fontStyle: FONT_STYLE_FLAG.BOLD,
+      fontStyle: FONT_STYLE_MASK.BOLD,
       fillColor: 'red',
       strokeColor: 'blue',
     };
-    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.ITALIC, true);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_MASK.ITALIC, true);
     expect(style).toEqual({
-      fontStyle: FONT_STYLE_FLAG.BOLD | FONT_STYLE_FLAG.ITALIC,
+      fontStyle: FONT_STYLE_MASK.BOLD | FONT_STYLE_MASK.ITALIC,
       fillColor: 'red',
       strokeColor: 'blue',
     });
@@ -60,70 +60,70 @@ describe('setStyleFlag', () => {
 
   test('multiple flags can be combined', () => {
     const style: CellStyle = {};
-    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.BOLD, true);
-    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.ITALIC, true);
-    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.UNDERLINE, true);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_MASK.BOLD, true);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_MASK.ITALIC, true);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_MASK.UNDERLINE, true);
     expect(style.fontStyle).toBe(
-      FONT_STYLE_FLAG.BOLD | FONT_STYLE_FLAG.ITALIC | FONT_STYLE_FLAG.UNDERLINE
+      FONT_STYLE_MASK.BOLD | FONT_STYLE_MASK.ITALIC | FONT_STYLE_MASK.UNDERLINE
     );
   });
 
   test('fontStyle undefined, set bold, no value', () => {
     const style: CellStyle = {};
-    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.BOLD);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_MASK.BOLD);
     expect(style.fontStyle).toBe(1);
   });
   test('fontStyle undefined, set bold, value is false', () => {
     const style: CellStyle = {};
-    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.BOLD, false);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_MASK.BOLD, false);
     expect(style.fontStyle).toBe(0);
   });
   test('fontStyle undefined, set italic, value is false', () => {
     const style: CellStyle = {};
-    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.ITALIC, false);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_MASK.ITALIC, false);
     expect(style.fontStyle).toBe(0);
   });
   test('fontStyle undefined, set underline, value is true', () => {
     const style: CellStyle = {};
-    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.UNDERLINE, true);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_MASK.UNDERLINE, true);
     expect(style.fontStyle).toBe(4);
   });
   test('fontStyle undefined, set strike-through, value is true', () => {
     const style: CellStyle = {};
-    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.STRIKETHROUGH, true);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_MASK.STRIKETHROUGH, true);
     expect(style.fontStyle).toBe(8);
   });
 
   test('fontStyle set without bold, toggle bold', () => {
     const style: CellStyle = { fontStyle: 2 };
-    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.BOLD);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_MASK.BOLD);
     expect(style.fontStyle).toBe(3);
   });
   test('fontStyle set with bold, toggle bold', () => {
     const style: CellStyle = { fontStyle: 9 };
-    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.BOLD);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_MASK.BOLD);
     expect(style.fontStyle).toBe(8);
   });
 
   test('fontStyle set without strike-through, set strike-through', () => {
     const style: CellStyle = { fontStyle: 7 };
-    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.STRIKETHROUGH, true);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_MASK.STRIKETHROUGH, true);
     expect(style.fontStyle).toBe(15);
   });
   test('fontStyle set without strike-through, unset strike-through', () => {
     const style: CellStyle = { fontStyle: 7 };
-    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.STRIKETHROUGH, false);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_MASK.STRIKETHROUGH, false);
     expect(style.fontStyle).toBe(7);
   });
 
   test('fontStyle set with underline, set underline', () => {
     const style: CellStyle = { fontStyle: 6 };
-    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.UNDERLINE, true);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_MASK.UNDERLINE, true);
     expect(style.fontStyle).toBe(6);
   });
   test('fontStyle set with underline, unset underline', () => {
     const style: CellStyle = { fontStyle: 6 };
-    setStyleFlag(style, 'fontStyle', FONT_STYLE_FLAG.UNDERLINE, false);
+    setStyleFlag(style, 'fontStyle', FONT_STYLE_MASK.UNDERLINE, false);
     expect(style.fontStyle).toBe(2);
   });
 });
@@ -147,7 +147,7 @@ test.each([
     graph.getDataModel(),
     [cell],
     'fontStyle',
-    FONT_STYLE_FLAG.BOLD,
+    FONT_STYLE_MASK.BOLD,
     true
   );
   expect(cell.style.fontStyle).toBe(5);

--- a/packages/core/__tests__/view/mixins/CellMixin.test.ts
+++ b/packages/core/__tests__/view/mixins/CellMixin.test.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import { describe, expect, test } from '@jest/globals';
 import { createCellWithStyle, createGraphWithoutPlugins } from '../../utils';
 import { Cell, type CellStyle } from '../../../src';
-import { FONT } from '../../../src/util/Constants';
+import { FONT_STYLE_FLAG } from '../../../src/util/Constants';
 
 test('setCellStyles on vertex', () => {
   const graph = createGraphWithoutPlugins();
@@ -50,7 +50,7 @@ test('setCellStyleFlags on vertex', () => {
   });
   expect(cell.style).toStrictEqual(style);
 
-  graph.setCellStyleFlags('fontStyle', FONT.UNDERLINE, null, [cell]);
+  graph.setCellStyleFlags('fontStyle', FONT_STYLE_FLAG.UNDERLINE, null, [cell]);
   expect(cell.style.fontStyle).toBe(7);
   expect(graph.getView().getState(cell)?.style?.fontStyle).toBe(7);
 });

--- a/packages/core/__tests__/view/mixins/CellMixin.test.ts
+++ b/packages/core/__tests__/view/mixins/CellMixin.test.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import { describe, expect, test } from '@jest/globals';
 import { createCellWithStyle, createGraphWithoutPlugins } from '../../utils';
 import { Cell, type CellStyle } from '../../../src';
-import { FONT_STYLE_FLAG } from '../../../src/util/Constants';
+import { FONT_STYLE_MASK } from '../../../src/util/Constants';
 
 test('setCellStyles on vertex', () => {
   const graph = createGraphWithoutPlugins();
@@ -50,7 +50,7 @@ test('setCellStyleFlags on vertex', () => {
   });
   expect(cell.style).toStrictEqual(style);
 
-  graph.setCellStyleFlags('fontStyle', FONT_STYLE_FLAG.UNDERLINE, null, [cell]);
+  graph.setCellStyleFlags('fontStyle', FONT_STYLE_MASK.UNDERLINE, null, [cell]);
   expect(cell.style.fontStyle).toBe(7);
   expect(graph.getView().getState(cell)?.style?.fontStyle).toBe(7);
 });

--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -33,7 +33,7 @@ import MaxForm from '../gui/MaxForm';
 import Outline from '../view/other/Outline';
 import Cell from '../view/cell/Cell';
 import Geometry from '../view/geometry/Geometry';
-import { FONT } from '../util/Constants';
+import { FONT_STYLE_FLAG } from '../util/Constants';
 import type { AbstractGraph } from '../view/AbstractGraph';
 import { Graph } from '../view/Graph';
 import SwimlaneManager from '../view/layout/SwimlaneManager';
@@ -1140,19 +1140,19 @@ export class Editor extends EventSource {
 
     this.addAction('bold', (editor: Editor) => {
       if (editor.graph.isEnabled()) {
-        editor.graph.toggleCellStyleFlags('fontStyle', FONT.BOLD);
+        editor.graph.toggleCellStyleFlags('fontStyle', FONT_STYLE_FLAG.BOLD);
       }
     });
 
     this.addAction('italic', (editor: Editor) => {
       if (editor.graph.isEnabled()) {
-        editor.graph.toggleCellStyleFlags('fontStyle', FONT.ITALIC);
+        editor.graph.toggleCellStyleFlags('fontStyle', FONT_STYLE_FLAG.ITALIC);
       }
     });
 
     this.addAction('underline', (editor: Editor) => {
       if (editor.graph.isEnabled()) {
-        editor.graph.toggleCellStyleFlags('fontStyle', FONT.UNDERLINE);
+        editor.graph.toggleCellStyleFlags('fontStyle', FONT_STYLE_FLAG.UNDERLINE);
       }
     });
 

--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -33,7 +33,7 @@ import MaxForm from '../gui/MaxForm';
 import Outline from '../view/other/Outline';
 import Cell from '../view/cell/Cell';
 import Geometry from '../view/geometry/Geometry';
-import { FONT_STYLE_FLAG } from '../util/Constants';
+import { FONT_STYLE_MASK } from '../util/Constants';
 import type { AbstractGraph } from '../view/AbstractGraph';
 import { Graph } from '../view/Graph';
 import SwimlaneManager from '../view/layout/SwimlaneManager';
@@ -1140,19 +1140,19 @@ export class Editor extends EventSource {
 
     this.addAction('bold', (editor: Editor) => {
       if (editor.graph.isEnabled()) {
-        editor.graph.toggleCellStyleFlags('fontStyle', FONT_STYLE_FLAG.BOLD);
+        editor.graph.toggleCellStyleFlags('fontStyle', FONT_STYLE_MASK.BOLD);
       }
     });
 
     this.addAction('italic', (editor: Editor) => {
       if (editor.graph.isEnabled()) {
-        editor.graph.toggleCellStyleFlags('fontStyle', FONT_STYLE_FLAG.ITALIC);
+        editor.graph.toggleCellStyleFlags('fontStyle', FONT_STYLE_MASK.ITALIC);
       }
     });
 
     this.addAction('underline', (editor: Editor) => {
       if (editor.graph.isEnabled()) {
-        editor.graph.toggleCellStyleFlags('fontStyle', FONT_STYLE_FLAG.UNDERLINE);
+        editor.graph.toggleCellStyleFlags('fontStyle', FONT_STYLE_MASK.UNDERLINE);
       }
     });
 

--- a/packages/core/src/internal/utils.ts
+++ b/packages/core/src/internal/utils.ts
@@ -65,6 +65,6 @@ export const mixInto = (dest: any) => (mixin: any) => {
  * @returns `true` if the value matches the binary mask.
  * @private Subject to change prior being part of the public API.
  */
-export const matchBinaryMask = (value: number, mask: number) => {
-  return (value & mask) === mask;
+export const matchBinaryMask = (value: number | undefined | null, mask: number) => {
+  return (value! & mask) === mask;
 };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -334,8 +334,7 @@ export type CellStateStyle = {
    */
   fontSize?: number;
   /**
-   * Values may be any logical AND (sum) of the {@link FONT}. For instance, FONT.BOLD,
-   * FONT.ITALIC, ...
+   * Values may be any logical AND (sum) of the {@link FONT_STYLE_FLAG}. For instance, FONT_STYLE_FLAG.BOLD, FONT_STYLE_FLAG.ITALIC, ...
    */
   fontStyle?: number;
   /**

--- a/packages/core/src/util/Constants.ts
+++ b/packages/core/src/util/Constants.ts
@@ -399,16 +399,16 @@ export const PAGE_FORMAT_LETTER_LANDSCAPE = [0, 0, 1100, 850];
  */
 export const NONE = 'none';
 
-export enum FONT {
+export const FONT_STYLE_FLAG = {
   /** for bold fonts. */
-  BOLD = 1,
+  BOLD: 1,
   /** for italic fonts. */
-  ITALIC = 2,
+  ITALIC: 2,
   /** for underlined fonts. */
-  UNDERLINE = 4,
+  UNDERLINE: 4,
   /** for strikethrough fonts. */
-  STRIKETHROUGH = 8,
-}
+  STRIKETHROUGH: 8,
+} as const;
 
 /**
  * Bitwise mask for all directions.

--- a/packages/core/src/util/Constants.ts
+++ b/packages/core/src/util/Constants.ts
@@ -399,7 +399,7 @@ export const PAGE_FORMAT_LETTER_LANDSCAPE = [0, 0, 1100, 850];
  */
 export const NONE = 'none';
 
-export const FONT_STYLE_FLAG = {
+export const FONT_STYLE_MASK = {
   /** for bold fonts. */
   BOLD: 1,
   /** for italic fonts. */

--- a/packages/core/src/util/styleUtils.ts
+++ b/packages/core/src/util/styleUtils.ts
@@ -17,7 +17,12 @@ limitations under the License.
 */
 
 import Client from '../Client';
-import { DEFAULT_FONTFAMILY, DEFAULT_FONTSIZE, FONT, LINE_HEIGHT } from './Constants';
+import {
+  DEFAULT_FONTFAMILY,
+  DEFAULT_FONTSIZE,
+  FONT_STYLE_FLAG,
+  LINE_HEIGHT,
+} from './Constants';
 import Point from '../view/geometry/Point';
 import Dictionary from './Dictionary';
 import CellPath from '../view/cell/CellPath';
@@ -451,12 +456,14 @@ export const getSizeForString = (
 
   // Sets the font style
   if (fontStyle !== null) {
-    matchBinaryMask(fontStyle, FONT.BOLD) && (div.style.fontWeight = 'bold');
-    matchBinaryMask(fontStyle, FONT.ITALIC) && (div.style.fontWeight = 'italic');
+    matchBinaryMask(fontStyle, FONT_STYLE_FLAG.BOLD) && (div.style.fontWeight = 'bold');
+    matchBinaryMask(fontStyle, FONT_STYLE_FLAG.ITALIC) &&
+      (div.style.fontWeight = 'italic');
 
     const txtDecor = [];
-    matchBinaryMask(fontStyle, FONT.UNDERLINE) && txtDecor.push('underline');
-    matchBinaryMask(fontStyle, FONT.STRIKETHROUGH) && txtDecor.push('line-through');
+    matchBinaryMask(fontStyle, FONT_STYLE_FLAG.UNDERLINE) && txtDecor.push('underline');
+    matchBinaryMask(fontStyle, FONT_STYLE_FLAG.STRIKETHROUGH) &&
+      txtDecor.push('line-through');
     txtDecor.length > 0 && (div.style.textDecoration = txtDecor.join(' '));
   }
 

--- a/packages/core/src/util/styleUtils.ts
+++ b/packages/core/src/util/styleUtils.ts
@@ -20,7 +20,7 @@ import Client from '../Client';
 import {
   DEFAULT_FONTFAMILY,
   DEFAULT_FONTSIZE,
-  FONT_STYLE_FLAG,
+  FONT_STYLE_MASK,
   LINE_HEIGHT,
 } from './Constants';
 import Point from '../view/geometry/Point';
@@ -456,13 +456,13 @@ export const getSizeForString = (
 
   // Sets the font style
   if (fontStyle !== null) {
-    matchBinaryMask(fontStyle, FONT_STYLE_FLAG.BOLD) && (div.style.fontWeight = 'bold');
-    matchBinaryMask(fontStyle, FONT_STYLE_FLAG.ITALIC) &&
+    matchBinaryMask(fontStyle, FONT_STYLE_MASK.BOLD) && (div.style.fontWeight = 'bold');
+    matchBinaryMask(fontStyle, FONT_STYLE_MASK.ITALIC) &&
       (div.style.fontStyle = 'italic');
 
     const txtDecor = [];
-    matchBinaryMask(fontStyle, FONT_STYLE_FLAG.UNDERLINE) && txtDecor.push('underline');
-    matchBinaryMask(fontStyle, FONT_STYLE_FLAG.STRIKETHROUGH) &&
+    matchBinaryMask(fontStyle, FONT_STYLE_MASK.UNDERLINE) && txtDecor.push('underline');
+    matchBinaryMask(fontStyle, FONT_STYLE_MASK.STRIKETHROUGH) &&
       txtDecor.push('line-through');
     txtDecor.length > 0 && (div.style.textDecoration = txtDecor.join(' '));
   }

--- a/packages/core/src/util/styleUtils.ts
+++ b/packages/core/src/util/styleUtils.ts
@@ -348,7 +348,7 @@ export const setCellStyles = (
  * setCellStyleFlags(graph.model,
  *       cells,
  *       'fontStyle',
- *       constants.FONT.BOLD);
+ *       constants.FONT_STYLE_FLAG.BOLD);
  * ```
  *
  * @param model {@link GraphDataModel} that contains the cells.

--- a/packages/core/src/view/canvas/SvgCanvas2D.ts
+++ b/packages/core/src/view/canvas/SvgCanvas2D.ts
@@ -24,7 +24,7 @@ import {
   ABSOLUTE_LINE_HEIGHT,
   DEFAULT_FONTFAMILY,
   DEFAULT_FONTSIZE,
-  FONT_STYLE_FLAG,
+  FONT_STYLE_MASK,
   LINE_HEIGHT,
   NONE,
   NS_SVG,
@@ -472,14 +472,14 @@ class SvgCanvas2D extends AbstractCanvas2D {
       // Text-anchor start is default in SVG
       anchor !== 'start' && alt.setAttribute('text-anchor', anchor);
       const fontStyle = s.fontStyle;
-      matchBinaryMask(fontStyle, FONT_STYLE_FLAG.BOLD) &&
+      matchBinaryMask(fontStyle, FONT_STYLE_MASK.BOLD) &&
         alt.setAttribute('font-weight', 'bold');
-      matchBinaryMask(fontStyle, FONT_STYLE_FLAG.ITALIC) &&
+      matchBinaryMask(fontStyle, FONT_STYLE_MASK.ITALIC) &&
         alt.setAttribute('font-style', 'italic');
 
       const txtDecor = [];
-      matchBinaryMask(fontStyle, FONT_STYLE_FLAG.UNDERLINE) && txtDecor.push('underline');
-      matchBinaryMask(fontStyle, FONT_STYLE_FLAG.STRIKETHROUGH) &&
+      matchBinaryMask(fontStyle, FONT_STYLE_MASK.UNDERLINE) && txtDecor.push('underline');
+      matchBinaryMask(fontStyle, FONT_STYLE_MASK.STRIKETHROUGH) &&
         txtDecor.push('line-through');
       txtDecor.length > 0 && alt.setAttribute('text-decoration', txtDecor.join(' '));
 
@@ -1358,12 +1358,12 @@ class SvgCanvas2D extends AbstractCanvas2D {
       }; `;
 
     const fontStyle = s.fontStyle;
-    matchBinaryMask(fontStyle, FONT_STYLE_FLAG.BOLD) && (css += 'font-weight: bold; ');
-    matchBinaryMask(fontStyle, FONT_STYLE_FLAG.ITALIC) && (css += 'font-style: italic; ');
+    matchBinaryMask(fontStyle, FONT_STYLE_MASK.BOLD) && (css += 'font-weight: bold; ');
+    matchBinaryMask(fontStyle, FONT_STYLE_MASK.ITALIC) && (css += 'font-style: italic; ');
 
     const txtDecor = [];
-    matchBinaryMask(fontStyle, FONT_STYLE_FLAG.UNDERLINE) && txtDecor.push('underline');
-    matchBinaryMask(fontStyle, FONT_STYLE_FLAG.STRIKETHROUGH) &&
+    matchBinaryMask(fontStyle, FONT_STYLE_MASK.UNDERLINE) && txtDecor.push('underline');
+    matchBinaryMask(fontStyle, FONT_STYLE_MASK.STRIKETHROUGH) &&
       txtDecor.push('line-through');
     txtDecor.length > 0 && (css += `text-decoration: ${txtDecor.join(' ')}; `);
 
@@ -1650,14 +1650,14 @@ class SvgCanvas2D extends AbstractCanvas2D {
     }
 
     const fontStyle = s.fontStyle;
-    matchBinaryMask(fontStyle, FONT_STYLE_FLAG.BOLD) &&
+    matchBinaryMask(fontStyle, FONT_STYLE_MASK.BOLD) &&
       node.setAttribute('font-weight', 'bold');
-    matchBinaryMask(fontStyle, FONT_STYLE_FLAG.ITALIC) &&
+    matchBinaryMask(fontStyle, FONT_STYLE_MASK.ITALIC) &&
       node.setAttribute('font-style', 'italic');
 
     const txtDecor = [];
-    matchBinaryMask(fontStyle, FONT_STYLE_FLAG.UNDERLINE) && txtDecor.push('underline');
-    matchBinaryMask(fontStyle, FONT_STYLE_FLAG.STRIKETHROUGH) &&
+    matchBinaryMask(fontStyle, FONT_STYLE_MASK.UNDERLINE) && txtDecor.push('underline');
+    matchBinaryMask(fontStyle, FONT_STYLE_MASK.STRIKETHROUGH) &&
       txtDecor.push('line-through');
     txtDecor.length > 0 && node.setAttribute('text-decoration', txtDecor.join(' '));
   }
@@ -1727,9 +1727,9 @@ class SvgCanvas2D extends AbstractCanvas2D {
         div.style.visibility = 'hidden';
         div.style.display = 'inline-block';
 
-        matchBinaryMask(s.fontStyle, FONT_STYLE_FLAG.BOLD) &&
+        matchBinaryMask(s.fontStyle, FONT_STYLE_MASK.BOLD) &&
           (div.style.fontWeight = 'bold');
-        matchBinaryMask(s.fontStyle, FONT_STYLE_FLAG.ITALIC) &&
+        matchBinaryMask(s.fontStyle, FONT_STYLE_MASK.ITALIC) &&
           (div.style.fontStyle = 'italic');
 
         str = htmlEntities(str, false);

--- a/packages/core/src/view/canvas/SvgCanvas2D.ts
+++ b/packages/core/src/view/canvas/SvgCanvas2D.ts
@@ -24,7 +24,7 @@ import {
   ABSOLUTE_LINE_HEIGHT,
   DEFAULT_FONTFAMILY,
   DEFAULT_FONTSIZE,
-  FONT,
+  FONT_STYLE_FLAG,
   LINE_HEIGHT,
   NONE,
   NS_SVG,
@@ -472,12 +472,15 @@ class SvgCanvas2D extends AbstractCanvas2D {
       // Text-anchor start is default in SVG
       anchor !== 'start' && alt.setAttribute('text-anchor', anchor);
       const fontStyle = s.fontStyle;
-      matchBinaryMask(fontStyle, FONT.BOLD) && alt.setAttribute('font-weight', 'bold');
-      matchBinaryMask(fontStyle, FONT.ITALIC) && alt.setAttribute('font-style', 'italic');
+      matchBinaryMask(fontStyle, FONT_STYLE_FLAG.BOLD) &&
+        alt.setAttribute('font-weight', 'bold');
+      matchBinaryMask(fontStyle, FONT_STYLE_FLAG.ITALIC) &&
+        alt.setAttribute('font-style', 'italic');
 
       const txtDecor = [];
-      matchBinaryMask(fontStyle, FONT.UNDERLINE) && txtDecor.push('underline');
-      matchBinaryMask(fontStyle, FONT.STRIKETHROUGH) && txtDecor.push('line-through');
+      matchBinaryMask(fontStyle, FONT_STYLE_FLAG.UNDERLINE) && txtDecor.push('underline');
+      matchBinaryMask(fontStyle, FONT_STYLE_FLAG.STRIKETHROUGH) &&
+        txtDecor.push('line-through');
       txtDecor.length > 0 && alt.setAttribute('text-decoration', txtDecor.join(' '));
 
       write(alt, <string>text);
@@ -1355,12 +1358,13 @@ class SvgCanvas2D extends AbstractCanvas2D {
       }; `;
 
     const fontStyle = s.fontStyle;
-    matchBinaryMask(fontStyle, FONT.BOLD) && (css += 'font-weight: bold; ');
-    matchBinaryMask(fontStyle, FONT.ITALIC) && (css += 'font-style: italic; ');
+    matchBinaryMask(fontStyle, FONT_STYLE_FLAG.BOLD) && (css += 'font-weight: bold; ');
+    matchBinaryMask(fontStyle, FONT_STYLE_FLAG.ITALIC) && (css += 'font-style: italic; ');
 
     const txtDecor = [];
-    matchBinaryMask(fontStyle, FONT.UNDERLINE) && txtDecor.push('underline');
-    matchBinaryMask(fontStyle, FONT.STRIKETHROUGH) && txtDecor.push('line-through');
+    matchBinaryMask(fontStyle, FONT_STYLE_FLAG.UNDERLINE) && txtDecor.push('underline');
+    matchBinaryMask(fontStyle, FONT_STYLE_FLAG.STRIKETHROUGH) &&
+      txtDecor.push('line-through');
     txtDecor.length > 0 && (css += `text-decoration: ${txtDecor.join(' ')}; `);
 
     return css;
@@ -1646,12 +1650,15 @@ class SvgCanvas2D extends AbstractCanvas2D {
     }
 
     const fontStyle = s.fontStyle;
-    matchBinaryMask(fontStyle, FONT.BOLD) && node.setAttribute('font-weight', 'bold');
-    matchBinaryMask(fontStyle, FONT.ITALIC) && node.setAttribute('font-style', 'italic');
+    matchBinaryMask(fontStyle, FONT_STYLE_FLAG.BOLD) &&
+      node.setAttribute('font-weight', 'bold');
+    matchBinaryMask(fontStyle, FONT_STYLE_FLAG.ITALIC) &&
+      node.setAttribute('font-style', 'italic');
 
     const txtDecor = [];
-    matchBinaryMask(fontStyle, FONT.UNDERLINE) && txtDecor.push('underline');
-    matchBinaryMask(fontStyle, FONT.STRIKETHROUGH) && txtDecor.push('line-through');
+    matchBinaryMask(fontStyle, FONT_STYLE_FLAG.UNDERLINE) && txtDecor.push('underline');
+    matchBinaryMask(fontStyle, FONT_STYLE_FLAG.STRIKETHROUGH) &&
+      txtDecor.push('line-through');
     txtDecor.length > 0 && node.setAttribute('text-decoration', txtDecor.join(' '));
   }
 
@@ -1720,8 +1727,10 @@ class SvgCanvas2D extends AbstractCanvas2D {
         div.style.visibility = 'hidden';
         div.style.display = 'inline-block';
 
-        matchBinaryMask(s.fontStyle, FONT.BOLD) && (div.style.fontWeight = 'bold');
-        matchBinaryMask(s.fontStyle, FONT.ITALIC) && (div.style.fontStyle = 'italic');
+        matchBinaryMask(s.fontStyle, FONT_STYLE_FLAG.BOLD) &&
+          (div.style.fontWeight = 'bold');
+        matchBinaryMask(s.fontStyle, FONT_STYLE_FLAG.ITALIC) &&
+          (div.style.fontStyle = 'italic');
 
         str = htmlEntities(str, false);
         div.innerHTML = str.replace(/\n/g, '<br/>');

--- a/packages/core/src/view/geometry/node/TextShape.ts
+++ b/packages/core/src/view/geometry/node/TextShape.ts
@@ -23,7 +23,7 @@ import {
   DEFAULT_FONTSIZE,
   DEFAULT_FONTSTYLE,
   DEFAULT_TEXT_DIRECTION,
-  FONT_STYLE_FLAG,
+  FONT_STYLE_MASK,
   NONE,
   WORD_WRAP,
   LINE_HEIGHT,
@@ -594,15 +594,15 @@ class TextShape extends Shape {
         this.color
       }; line-height: ${lh}; pointer-events: ${this.pointerEvents ? 'all' : 'none'}; `;
 
-    matchBinaryMask(this.fontStyle, FONT_STYLE_FLAG.BOLD) &&
+    matchBinaryMask(this.fontStyle, FONT_STYLE_MASK.BOLD) &&
       (css += 'font-weight: bold; ');
-    matchBinaryMask(this.fontStyle, FONT_STYLE_FLAG.ITALIC) &&
+    matchBinaryMask(this.fontStyle, FONT_STYLE_MASK.ITALIC) &&
       (css += 'font-style: italic; ');
 
     const txtDecor = [];
-    matchBinaryMask(this.fontStyle, FONT_STYLE_FLAG.UNDERLINE) &&
+    matchBinaryMask(this.fontStyle, FONT_STYLE_MASK.UNDERLINE) &&
       txtDecor.push('underline');
-    matchBinaryMask(this.fontStyle, FONT_STYLE_FLAG.STRIKETHROUGH) &&
+    matchBinaryMask(this.fontStyle, FONT_STYLE_MASK.STRIKETHROUGH) &&
       txtDecor.push('line-through');
     txtDecor.length > 0 && (css += `text-decoration: ${txtDecor.join(' ')}; `);
 
@@ -799,18 +799,18 @@ class TextShape extends Shape {
     style.verticalAlign = 'top';
     style.color = this.color;
 
-    matchBinaryMask(this.fontStyle, FONT_STYLE_FLAG.BOLD)
+    matchBinaryMask(this.fontStyle, FONT_STYLE_MASK.BOLD)
       ? (style.fontWeight = 'bold')
       : (style.fontWeight = '');
 
-    matchBinaryMask(this.fontStyle, FONT_STYLE_FLAG.ITALIC)
+    matchBinaryMask(this.fontStyle, FONT_STYLE_MASK.ITALIC)
       ? (style.fontStyle = 'italic')
       : (style.fontStyle = '');
 
     const txtDecor = [];
-    matchBinaryMask(this.fontStyle, FONT_STYLE_FLAG.UNDERLINE) &&
+    matchBinaryMask(this.fontStyle, FONT_STYLE_MASK.UNDERLINE) &&
       txtDecor.push('underline');
-    matchBinaryMask(this.fontStyle, FONT_STYLE_FLAG.STRIKETHROUGH) &&
+    matchBinaryMask(this.fontStyle, FONT_STYLE_MASK.STRIKETHROUGH) &&
       txtDecor.push('line-through');
     txtDecor.length > 0 && (style.textDecoration = txtDecor.join(' '));
 

--- a/packages/core/src/view/geometry/node/TextShape.ts
+++ b/packages/core/src/view/geometry/node/TextShape.ts
@@ -23,7 +23,7 @@ import {
   DEFAULT_FONTSIZE,
   DEFAULT_FONTSTYLE,
   DEFAULT_TEXT_DIRECTION,
-  FONT,
+  FONT_STYLE_FLAG,
   NONE,
   WORD_WRAP,
   LINE_HEIGHT,
@@ -594,12 +594,16 @@ class TextShape extends Shape {
         this.color
       }; line-height: ${lh}; pointer-events: ${this.pointerEvents ? 'all' : 'none'}; `;
 
-    matchBinaryMask(this.fontStyle, FONT.BOLD) && (css += 'font-weight: bold; ');
-    matchBinaryMask(this.fontStyle, FONT.ITALIC) && (css += 'font-style: italic; ');
+    matchBinaryMask(this.fontStyle, FONT_STYLE_FLAG.BOLD) &&
+      (css += 'font-weight: bold; ');
+    matchBinaryMask(this.fontStyle, FONT_STYLE_FLAG.ITALIC) &&
+      (css += 'font-style: italic; ');
 
     const txtDecor = [];
-    matchBinaryMask(this.fontStyle, FONT.UNDERLINE) && txtDecor.push('underline');
-    matchBinaryMask(this.fontStyle, FONT.STRIKETHROUGH) && txtDecor.push('line-through');
+    matchBinaryMask(this.fontStyle, FONT_STYLE_FLAG.UNDERLINE) &&
+      txtDecor.push('underline');
+    matchBinaryMask(this.fontStyle, FONT_STYLE_FLAG.STRIKETHROUGH) &&
+      txtDecor.push('line-through');
     txtDecor.length > 0 && (css += `text-decoration: ${txtDecor.join(' ')}; `);
 
     return css;
@@ -795,17 +799,19 @@ class TextShape extends Shape {
     style.verticalAlign = 'top';
     style.color = this.color;
 
-    matchBinaryMask(this.fontStyle, FONT.BOLD)
+    matchBinaryMask(this.fontStyle, FONT_STYLE_FLAG.BOLD)
       ? (style.fontWeight = 'bold')
       : (style.fontWeight = '');
 
-    matchBinaryMask(this.fontStyle, FONT.ITALIC)
+    matchBinaryMask(this.fontStyle, FONT_STYLE_FLAG.ITALIC)
       ? (style.fontStyle = 'italic')
       : (style.fontStyle = '');
 
     const txtDecor = [];
-    matchBinaryMask(this.fontStyle, FONT.UNDERLINE) && txtDecor.push('underline');
-    matchBinaryMask(this.fontStyle, FONT.STRIKETHROUGH) && txtDecor.push('line-through');
+    matchBinaryMask(this.fontStyle, FONT_STYLE_FLAG.UNDERLINE) &&
+      txtDecor.push('underline');
+    matchBinaryMask(this.fontStyle, FONT_STYLE_FLAG.STRIKETHROUGH) &&
+      txtDecor.push('line-through');
     txtDecor.length > 0 && (style.textDecoration = txtDecor.join(' '));
 
     if (this.align === 'center') {

--- a/packages/core/src/view/plugins/CellEditorHandler.ts
+++ b/packages/core/src/view/plugins/CellEditorHandler.ts
@@ -25,7 +25,7 @@ import {
   DEFAULT_FONTFAMILY,
   DEFAULT_FONTSIZE,
   DEFAULT_TEXT_DIRECTION,
-  FONT,
+  FONT_STYLE_FLAG,
   LINE_HEIGHT,
   NONE,
   WORD_WRAP,
@@ -696,14 +696,14 @@ class CellEditorHandler implements GraphPlugin {
       const family = state.style.fontFamily ?? DEFAULT_FONTFAMILY;
       const color = state.style.fontColor ?? 'black';
       const align = state.style.align ?? 'left';
-      const bold = (state.style.fontStyle || 0) & FONT.BOLD;
-      const italic = (state.style.fontStyle || 0) & FONT.ITALIC;
+      const bold = (state.style.fontStyle || 0) & FONT_STYLE_FLAG.BOLD;
+      const italic = (state.style.fontStyle || 0) & FONT_STYLE_FLAG.ITALIC;
 
       const txtDecor = [];
-      if ((state.style.fontStyle || 0) & FONT.UNDERLINE) {
+      if ((state.style.fontStyle || 0) & FONT_STYLE_FLAG.UNDERLINE) {
         txtDecor.push('underline');
       }
-      if ((state.style.fontStyle || 0) & FONT.STRIKETHROUGH) {
+      if ((state.style.fontStyle || 0) & FONT_STYLE_FLAG.STRIKETHROUGH) {
         txtDecor.push('line-through');
       }
 

--- a/packages/core/src/view/plugins/CellEditorHandler.ts
+++ b/packages/core/src/view/plugins/CellEditorHandler.ts
@@ -45,7 +45,7 @@ import {
   isShiftDown,
 } from '../../util/EventUtils';
 import EventSource from '../event/EventSource';
-
+import { matchBinaryMask } from '../../internal/utils';
 import type { AbstractGraph } from '../AbstractGraph';
 import type { AlignValue, GraphPlugin } from '../../types';
 import type TooltipHandler from './TooltipHandler';
@@ -691,47 +691,47 @@ class CellEditorHandler implements GraphPlugin {
 
     if (state) {
       // Configures the style of the in-place editor
-      const { scale } = this.graph.getView();
-      const size = state.style.fontSize ?? DEFAULT_FONTSIZE;
-      const family = state.style.fontFamily ?? DEFAULT_FONTFAMILY;
-      const color = state.style.fontColor ?? 'black';
-      const align = state.style.align ?? 'left';
-      const bold = (state.style.fontStyle || 0) & FONT_STYLE_MASK.BOLD;
-      const italic = (state.style.fontStyle || 0) & FONT_STYLE_MASK.ITALIC;
+      // Notice that the logic here is duplicated with styleUtils.getSizeForString
+      const stateStyle = state.style;
+      const size = stateStyle.fontSize ?? DEFAULT_FONTSIZE;
+      const family = stateStyle.fontFamily ?? DEFAULT_FONTFAMILY;
+      const color = stateStyle.fontColor ?? 'black';
+      const align = stateStyle.align ?? 'left';
+      const fontStyle = stateStyle.fontStyle ?? 0;
+      const bold = matchBinaryMask(fontStyle, FONT_STYLE_MASK.BOLD);
+      const italic = matchBinaryMask(fontStyle, FONT_STYLE_MASK.ITALIC);
 
       const txtDecor = [];
-      if ((state.style.fontStyle || 0) & FONT_STYLE_MASK.UNDERLINE) {
-        txtDecor.push('underline');
-      }
-      if ((state.style.fontStyle || 0) & FONT_STYLE_MASK.STRIKETHROUGH) {
+      matchBinaryMask(fontStyle, FONT_STYLE_MASK.UNDERLINE) && txtDecor.push('underline');
+      matchBinaryMask(fontStyle, FONT_STYLE_MASK.STRIKETHROUGH) &&
         txtDecor.push('line-through');
-      }
 
-      const textarea = <HTMLElement>this.textarea;
-      textarea.style.lineHeight = ABSOLUTE_LINE_HEIGHT
+      const textarea = this.textarea!; // code above ensure it is always set
+      const textareaStyle = textarea.style;
+      textareaStyle.lineHeight = ABSOLUTE_LINE_HEIGHT
         ? `${Math.round(size * LINE_HEIGHT)}px`
         : String(LINE_HEIGHT);
-      textarea.style.backgroundColor = this.getBackgroundColor(state) || 'transparent';
-      textarea.style.textDecoration = txtDecor.join(' ');
-      textarea.style.fontWeight = bold ? 'bold' : 'normal';
-      textarea.style.fontStyle = italic ? 'italic' : '';
-      textarea.style.fontSize = `${Math.round(size)}px`;
-      textarea.style.zIndex = String(this.zIndex);
-      textarea.style.fontFamily = family;
-      textarea.style.textAlign = align;
-      textarea.style.outline = 'none';
-      textarea.style.color = color;
+      textareaStyle.backgroundColor = this.getBackgroundColor(state) || 'transparent';
+      textareaStyle.textDecoration = txtDecor.join(' ');
+      textareaStyle.fontWeight = bold ? 'bold' : 'normal';
+      textareaStyle.fontStyle = italic ? 'italic' : '';
+      textareaStyle.fontSize = `${Math.round(size)}px`;
+      textareaStyle.zIndex = String(this.zIndex);
+      textareaStyle.fontFamily = family;
+      textareaStyle.textAlign = align;
+      textareaStyle.outline = 'none';
+      textareaStyle.color = color;
 
-      let dir = (this.textDirection =
-        state.style.textDirection ?? DEFAULT_TEXT_DIRECTION);
+      let dir = (this.textDirection = stateStyle.textDirection ?? DEFAULT_TEXT_DIRECTION);
 
+      const stateText = state.text;
       if (dir === 'auto') {
         if (
-          state.text !== null &&
-          state.text.dialect !== 'strictHtml' &&
-          !isNode(state.text.value)
+          stateText !== null &&
+          stateText.dialect !== 'strictHtml' &&
+          !isNode(stateText.value)
         ) {
-          dir = state.text.getAutoDirection();
+          dir = stateText.getAutoDirection();
         }
       }
 
@@ -763,13 +763,13 @@ class CellEditorHandler implements GraphPlugin {
       this.trigger = trigger;
       this.textNode = null;
 
-      if (state.text !== null && this.isHideLabel(state)) {
-        this.textNode = <SVGGElement>state.text.node;
+      if (stateText !== null && this.isHideLabel(state)) {
+        this.textNode = stateText.node;
         this.textNode.style.visibility = 'hidden';
       }
 
       // Workaround for initial offsetHeight not ready for heading in markup
-      if (this.autoSize && (state.cell.isEdge() || state.style.overflow !== 'fill')) {
+      if (this.autoSize && (state.cell.isEdge() || stateStyle.overflow !== 'fill')) {
         window.setTimeout(() => {
           this.resize();
         }, 0);

--- a/packages/core/src/view/plugins/CellEditorHandler.ts
+++ b/packages/core/src/view/plugins/CellEditorHandler.ts
@@ -25,7 +25,7 @@ import {
   DEFAULT_FONTFAMILY,
   DEFAULT_FONTSIZE,
   DEFAULT_TEXT_DIRECTION,
-  FONT_STYLE_FLAG,
+  FONT_STYLE_MASK,
   LINE_HEIGHT,
   NONE,
   WORD_WRAP,
@@ -696,14 +696,14 @@ class CellEditorHandler implements GraphPlugin {
       const family = state.style.fontFamily ?? DEFAULT_FONTFAMILY;
       const color = state.style.fontColor ?? 'black';
       const align = state.style.align ?? 'left';
-      const bold = (state.style.fontStyle || 0) & FONT_STYLE_FLAG.BOLD;
-      const italic = (state.style.fontStyle || 0) & FONT_STYLE_FLAG.ITALIC;
+      const bold = (state.style.fontStyle || 0) & FONT_STYLE_MASK.BOLD;
+      const italic = (state.style.fontStyle || 0) & FONT_STYLE_MASK.ITALIC;
 
       const txtDecor = [];
-      if ((state.style.fontStyle || 0) & FONT_STYLE_FLAG.UNDERLINE) {
+      if ((state.style.fontStyle || 0) & FONT_STYLE_MASK.UNDERLINE) {
         txtDecor.push('underline');
       }
-      if ((state.style.fontStyle || 0) & FONT_STYLE_FLAG.STRIKETHROUGH) {
+      if ((state.style.fontStyle || 0) & FONT_STYLE_MASK.STRIKETHROUGH) {
         txtDecor.push('line-through');
       }
 

--- a/packages/html/stories/EdgeCurvedAndRounded.stories.ts
+++ b/packages/html/stories/EdgeCurvedAndRounded.stories.ts
@@ -91,12 +91,12 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   style.perimeter = Perimeter.EllipsePerimeter;
   style.fontColor = 'white';
   style.gradientColor = 'white';
-  style.fontStyle = constants.FONT.BOLD;
+  style.fontStyle = constants.FONT_STYLE_FLAG.BOLD;
   style.fontSize = 14;
 
   // Makes all edges with a black, bold label
   style = graph.stylesheet.getDefaultEdgeStyle();
-  style.fontStyle = constants.FONT.BOLD;
+  style.fontStyle = constants.FONT_STYLE_FLAG.BOLD;
   style.fontColor = 'black';
   style.strokeWidth = 2;
   if (args.style === 'curved') style.curved = true;

--- a/packages/html/stories/EdgeCurvedAndRounded.stories.ts
+++ b/packages/html/stories/EdgeCurvedAndRounded.stories.ts
@@ -91,12 +91,12 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   style.perimeter = Perimeter.EllipsePerimeter;
   style.fontColor = 'white';
   style.gradientColor = 'white';
-  style.fontStyle = constants.FONT_STYLE_FLAG.BOLD;
+  style.fontStyle = constants.FONT_STYLE_MASK.BOLD;
   style.fontSize = 14;
 
   // Makes all edges with a black, bold label
   style = graph.stylesheet.getDefaultEdgeStyle();
-  style.fontStyle = constants.FONT_STYLE_FLAG.BOLD;
+  style.fontStyle = constants.FONT_STYLE_MASK.BOLD;
   style.fontColor = 'black';
   style.strokeWidth = 2;
   if (args.style === 'curved') style.curved = true;

--- a/packages/html/stories/HoverStyle.stories.js
+++ b/packages/html/stories/HoverStyle.stories.js
@@ -45,7 +45,7 @@ const Template = ({ label, ...args }) => {
     // once it is set, whereas the above overrides the default value
     state.style.rounded = hover ? '1' : '0';
     state.style.strokeWidth = hover ? '4' : '1';
-    state.style.fontStyle = hover ? constants.FONT.BOLD : '0';
+    state.style.fontStyle = hover ? constants.FONT_STYLE_FLAG.BOLD : '0';
   }
 
   // Changes fill color to red on mouseover

--- a/packages/html/stories/HoverStyle.stories.js
+++ b/packages/html/stories/HoverStyle.stories.js
@@ -45,7 +45,7 @@ const Template = ({ label, ...args }) => {
     // once it is set, whereas the above overrides the default value
     state.style.rounded = hover ? '1' : '0';
     state.style.strokeWidth = hover ? '4' : '1';
-    state.style.fontStyle = hover ? constants.FONT_STYLE_FLAG.BOLD : '0';
+    state.style.fontStyle = hover ? constants.FONT_STYLE_MASK.BOLD : '0';
   }
 
   // Changes fill color to red on mouseover

--- a/packages/html/stories/Merge.stories.ts
+++ b/packages/html/stories/Merge.stories.ts
@@ -71,13 +71,13 @@ const Template = ({ label, ...args }: Record<string, any>) => {
   style.perimeter = Perimeter.EllipsePerimeter;
   style.fontColor = 'white';
   style.gradientColor = 'white';
-  style.fontStyle = constants.FONT_STYLE_FLAG.BOLD;
+  style.fontStyle = constants.FONT_STYLE_MASK.BOLD;
   style.fontSize = 14;
   style.shadow = true;
 
   // Makes all edges with a black, bold label
   style = graph.stylesheet.getDefaultEdgeStyle();
-  style.fontStyle = constants.FONT_STYLE_FLAG.BOLD;
+  style.fontStyle = constants.FONT_STYLE_MASK.BOLD;
   style.fontColor = 'black';
   style.strokeWidth = 2;
 

--- a/packages/html/stories/Merge.stories.ts
+++ b/packages/html/stories/Merge.stories.ts
@@ -71,13 +71,13 @@ const Template = ({ label, ...args }: Record<string, any>) => {
   style.perimeter = Perimeter.EllipsePerimeter;
   style.fontColor = 'white';
   style.gradientColor = 'white';
-  style.fontStyle = constants.FONT.BOLD;
+  style.fontStyle = constants.FONT_STYLE_FLAG.BOLD;
   style.fontSize = 14;
   style.shadow = true;
 
   // Makes all edges with a black, bold label
   style = graph.stylesheet.getDefaultEdgeStyle();
-  style.fontStyle = constants.FONT.BOLD;
+  style.fontStyle = constants.FONT_STYLE_FLAG.BOLD;
   style.fontColor = 'black';
   style.strokeWidth = 2;
 

--- a/packages/html/stories/SecondLabel.stories.js
+++ b/packages/html/stories/SecondLabel.stories.js
@@ -127,7 +127,7 @@ const Template = ({ label, ...args }) => {
         state.secondLabel.color = 'black';
         state.secondLabel.family = 'Verdana';
         state.secondLabel.size = 8;
-        state.secondLabel.fontStyle = constants.FONT.ITALIC;
+        state.secondLabel.fontStyle = constants.FONT_STYLE_FLAG.ITALIC;
         state.secondLabel.background = 'yellow';
         state.secondLabel.border = 'black';
         state.secondLabel.valign = 'bottom';

--- a/packages/html/stories/SecondLabel.stories.js
+++ b/packages/html/stories/SecondLabel.stories.js
@@ -127,7 +127,7 @@ const Template = ({ label, ...args }) => {
         state.secondLabel.color = 'black';
         state.secondLabel.family = 'Verdana';
         state.secondLabel.size = 8;
-        state.secondLabel.fontStyle = constants.FONT_STYLE_FLAG.ITALIC;
+        state.secondLabel.fontStyle = constants.FONT_STYLE_MASK.ITALIC;
         state.secondLabel.background = 'yellow';
         state.secondLabel.border = 'black';
         state.secondLabel.valign = 'bottom';

--- a/packages/ts-example-selected-features/vite.config.js
+++ b/packages/ts-example-selected-features/vite.config.js
@@ -27,7 +27,7 @@ export default defineConfig(({ mode }) => {
           },
         },
       },
-      chunkSizeWarningLimit: 377, // @maxgraph/core
+      chunkSizeWarningLimit: 378, // @maxgraph/core
     },
   };
 });


### PR DESCRIPTION
BREAKING CHANGES: The `constants.FONT` enum has been removed and replaced by the `constants.FONT_STYLE_FLAG` value object.

## Notes

Covers #378



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - None.

- **Refactor**
  - Replaced the font style enum with a constant object for font style flags throughout the application, updating all font style references including UI text styling and editor actions.
  - Improved internal handling of font style flags with enhanced bitmask matching supporting nullish values.

- **Documentation**
  - Updated changelog and code comments to reflect the new font style flag usage.

- **Tests**
  - Updated test cases to use the new font style flag constants.

- **Chores**
  - Increased the chunk size warning limit in the build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->