### PR TITLE
docs(release): fix the name of the zip files to archive

### DIFF
--- a/packages/website/docs/development/release.md
+++ b/packages/website/docs/development/release.md
@@ -96,10 +96,10 @@ Attach the examples and the website to the release (in the "assets" location):
   - Retrieve the artifacts built by GitHub Actions on the commit of the tag
   - examples:
     - location: https://github.com/maxGraph/maxGraph/actions/workflows/build.yml
-    - rename the file to: `maxgraph_<version>_website.zip`
+    - rename the file to: `maxgraph_<version>_examples.zip`
   - website:
     - location: https://github.com/maxGraph/maxGraph/actions/workflows/generate-website.yml. The artifact is not available in the summary of the job. Open the log to get the URL of the artifact.
-    - rename the file to: `maxgraph_<version>_examples.zip`
+    - rename the file to: `maxgraph_<version>_website.zip`
 
 Before you publish the release, make sure that a discussion will be created in the `Announces` category when the release
 is published.


### PR DESCRIPTION
The names of the examples zip and the website zip were interchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected artifact naming instructions in the release documentation to accurately match artifact names with their respective content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->