### PR TITLE
fix: correctly set italic in `styleUtils.getSizeForString`

### DIFF
--- a/packages/core/src/util/styleUtils.ts
+++ b/packages/core/src/util/styleUtils.ts
@@ -433,7 +433,7 @@ export const setOpacity = (node: HTMLElement | SVGElement, value: number) => {
  * @param fontSize Integer that specifies the font size in pixels. Default is {@link DEFAULT_FONTSIZE}.
  * @param fontFamily String that specifies the name of the font family. Default is {@link DEFAULT_FONTFAMILY}.
  * @param textWidth Optional width for text wrapping.
- * @param fontStyle Optional font style.
+ * @param fontStyle Optional font style, value generally taken from {@link CellStateStyle.fontStyle}.
  */
 export const getSizeForString = (
   text: string,
@@ -452,7 +452,7 @@ export const getSizeForString = (
   // Sets the font style
   if (fontStyle !== null) {
     matchBinaryMask(fontStyle, FONT.BOLD) && (div.style.fontWeight = 'bold');
-    matchBinaryMask(fontStyle, FONT.ITALIC) && (div.style.fontWeight = 'italic');
+    matchBinaryMask(fontStyle, FONT.ITALIC) && (div.style.fontStyle = 'italic');
 
     const txtDecor = [];
     matchBinaryMask(fontStyle, FONT.UNDERLINE) && txtDecor.push('underline');


### PR DESCRIPTION
The problem was introduced in 6fc05a38, probably by a wrong copy/paste of the previous line of code.
When the text was in italic, the style attribute 'fontWeight' was incorrectly set instead of the 'fontStyle' attribute.
The returned size was then incorrect.

## Notes

Discovered in https://github.com/maxGraph/maxGraph/pull/804#pullrequestreview-2813298816



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the application of italic font style so that text now properly appears italicized when expected.

- **Documentation**
  - Clarified the description of the font style parameter in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->