### PR TITLE
test: verify AbstractGraph.createHandler factory method delegation

### DIFF
--- a/packages/core/__tests__/view/Graph.test.ts
+++ b/packages/core/__tests__/view/Graph.test.ts
@@ -24,6 +24,7 @@ import {
   EdgeSegmentHandler,
   EdgeStyle,
   type EdgeStyleFunction,
+  EdgeStyleRegistry,
   ElbowEdgeHandler,
   Point,
   Rectangle,
@@ -190,6 +191,56 @@ describe('createEdgeHandler', () => {
       expectExactInstanceOfEdgeHandler(graph.createEdgeHandler(cellState, edgeStyle));
     }
   );
+
+  describe('Custom edge handler', () => {
+    test('default', () => {
+      class CustomEdgeHandler extends EdgeHandler {}
+      const edgeStyle = customEdgeStyle;
+      // EdgeStyleRegistry.add('custom', edgeStyle);
+
+      const graph = new BaseGraph();
+      graph.createEdgeHandlerInstance = (state) => {
+        return new CustomEdgeHandler(state);
+      };
+
+      const cellState = createCellStateOfEdge(graph);
+      expect(graph.createEdgeHandler(cellState, edgeStyle)).toBeInstanceOf(
+        CustomEdgeHandler
+      );
+    });
+
+    test('elbow', () => {
+      class CustomEdgeHandler extends ElbowEdgeHandler {}
+      const edgeStyle = customEdgeStyle;
+      EdgeStyleRegistry.add('custom', edgeStyle, { handlerKind: 'elbow' });
+
+      const graph = new BaseGraph();
+      graph.createElbowEdgeHandler = (state) => {
+        return new CustomEdgeHandler(state);
+      };
+
+      const cellState = createCellStateOfEdge(graph);
+      expect(graph.createEdgeHandler(cellState, edgeStyle)).toBeInstanceOf(
+        CustomEdgeHandler
+      );
+    });
+
+    test('segment', () => {
+      class CustomEdgeHandler extends EdgeSegmentHandler {}
+      const edgeStyle = customEdgeStyle;
+      EdgeStyleRegistry.add('custom', edgeStyle, { handlerKind: 'segment' });
+
+      const graph = new BaseGraph();
+      graph.createEdgeSegmentHandler = (state) => {
+        return new CustomEdgeHandler(state);
+      };
+
+      const cellState = createCellStateOfEdge(graph);
+      expect(graph.createEdgeHandler(cellState, edgeStyle)).toBeInstanceOf(
+        CustomEdgeHandler
+      );
+    });
+  });
 });
 
 describe('createHandler', () => {

--- a/packages/core/__tests__/view/Graph.test.ts
+++ b/packages/core/__tests__/view/Graph.test.ts
@@ -38,6 +38,13 @@ const customEdgeStyle: EdgeStyleFunction = () => {
   // do nothing, we just need a custom implementation that is not registered by default
 };
 
+beforeEach(() => {
+  unregisterAllEdgeStyles();
+});
+afterAll(() => {
+  unregisterAllEdgeStyles();
+});
+
 describe('isOrthogonal', () => {
   test('Style of the CellState, orthogonal: true', () => {
     const graph = new BaseGraph();
@@ -58,11 +65,7 @@ describe('isOrthogonal', () => {
 
   describe('Default builtin styles registered', () => {
     beforeEach(() => {
-      unregisterAllEdgeStyles();
       registerDefaultEdgeStyles();
-    });
-    afterAll(() => {
-      unregisterAllEdgeStyles();
     });
 
     test.each([
@@ -129,11 +132,7 @@ const createCellStateOfEdge = (graph: AbstractGraph): CellState =>
 describe('createEdgeHandler', () => {
   describe('Default builtin styles registered', () => {
     beforeEach(() => {
-      unregisterAllEdgeStyles();
       registerDefaultEdgeStyles();
-    });
-    afterAll(() => {
-      unregisterAllEdgeStyles();
     });
 
     test.each([

--- a/packages/core/__tests__/view/Graph.test.ts
+++ b/packages/core/__tests__/view/Graph.test.ts
@@ -195,7 +195,6 @@ describe('createEdgeHandler', () => {
     test('default', () => {
       class CustomEdgeHandler extends EdgeHandler {}
       const edgeStyle = customEdgeStyle;
-      // EdgeStyleRegistry.add('custom', edgeStyle);
 
       const graph = new BaseGraph();
       graph.createEdgeHandlerInstance = (state) => {


### PR DESCRIPTION
Add tests ensuring `AbstractGraph.createEdgeHandler` properly delegates to specialized factory methods
(createElbowEdgeHandler and createEdgeSegmentHandler) based on edge style registry configuration.
Tests cover both built-in edge styles and custom handler implementations.

This prepares the move of these methods to `SelectionCellsHandler` where they are used.

### Notes

Covers #762 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Tests**
  - Added new tests to verify support for custom edge handler classes when using custom edge styles, ensuring correct instantiation for different handler types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->