### PR TITLE
refactor: migrate the Control story to TypeScript

### DIFF
--- a/packages/html/stories/Boundary.mdx
+++ b/packages/html/stories/Boundary.mdx
@@ -1,4 +1,4 @@
-import { ArgTypes, Canvas, Controls, Meta, Story } from '@storybook/blocks';
+import { Canvas, Controls, Meta } from '@storybook/blocks';
 import * as story from './Boundary.stories';
 
 <Meta of={story} />

--- a/packages/html/stories/Control.mdx
+++ b/packages/html/stories/Control.mdx
@@ -1,0 +1,14 @@
+import { Canvas, Controls, Meta } from '@storybook/blocks';
+import * as story from './Control.stories';
+
+<Meta of={story} />
+
+# Control
+
+This example demonstrates adding controls to specific cells in a graph.
+
+Click on the control of the Vertex to delete the Vertex.
+
+
+<Canvas/>
+<Controls />

--- a/packages/html/stories/Control.stories.ts
+++ b/packages/html/stories/Control.stories.ts
@@ -62,7 +62,7 @@ export default {
 
 type CustomCellState = CellState & { deleteControl: Shape | null };
 
-const Template = ({ label, ...args }: Record<string, any>) => {
+const Template = ({ ...args }: Record<string, any>) => {
   const div = document.createElement('div');
   const container = createGraphContainer(args);
   div.appendChild(container);

--- a/packages/html/stories/Control.stories.ts
+++ b/packages/html/stories/Control.stories.ts
@@ -158,12 +158,12 @@ const Template = ({ label, ...args }: Record<string, any>) => {
     }
   }
 
-  // Enables rubberband selection
-  const plugins = getDefaultPlugins();
-  if (args.rubberBand) plugins.push(RubberBandHandler);
-
   // Creates the graph inside the given container
-  const graph = new MyCustomGraph(container, plugins);
+  const graph = new MyCustomGraph(container, [
+    ...getDefaultPlugins(),
+    // Enables rubberband selection
+    ...(args.rubberBand ? [RubberBandHandler] : []),
+  ]);
   graph.setPanning(true);
 
   if (args.resizeContainer) {


### PR DESCRIPTION
Ease the maintenance and detect the errors earlier.

Extra improvements:
- Disable the context menu to make the panning correctly work
- Add a "reset zoom" button
- Add more cells to better illustrate the feature
- Add a Storybook argument to enable Graph.resizeContainer that was previously commented
- Add documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new interactive story demonstrating controls for deleting vertices within a graph, including UI buttons for zoom and reset actions.

- **Documentation**
  - Introduced a new Storybook documentation page explaining and showcasing the graph controls feature.

- **Refactor**
  - Improved story structure with enhanced typing, plugin-based graph initialization, and expanded example content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->