### PR TITLE
fix(FitPlugin): handle edge cases in fitCenter calculation

### DIFF
--- a/packages/core/__tests__/view/plugins/FitPlugin.test.ts
+++ b/packages/core/__tests__/view/plugins/FitPlugin.test.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2025-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { expect, test } from '@jest/globals';
+import { BaseGraph, FitPlugin } from '../../../src';
+
+test('fitCenter when graph has dimensions set to zero', () => {
+  const graph = new BaseGraph({ plugins: [FitPlugin] });
+  const scale = graph.getPlugin<FitPlugin>('fit').fitCenter();
+  expect(scale).toBe(1);
+});

--- a/packages/core/src/view/plugins/FitPlugin.ts
+++ b/packages/core/src/view/plugins/FitPlugin.ts
@@ -84,6 +84,9 @@ export class FitPlugin implements GraphPlugin {
       clientWidth / width,
       clientHeight / height
     );
+    if (!Number.isFinite(newScale)) {
+      newScale = originalScale;
+    }
 
     const translateX = Math.floor(
       view.translate.x +


### PR DESCRIPTION
Prevent division by zero and non-finite scaling values when graph
bounds have zero dimensions (width/height = 0) or when container
is improperly sized. Maintains original scale in these invalid
scenarios to ensure consistent behavior.

This issue particularly used to affect headless environments (tests, Node.js)
where containers may have zero height/width, which is less common in
browser contexts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of edge cases in the fit-to-center feature to prevent invalid scaling when graph dimensions are zero.

- **Tests**
  - Added a test to verify correct behavior of the fit-to-center feature when graph dimensions are zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->