### PR TITLE
refactor!: standardize style registries with `Registry` interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,11 @@ _**Note:** Yet to be released breaking changes appear here._
   - `EdgeHandlerConfig`
   - `HandleConfig`
   - `VertexHandlerConfig`
+- All registries used to manage "styles" elements now derived from the `Registry` interface for consistency.
+  So, they all share the same methods (add, get and clear) and their internal storage is no longer accessible.
+- The `MarkerShape` registry has been renamed to `MarkerShapeRegistry`.
+- The Shapes are now registered in `ShapeRegistry` instead in `CellRenderer`.
 - `StyleRegistry` has been removed. Use `EdgeStyleRegistry` and `PerimeterRegistry` instead.
-  The methods of the new registries are also named differently.
 
 ## 0.19.0
 

--- a/packages/core/__tests__/view/geometry/node/StencilShapeRegistry.test.ts
+++ b/packages/core/__tests__/view/geometry/node/StencilShapeRegistry.test.ts
@@ -17,8 +17,8 @@ limitations under the License.
 import { describe, expect, test } from '@jest/globals';
 import { StencilShapeRegistry } from '../../../../src';
 
-describe('getStencil', () => {
+describe('get', () => {
   test.each([null, undefined, 'unknown'])('pass %s, return undefined', (name) => {
-    expect(StencilShapeRegistry.getStencil(name)).toBeUndefined();
+    expect(StencilShapeRegistry.get(name)).toBeNull();
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -122,7 +122,7 @@ export {
   default as StencilShape,
   StencilShapeConfig,
 } from './view/geometry/stencil/StencilShape';
-export { default as StencilShapeRegistry } from './view/geometry/stencil/StencilShapeRegistry';
+export * from './view/geometry/stencil/StencilShapeRegistry';
 
 export { default as Guide } from './view/other/Guide';
 
@@ -197,12 +197,13 @@ export { default as Geometry } from './view/geometry/Geometry';
 export { default as ObjectIdentity } from './util/ObjectIdentity';
 export { default as Point } from './view/geometry/Point';
 export { default as Rectangle } from './view/geometry/Rectangle';
+export * from './view/geometry/ShapeRegistry';
 
 export * from './view/style/builtin-style-elements';
 export * from './view/style/config';
 export * from './view/style/register';
 export * from './view/style/edge/EdgeStyleRegistry';
-export { default as MarkerShape } from './view/style/marker/EdgeMarkerRegistry';
+export { EdgeMarkerRegistry } from './view/style/marker/EdgeMarkerRegistry';
 export { PerimeterRegistry } from './view/style/perimeter/PerimeterRegistry';
 export { Stylesheet } from './view/style/Stylesheet';
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1564,3 +1564,32 @@ export interface EdgeStyleRegistryInterface extends Registry<EdgeStyleFunction> 
    */
   getHandlerKind(edgeStyle?: EdgeStyleFunction | null): EdgeStyleHandlerKind;
 }
+
+/**
+ * The definition of a registry that stores the {@link MarkerFactoryFunction}s and their configuration.
+ *
+ * @since 0.20.0
+ * @category Style
+ * @category Configuration
+ */
+export interface EdgeMarkerRegistryInterface extends Registry<MarkerFactoryFunction> {
+  /**
+   * Returns a {@link MarkerFunction} to paint the given marker.
+   *
+   * The type parameter is used to retrieve the correct {@link MarkerFactoryFunction} from the registry which is then used to create the {@link MarkerFunction}.
+   *
+   * If none is found, `null` is returned.
+   */
+  createMarker(
+    canvas: AbstractCanvas2D,
+    shape: Shape,
+    type: StyleArrowValue,
+    pe: Point,
+    unitX: number,
+    unitY: number,
+    size: number,
+    source: boolean,
+    sw: number,
+    filled: boolean
+  ): MarkerFunction | null;
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -212,7 +212,7 @@ export type CellStateStyle = {
   /**
    * This defines the style of the end arrow marker.
    *
-   * Possible values are all names of registered arrow markers with {@link MarkerShape.addMarker}.
+   * Possible values are all names of registered arrow markers with {@link EdgeMarkerRegistry.add}.
    * This includes {@link ArrowValue} values and custom names that have been registered.
    *
    * See {@link startArrow}.
@@ -761,7 +761,7 @@ export type CellStateStyle = {
   /**
    * This defines the style of the start arrow marker.
    *
-   * Possible values are all names of registered arrow markers with {@link MarkerShape.addMarker}.
+   * Possible values are all names of registered arrow markers with {@link EdgeMarkerRegistry.add}.
    * This includes {@link ArrowValue} values and the names of any new shapes.
    *
    * See {@link endArrow}.
@@ -938,7 +938,7 @@ export type OverflowValue = 'fill' | 'width' | 'auto' | 'hidden' | 'scroll' | 'v
 /** @category Style */
 export type WhiteSpaceValue = 'normal' | 'wrap' | 'nowrap' | 'pre';
 /**
- * Names used to register the edge markers provided out-of-the-box by maxGraph with {@link MarkerShape.addMarker}.
+ * Names used to register the edge markers provided out-of-the-box by maxGraph with {@link EdgeMarkerRegistry.add}.
  *
  * Can be used as a value for {@link CellStateStyle.startArrow} and {@link CellStateStyle.endArrow}.
  *

--- a/packages/core/src/view/cell/CellRenderer.ts
+++ b/packages/core/src/view/cell/CellRenderer.ts
@@ -45,7 +45,7 @@ import Cell from './Cell';
 import CellOverlay from './CellOverlay';
 import { getClientX, getClientY, getSource } from '../../util/EventUtils';
 import { isNode } from '../../util/domUtils';
-import type { CellStateStyle, ShapeConstructor, StyleShapeValue } from '../../types';
+import type { CellStateStyle, ShapeConstructor } from '../../types';
 import type SelectionCellsHandler from '../plugins/SelectionCellsHandler';
 
 const placeholderStyleValues = ['inherit', 'swimlane', 'indicated'];

--- a/packages/core/src/view/cell/CellRenderer.ts
+++ b/packages/core/src/view/cell/CellRenderer.ts
@@ -31,7 +31,8 @@ import { getRotatedPoint, mod, toRadians } from '../../util/mathUtils';
 import { convertPoint } from '../../util/styleUtils';
 import { equalEntries, equalPoints } from '../../util/arrayUtils';
 import Rectangle from '../geometry/Rectangle';
-import StencilShapeRegistry from '../geometry/stencil/StencilShapeRegistry';
+import { ShapeRegistry } from '../geometry/ShapeRegistry';
+import { StencilShapeRegistry } from '../geometry/stencil/StencilShapeRegistry';
 import InternalEvent from '../event/InternalEvent';
 import Client from '../../Client';
 import InternalMouseEvent from '../event/InternalMouseEvent';
@@ -56,45 +57,16 @@ const placeholderStyleProperties: (keyof CellStateStyle)[] = [
 ];
 
 /**
- * Renders cells into a document object model. The <defaultShapes> is a global
- * map of shape names, constructor pairs that is used in all instances. You can
- * get a list of all available shape names using the following code.
+ * Renders {@link Cell}s into a document object model.
  *
- * In general the cell renderer is in charge of creating, redrawing and
- * destroying the shape and label associated with a cell state, as well as
- * some other graphical objects, namely controls and overlays. The shape
- * hierarchy in the display (i.e. the hierarchy in which the DOM nodes
- * appear in the document) does not reflect the cell hierarchy. The shapes
- * are a (flat) sequence of shapes and labels inside the draw pane of the
- * graph view, with some exceptions, namely the HTML labels being placed
- * directly inside the graph container for certain browsers.
+ * In general, the `CellRenderer` is in charge of creating, redrawing and destroying the shape and label associated with a cell state,
+ * as well as some other graphical objects, namely controls and overlays.
+ *
+ * The shape hierarchy in the display (i.e. the hierarchy in which the DOM nodes appear in the document) does not reflect the cell hierarchy.
+ * The shapes are a (flat) sequence of shapes and labels inside the draw pane of the {@link GraphView}, with some exceptions,
+ * namely the HTML labels being placed directly inside the graph container for certain browsers.
  */
 class CellRenderer {
-  /**
-   * Static array that contains the globally registered shapes which are known to all instances of this class.
-   *
-   * For adding new shapes you should use {@link CellRenderer.registerShape}.
-   *
-   * Built-in shapes:
-   * - actor
-   * - arrow
-   * - arrow connector (for edges)
-   * - cloud
-   * - connector (for edges)
-   * - cylinder
-   * - double ellipse
-   * - ellipse
-   * - hexagon
-   * - image
-   * - label
-   * - line (for edges)
-   * - rectangle
-   * - rhombus
-   * - swimlane
-   * - triangle
-   */
-  static defaultShapes: { [key: string]: typeof Shape } = {};
-
   /**
    * Defines the default shape for edges.
    * @default {@link ConnectorShape}
@@ -144,21 +116,6 @@ class CellRenderer {
   forceControlClickHandler = false;
 
   /**
-   * Registers the given constructor under the specified key in this instance of the renderer.
-   *
-   * For example:
-   * ```javascript
-   * CellRenderer.registerShape('rectangle', RectangleShape);
-   * ```
-   *
-   * @param key the shape name.
-   * @param shape constructor of the {@link Shape} subclass.
-   */
-  static registerShape(key: StyleShapeValue, shape: ShapeConstructor): void {
-    CellRenderer.defaultShapes[key] = shape;
-  }
-
-  /**
    * Initializes the shape in the given state by calling its init method with
    * the correct container after configuring it using {@link configureShape}.
    *
@@ -179,7 +136,7 @@ class CellRenderer {
    */
   createShape(state: CellState): Shape {
     // Checks if there is a stencil for the name and creates a shape instance for the stencil if one exists
-    const stencil = StencilShapeRegistry.getStencil(state.style.shape);
+    const stencil = StencilShapeRegistry.get(state.style.shape);
     if (stencil) {
       return new Shape(stencil);
     }
@@ -199,10 +156,10 @@ class CellRenderer {
   }
 
   /**
-   * Returns the shape for the given name from {@link defaultShapes}.
+   * Returns the shape for the given name from {@link ShapeRegistry}.
    */
   getShape(name?: string | null): ShapeConstructor | null {
-    return name ? CellRenderer.defaultShapes[name] : null;
+    return ShapeRegistry.get(name);
   }
 
   /**

--- a/packages/core/src/view/cell/register-shapes.ts
+++ b/packages/core/src/view/cell/register-shapes.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import CellRenderer from './CellRenderer';
+import { ShapeRegistry } from '../geometry/ShapeRegistry';
 import type { ShapeConstructor, ShapeValue } from '../../types';
 import RectangleShape from '../geometry/node/RectangleShape';
 import EllipseShape from '../geometry/node/EllipseShape';
@@ -63,7 +63,7 @@ export function registerDefaultShapes() {
       ['triangle', TriangleShape],
     ];
     for (const [shapeName, shapeClass] of shapesToRegister) {
-      CellRenderer.registerShape(shapeName, shapeClass);
+      ShapeRegistry.add(shapeName, shapeClass);
     }
 
     isDefaultElementsRegistered = true;
@@ -71,13 +71,13 @@ export function registerDefaultShapes() {
 }
 
 /**
- * Unregister all shapes from {@link CellRenderer}.
+ * Unregister all shapes from {@link ShapeRegistry}.
  *
  * @category Configuration
  * @category Style
  * @since 0.18.0
  */
 export function unregisterAllShapes() {
-  CellRenderer.defaultShapes = {};
+  ShapeRegistry.clear();
   isDefaultElementsRegistered = false;
 }

--- a/packages/core/src/view/geometry/ShapeRegistry.ts
+++ b/packages/core/src/view/geometry/ShapeRegistry.ts
@@ -1,0 +1,49 @@
+/*
+Copyright 2021-present The maxGraph project Contributors
+Copyright (c) 2006-2015, JGraph Ltd
+Copyright (c) 2006-2015, Gaudenz Alder
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import type { Registry, ShapeConstructor } from '../../types';
+import { BaseRegistry } from '../../internal/BaseRegistry';
+
+/**
+ * A registry that stores the {@link ShapeConstructor}s and their configuration.
+ *
+ * For adding new shapes you should use {@link ShapeRegistry.add}.
+ *
+ * Names generally used to register the built-in shapes:
+ * - actor
+ * - arrow
+ * - arrow connector (for edges)
+ * - cloud
+ * - connector (for edges)
+ * - cylinder
+ * - double ellipse
+ * - ellipse
+ * - hexagon
+ * - image
+ * - label
+ * - line (for edges)
+ * - rectangle
+ * - rhombus
+ * - swimlane
+ * - triangle
+ *
+ * @since 0.20.0
+ * @category Configuration
+ * @category Shape
+ */
+export const ShapeRegistry: Registry<ShapeConstructor> = new BaseRegistry();

--- a/packages/core/src/view/geometry/edge/ConnectorShape.ts
+++ b/packages/core/src/view/geometry/edge/ConnectorShape.ts
@@ -18,7 +18,7 @@ limitations under the License.
 
 import { DEFAULT_MARKERSIZE, NONE } from '../../../util/Constants';
 import PolylineShape from './PolylineShape';
-import MarkerShape from '../../style/marker/EdgeMarkerRegistry';
+import { EdgeMarkerRegistry } from '../../style/marker/EdgeMarkerRegistry';
 import Point from '../Point';
 import AbstractCanvas2D from '../../canvas/AbstractCanvas2D';
 import Rectangle from '../Rectangle';
@@ -121,7 +121,7 @@ class ConnectorShape extends PolylineShape {
       // orthogonal vectors describing the direction of the marker
       const filled = (source ? this.style.startFill : this.style.endFill) ?? true;
 
-      result = MarkerShape.createMarker(
+      result = EdgeMarkerRegistry.createMarker(
         c,
         this,
         type,

--- a/packages/core/src/view/geometry/stencil/StencilShape.ts
+++ b/packages/core/src/view/geometry/stencil/StencilShape.ts
@@ -20,7 +20,7 @@ import ConnectionConstraint from '../../other/ConnectionConstraint';
 import Rectangle from '../Rectangle';
 import Shape from '../Shape';
 import { NONE, RECTANGLE_ROUNDING_FACTOR } from '../../../util/Constants';
-import StencilShapeRegistry from './StencilShapeRegistry';
+import { StencilShapeRegistry } from './StencilShapeRegistry';
 import { getChildNodes, getTextContent } from '../../../util/domUtils';
 import Point from '../Point';
 import AbstractCanvas2D from '../../canvas/AbstractCanvas2D';
@@ -563,7 +563,7 @@ class StencilShape extends Shape {
           );
         }
       } else if (name === 'include-shape') {
-        const stencil = StencilShapeRegistry.getStencil(node.getAttribute('name'));
+        const stencil = StencilShapeRegistry.get(node.getAttribute('name'));
 
         if (stencil) {
           const x = x0 + Number(node.getAttribute('x')) * sx;

--- a/packages/core/src/view/geometry/stencil/StencilShapeRegistry.ts
+++ b/packages/core/src/view/geometry/stencil/StencilShapeRegistry.ts
@@ -16,14 +16,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import StencilShape from './StencilShape';
-
-type Stencils = {
-  [k: string]: StencilShape;
-};
+import type StencilShape from './StencilShape';
+import { BaseRegistry } from '../../../internal/BaseRegistry';
+import type { Registry } from '../../../types';
 
 /**
- * A singleton class that provides a registry for stencils and the methods for painting those stencils onto a canvas or into a DOM.
+ * A registry that stores the {@link StencilShape}s and their configuration.
  *
  * Here is an example showing how to add stencils:
  * ```javascript
@@ -33,7 +31,7 @@ type Stencils = {
  *
  * while (shape) {
  *   if (shape.nodeType === constants.NODE_TYPE.ELEMENT) {
- *    StencilShapeRegistry.addStencil(shape.getAttribute('name'), new StencilShape(shape));
+ *    StencilShapeRegistry.add(shape.getAttribute('name'), new StencilShape(shape));
  *  }
  *
  *  shape = shape.nextSibling;
@@ -45,23 +43,4 @@ type Stencils = {
  * @category Configuration
  * @category Shape
  */
-class StencilShapeRegistry {
-  static stencils: Stencils = {};
-
-  /**
-   * Adds the given {@link StencilShape}.
-   */
-  static addStencil(name: string, stencil: StencilShape): void {
-    StencilShapeRegistry.stencils[name] = stencil;
-  }
-
-  /**
-   * Returns the {@link StencilShape} for the given name.
-   */
-  static getStencil(name?: string | null): StencilShape | undefined {
-    // Tests are validating that using the non-null assertion (!) is safe
-    return StencilShapeRegistry.stencils[name!];
-  }
-}
-
-export default StencilShapeRegistry;
+export const StencilShapeRegistry: Registry<StencilShape> = new BaseRegistry();

--- a/packages/core/src/view/geometry/stencil/register.ts
+++ b/packages/core/src/view/geometry/stencil/register.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import StencilShapeRegistry from './StencilShapeRegistry';
+import { StencilShapeRegistry } from './StencilShapeRegistry';
 
 /**
  * Unregister all {@link StencilShape}s from {@link StencilShapeRegistry}.
@@ -24,5 +24,5 @@ import StencilShapeRegistry from './StencilShapeRegistry';
  * @since 0.18.0
  */
 export function unregisterAllStencilShapes() {
-  StencilShapeRegistry.stencils = {};
+  StencilShapeRegistry.clear();
 }

--- a/packages/core/src/view/style/builtin-style-elements.ts
+++ b/packages/core/src/view/style/builtin-style-elements.ts
@@ -29,7 +29,7 @@ export * as EdgeStyle from './edge';
 export * as Perimeter from './perimeter';
 
 /**
- * Includes all builtins edge markers which can be registered in {@link MarkerShape}.
+ * Includes all builtins edge markers which can be registered in {@link EdgeMarkerRegistry}.
  *
  * They are registered by default when instantiating {@link Graph} or they can all be registered by calling {@link registerDefaultEdgeMarkers}.
  *

--- a/packages/core/src/view/style/marker/EdgeMarkerRegistry.ts
+++ b/packages/core/src/view/style/marker/EdgeMarkerRegistry.ts
@@ -17,6 +17,7 @@ limitations under the License.
 */
 
 import type {
+  EdgeMarkerRegistryInterface,
   MarkerFactoryFunction,
   MarkerFunction,
   StyleArrowValue,
@@ -24,39 +25,13 @@ import type {
 import type AbstractCanvas2D from '../../canvas/AbstractCanvas2D';
 import type Point from '../../geometry/Point';
 import type Shape from '../../geometry/Shape';
+import { BaseRegistry } from '../../../internal/BaseRegistry';
 
-/**
- * A registry that stores the factory functions that create edge markers.
- *
- * NOTE: The signature and the name of in this class will change.
- *
- * @category Configuration
- * @category Style
- */
-class MarkerShape {
-  /**
-   * Maps from markers names to functions to paint the markers.
-   *
-   * Mapping: the attribute name on the object is the marker type, the associated value is the function to paint the marker
-   */
-  static markers: Record<string, MarkerFactoryFunction> = {};
-
-  /**
-   * Adds a factory method that updates a given endpoint and returns a
-   * function to paint the marker onto the given canvas.
-   */
-  static addMarker(type: StyleArrowValue, factory: MarkerFactoryFunction) {
-    MarkerShape.markers[type] = factory;
-  }
-
-  /**
-   * Returns a {@link MarkerFunction} to paint the given marker.
-   *
-   * The type parameter is used to retrieve the correct {@link MarkerFactoryFunction} from the registry which is then used to create the {@link MarkerFunction}.
-   *
-   * If none is found, `null` is returned.
-   */
-  static createMarker(
+class EdgeMarkerRegistryImpl
+  extends BaseRegistry<MarkerFactoryFunction>
+  implements EdgeMarkerRegistryInterface
+{
+  createMarker(
     canvas: AbstractCanvas2D,
     shape: Shape,
     type: StyleArrowValue,
@@ -68,11 +43,21 @@ class MarkerShape {
     sw: number,
     filled: boolean
   ): MarkerFunction | null {
-    const markerFunction = MarkerShape.markers[type];
+    const markerFunction = this.get(type);
     return markerFunction
       ? markerFunction(canvas, shape, type, pe, unitX, unitY, size, source, sw, filled)
       : null;
   }
 }
 
-export default MarkerShape;
+/**
+ * A registry that stores the {@link MarkerFactoryFunction}s and their configuration to let generate {@link MarkerFunction}.
+ *
+ * The name used to register the marker is the marker type. It is then used to create the marker with {@link createMarker}.
+ *
+ * @category Configuration
+ * @category Style
+ * @since 0.20.0
+ */
+export const EdgeMarkerRegistry: EdgeMarkerRegistryInterface =
+  new EdgeMarkerRegistryImpl();

--- a/packages/core/src/view/style/marker/edge-markers.ts
+++ b/packages/core/src/view/style/marker/edge-markers.ts
@@ -31,8 +31,8 @@ const isDiamond = (type: StyleArrowValue): boolean => type === 'diamond';
  *
  * Here is an example the registration of a factory edge marker function with `createArrow`:
  * ```js
- * MarkerShape.addMarker('classic', EdgeMarker.createArrow(2));
- * MarkerShape.addMarker('blockThin', EdgeMarker.createArrow(3));
+ * EdgeMarkerRegistry.add('classic', EdgeMarker.createArrow(2));
+ * EdgeMarkerRegistry.add('blockThin', EdgeMarker.createArrow(3));
  * ```
  *
  * @since 0.18.0
@@ -99,7 +99,7 @@ export const createArrow =
  *
  * Here is an example the registration of a factory edge marker function with `createOpenArrow`:
  * ```js
- * MarkerShape.addMarker('open', createOpenArrow(2));
+ * EdgeMarkerRegistry.add('open', createOpenArrow(2));
  * ```
  *
  * @since 0.18.0
@@ -185,8 +185,8 @@ export const oval = (
  * Generally used to create the "diamond" and "diamond thin" marker factory methods.
  *
  * ```js
- * MarkerShape.addMarker('diamond', diamond);
- * MarkerShape.addMarker('diamondThin', diamond);
+ * EdgeMarkerRegistry.add('diamond', diamond);
+ * EdgeMarkerRegistry.add('diamondThin', diamond);
  * ```
  *
  * @since 0.18.0

--- a/packages/core/src/view/style/register.ts
+++ b/packages/core/src/view/style/register.ts
@@ -130,7 +130,7 @@ export const unregisterAllPerimeters = (): void => {
 let isDefaultMarkersRegistered = false;
 /**
  *
- * Register default builtin {@link MarkerFactoryFunction}s in {@link MarkerShape}.
+ * Register default builtin {@link MarkerFactoryFunction}s in {@link EdgeMarkerRegistry}.
  *
  * @category Configuration
  * @category Style
@@ -157,7 +157,7 @@ export const registerDefaultEdgeMarkers = (): void => {
   }
 };
 /**
- * Unregister all {@link MarkerFactoryFunction}s from {@link MarkerShape}.
+ * Unregister all {@link MarkerFactoryFunction}s from {@link EdgeMarkerRegistry}.
  *
  * @category Configuration
  * @category Style

--- a/packages/core/src/view/style/register.ts
+++ b/packages/core/src/view/style/register.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { EdgeStyle, EdgeMarker, Perimeter } from './builtin-style-elements';
 import { EdgeStyleRegistry } from './edge/EdgeStyleRegistry';
-import MarkerShape from './marker/EdgeMarkerRegistry';
+import { EdgeMarkerRegistry } from './marker/EdgeMarkerRegistry';
 import { PerimeterRegistry } from './perimeter/PerimeterRegistry';
 import type {
   ArrowValue,
@@ -150,7 +150,7 @@ export const registerDefaultEdgeMarkers = (): void => {
       ['diamondThin', EdgeMarker.diamond],
     ];
     for (const [type, factory] of markersToRegister) {
-      MarkerShape.addMarker(type, factory);
+      EdgeMarkerRegistry.add(type, factory);
     }
 
     isDefaultMarkersRegistered = true;
@@ -164,6 +164,6 @@ export const registerDefaultEdgeMarkers = (): void => {
  * @since 0.18.0
  */
 export const unregisterAllEdgeMarkers = (): void => {
-  MarkerShape.markers = {};
+  EdgeMarkerRegistry.clear();
   isDefaultMarkersRegistered = false;
 };

--- a/packages/html/stories/Handles.stories.ts
+++ b/packages/html/stories/Handles.stories.ts
@@ -19,7 +19,6 @@ import {
   Graph,
   CylinderShape,
   DomHelpers,
-  CellRenderer,
   Point,
   Rectangle,
   VertexHandler,
@@ -32,6 +31,7 @@ import {
   VertexHandlerConfig,
   getDefaultPlugins,
   type GraphPluginConstructor,
+  ShapeRegistry,
 } from '@maxgraph/core';
 
 import {
@@ -106,7 +106,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
       }
     }
   }
-  CellRenderer.registerShape('myShape', MyShape);
+  ShapeRegistry.add('myShape', MyShape);
 
   // Enable rotation handle
   VertexHandlerConfig.rotationEnabled = true;

--- a/packages/html/stories/Markers.stories.ts
+++ b/packages/html/stories/Markers.stories.ts
@@ -19,11 +19,11 @@ import {
   Graph,
   EdgeHandler,
   SelectionHandler,
-  CellRenderer,
-  MarkerShape,
   CylinderShape,
   ArrowShape,
   Point,
+  ShapeRegistry,
+  EdgeMarkerRegistry,
 } from '@maxgraph/core';
 import type { AbstractCanvas2D, Shape, StyleArrowValue } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
@@ -47,7 +47,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   EdgeHandler.prototype.snapToTerminals = true;
 
   // Registers and defines the custom marker
-  MarkerShape.addMarker(
+  EdgeMarkerRegistry.add(
     'dash',
     function (
       canvas: AbstractCanvas2D,
@@ -96,7 +96,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
       }
     }
   }
-  CellRenderer.registerShape('message', MessageShape);
+  ShapeRegistry.add('message', MessageShape);
 
   // Defines custom edge shape
   class LinkShape extends ArrowShape {
@@ -141,7 +141,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
       c.stroke();
     }
   }
-  CellRenderer.registerShape('link', LinkShape);
+  ShapeRegistry.add('link', LinkShape);
 
   // Creates the graph
   const graph = new Graph(container);

--- a/packages/html/stories/Shape.stories.js
+++ b/packages/html/stories/Shape.stories.js
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Graph, CylinderShape, CellRenderer, ShapeRegistry } from '@maxgraph/core';
+import { Graph, CylinderShape, ShapeRegistry } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
 import { createGraphContainer } from './shared/configure.js';
 

--- a/packages/html/stories/Shape.stories.js
+++ b/packages/html/stories/Shape.stories.js
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Graph, CylinderShape, CellRenderer } from '@maxgraph/core';
+import { Graph, CylinderShape, CellRenderer, ShapeRegistry } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
 import { createGraphContainer } from './shared/configure.js';
 
@@ -92,7 +92,7 @@ const Template = ({ label, ...args }) => {
       }
     }
   }
-  CellRenderer.registerShape('box', BoxShape);
+  ShapeRegistry.add('box', BoxShape);
 
   // Creates the graph inside the DOM node.
   const graph = new Graph(container);

--- a/packages/html/stories/Stencils.stories.ts
+++ b/packages/html/stories/Stencils.stories.ts
@@ -18,7 +18,6 @@ limitations under the License.
 import {
   type AbstractCanvas2D,
   CellHighlight,
-  CellRenderer,
   type CellState,
   ConnectionHandler,
   DomHelpers,
@@ -32,6 +31,7 @@ import {
   type Rectangle,
   RubberBandHandler,
   Shape,
+  ShapeRegistry,
   StencilShape,
   StencilShapeRegistry,
   StyleDefaultsConfig,
@@ -95,7 +95,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
 
     // Uses the shape for resize previews
     override createSelectionShape(bounds: Rectangle) {
-      const stencil = StencilShapeRegistry.getStencil(this.state.style.shape);
+      const stencil = StencilShapeRegistry.get(this.state.style.shape);
       let shape: Shape;
 
       if (stencil) {
@@ -166,7 +166,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   }
 
   // Replaces existing actor shape
-  CellRenderer.registerShape('customShape', CustomShape);
+  ShapeRegistry.add('customShape', CustomShape);
 
   // Loads the stencils into the registry
   const req = requestUtils.load('stencils.xml');
@@ -175,7 +175,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
 
   while (shape != null) {
     if (isElement(shape)) {
-      StencilShapeRegistry.addStencil(
+      StencilShapeRegistry.add(
         shape.getAttribute('name')!, // the "name" attribute is always set
         new StencilShape(shape)
       );

--- a/packages/html/stories/StencilsViewer.stories.ts
+++ b/packages/html/stories/StencilsViewer.stories.ts
@@ -92,11 +92,8 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   const shape = doc.documentElement;
 
   if (isElement(shape)) {
-    const name = shape.getAttribute('name')!;
-    StencilShapeRegistry.addStencil(
-      name, // the "name" attribute is always set
-      new StencilShape(shape)
-    );
+    const name = shape.getAttribute('name')!; // the "name" attribute is always set
+    StencilShapeRegistry.add(name, new StencilShape(shape));
   }
 
   if (!args.contextMenu) InternalEvent.disableContextMenu(container);

--- a/packages/html/stories/Tree.stories.js
+++ b/packages/html/stories/Tree.stories.js
@@ -28,6 +28,7 @@ import {
   LayoutManager,
   Rectangle,
   Point,
+  ShapeRegistry,
 } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
 import { configureImagesBasePath, createGraphContainer } from './shared/configure.js';
@@ -84,7 +85,7 @@ const Template = ({ label, ...args }) => {
       }
     }
   }
-  CellRenderer.registerShape('treenode', TreeNodeShape);
+  ShapeRegistry.add('treenode', TreeNodeShape);
 
   class MyCustomGraphView extends GraphView {
     updateFloatingTerminalPoint(edge, start, end, source) {

--- a/packages/html/stories/Wires.stories.js
+++ b/packages/html/stories/Wires.stories.js
@@ -63,7 +63,6 @@ import {
   ConnectionConstraint,
   Point,
   CylinderShape,
-  CellRenderer,
   DomHelpers,
   Rectangle,
   EdgeHandler,

--- a/packages/html/stories/Wires.stories.js
+++ b/packages/html/stories/Wires.stories.js
@@ -82,6 +82,7 @@ import {
   PopupMenuHandler,
   cellArrayUtils,
   StyleDefaultsConfig,
+  ShapeRegistry,
 } from '@maxgraph/core';
 
 import {
@@ -603,9 +604,7 @@ const Template = ({ label, ...args }) => {
     }
   }
 
-  CellRenderer.registerShape('resistor', ResistorShape);
-
-  // Implements a custom resistor shape. Direction currently ignored here.
+  ShapeRegistry.add('resistor', ResistorShape);
 
   const WireConnector = function (state, source, target, hints, result) {
     // Creates array of all way- and terminal points

--- a/packages/js-example-selected-features/src/index.js
+++ b/packages/js-example-selected-features/src/index.js
@@ -22,8 +22,8 @@ import {
   constants,
   DomHelpers,
   EdgeMarker,
+  EdgeMarkerRegistry,
   InternalEvent,
-  MarkerShape,
   ModelXmlSerializer,
   PanningHandler,
   Perimeter,
@@ -40,7 +40,7 @@ class CustomGraph extends BaseGraph {
   registerDefaults() {
     // Register styles
     PerimeterRegistry.add('rectanglePerimeter', Perimeter.RectanglePerimeter); // declared in the default vertex style, so must be registered to be used
-    MarkerShape.addMarker('classic', EdgeMarker.createArrow(2));
+    EdgeMarkerRegistry.add('classic', EdgeMarker.createArrow(2));
   }
 }
 

--- a/packages/ts-example-selected-features/src/main.ts
+++ b/packages/ts-example-selected-features/src/main.ts
@@ -19,21 +19,21 @@ import './style.css';
 import {
   BaseGraph,
   CellEditorHandler,
-  CellRenderer,
   constants,
   EdgeMarker,
+  EdgeMarkerRegistry,
   EdgeStyle,
   EdgeStyleRegistry,
   EllipseShape,
   FitPlugin,
   InternalEvent,
-  MarkerShape,
   PanningHandler,
   Perimeter,
   PerimeterRegistry,
   RubberBandHandler,
   SelectionCellsHandler,
   SelectionHandler,
+  ShapeRegistry,
 } from '@maxgraph/core';
 
 /**
@@ -43,7 +43,7 @@ class CustomGraph extends BaseGraph {
   protected override registerDefaults() {
     // Register shapes
     // RectangleShape is not registered here because it is always available. It is the fallback shape for vertices when no shape is returned by the registry
-    CellRenderer.registerShape('ellipse', EllipseShape);
+    ShapeRegistry.add('ellipse', EllipseShape);
 
     // Register styles
     PerimeterRegistry.add('ellipsePerimeter', Perimeter.EllipsePerimeter);
@@ -54,8 +54,8 @@ class CustomGraph extends BaseGraph {
     });
 
     const arrowFunction = EdgeMarker.createArrow(2);
-    MarkerShape.addMarker('classic', arrowFunction);
-    MarkerShape.addMarker('block', arrowFunction);
+    EdgeMarkerRegistry.add('classic', arrowFunction);
+    EdgeMarkerRegistry.add('block', arrowFunction);
   }
 }
 

--- a/packages/ts-example/src/custom-shapes.ts
+++ b/packages/ts-example/src/custom-shapes.ts
@@ -15,11 +15,11 @@ limitations under the License.
 */
 
 import type { AbstractCanvas2D, ColorValue, Rectangle } from '@maxgraph/core';
-import { CellRenderer, EllipseShape, RectangleShape } from '@maxgraph/core';
+import { EllipseShape, RectangleShape, ShapeRegistry } from '@maxgraph/core';
 
 export const registerCustomShapes = (): void => {
-  CellRenderer.registerShape('customRectangle', CustomRectangleShape);
-  CellRenderer.registerShape('customEllipse', CustomEllipseShape);
+  ShapeRegistry.add('customRectangle', CustomRectangleShape);
+  ShapeRegistry.add('customEllipse', CustomEllipseShape);
 };
 
 class CustomRectangleShape extends RectangleShape {

--- a/packages/website/docs/usage/global-configuration.md
+++ b/packages/website/docs/usage/global-configuration.md
@@ -52,11 +52,11 @@ See also discussions in [issue #192](https://github.com/maxGraph/maxGraph/issues
 
 `maxGraph` provides several global registries used to register style configurations.
 
-  - `EdgeMarkerRegistry`: edge markers (since 0.20.0, previously managed by `MarkerShape`)
-  - `EdgeStyleRegistry`: edge styles (since 0.20.0, previously managed by `StyleRegistry`)
-  - `PerimeterRegistry`: perimeters (since 0.20.0, previously managed by `StyleRegistry`)
-  - `ShapeRegistry`: shapes (since 0.20.0, previously managed by `CellRenderer`)
-  - `StencilShapeRegistry`: stencil shapes
+- `EdgeMarkerRegistry`: edge markers (since 0.20.0, previously managed by `MarkerShape`)
+- `EdgeStyleRegistry`: edge styles (since 0.20.0, previously managed by `StyleRegistry`)
+- `PerimeterRegistry`: perimeters (since 0.20.0, previously managed by `StyleRegistry`)
+- `ShapeRegistry`: shapes (since 0.20.0, previously managed by `CellRenderer`)
+- `StencilShapeRegistry`: stencil shapes
 
 When instantiating a `Graph` object, the registries are filled with `maxGraph` default style configurations. There is no default stencil shapes registered by default.
 

--- a/packages/website/docs/usage/global-configuration.md
+++ b/packages/website/docs/usage/global-configuration.md
@@ -52,10 +52,10 @@ See also discussions in [issue #192](https://github.com/maxGraph/maxGraph/issues
 
 `maxGraph` provides several global registries used to register style configurations.
 
+  - `EdgeMarkerRegistry`: edge markers (since 0.20.0, previously managed by `MarkerShape`)
   - `EdgeStyleRegistry`: edge styles (since 0.20.0, previously managed by `StyleRegistry`)
-  - `CellRenderer`: shapes
-  - `MarkerShape`: edge markers (also known as `startArrow` and `endArrow` in `CellStateStyle`)
   - `PerimeterRegistry`: perimeters (since 0.20.0, previously managed by `StyleRegistry`)
+  - `ShapeRegistry`: shapes (since 0.20.0, previously managed by `CellRenderer`)
   - `StencilShapeRegistry`: stencil shapes
 
 When instantiating a `Graph` object, the registries are filled with `maxGraph` default style configurations. There is no default stencil shapes registered by default.


### PR DESCRIPTION
Replace custom registry implementations with a consistent BaseRegistry pattern across `StencilShapeRegistry`,
`MarkerShapeRegistry` (formerly MarkerShape), and `ShapeRegistry` (formerly in CellRenderer).

This breaking change ensures all style-related registries share the same interface and behavior, simplifying usage patterns
and improving maintainability throughout the codebase.

BREAKING CHANGES:
- All registries used to manage "styles" elements now derived from the `Registry` interface for consistency.
  So, they all share the same methods (add, get and clear) and their internal storage is no longer accessible.
- The `MarkerShape` registry has been renamed to `MarkerShapeRegistry`.
- The Shapes are now registered in `ShapeRegistry` instead in `CellRenderer`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced centralized registries for shapes and edge markers, enabling unified registration and management of custom shapes and markers.
  - Added a new interface for edge marker creation supporting advanced customization.

- **Refactor**
  - Replaced static registration methods with `ShapeRegistry` and `EdgeMarkerRegistry` throughout the codebase.
  - Updated stencil and shape registration methods to use new registry interfaces and consistent method names.
  - Transitioned from internal shape management in `CellRenderer` to external registries for improved modularity.

- **Documentation**
  - Updated documentation and changelog to reflect the new registry APIs, naming conventions, and usage patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->