### PR TITLE
feat: let choose the implementation of `ConstraintHandler`

### DIFF
--- a/packages/core/src/view/handler/ConstraintHandler.ts
+++ b/packages/core/src/view/handler/ConstraintHandler.ts
@@ -463,8 +463,13 @@ class ConstraintHandler {
   /**
    * Returns true if the given icon intersects the given rectangle.
    */
-  intersects(icon: ImageShape, mouse: Rectangle, source: boolean, existingEdge: boolean) {
-    return intersects(icon.bounds as Rectangle, mouse);
+  intersects(
+    icon: ImageShape,
+    rectangle: Rectangle,
+    source: boolean,
+    existingEdge: boolean
+  ) {
+    return intersects(icon.bounds!, rectangle);
   }
 
   /**

--- a/packages/core/src/view/handler/ConstraintHandler.ts
+++ b/packages/core/src/view/handler/ConstraintHandler.ts
@@ -461,7 +461,7 @@ class ConstraintHandler {
   }
 
   /**
-   * Returns true if the given icon intersects the given rectangle.
+   * Returns `true` if the given icon intersects the given rectangle.
    */
   intersects(
     icon: ImageShape,

--- a/packages/core/src/view/handler/EdgeHandler.ts
+++ b/packages/core/src/view/handler/EdgeHandler.ts
@@ -89,8 +89,7 @@ class EdgeHandler implements MouseListenerSet {
   marker: CellMarker;
 
   /**
-   * Holds the {@link ConstraintHandler} used for drawing and highlighting
-   * constraints.
+   * Holds the {@link ConstraintHandler} used for drawing and highlighting constraints.
    */
   constraintHandler: ConstraintHandler;
 
@@ -231,7 +230,7 @@ class EdgeHandler implements MouseListenerSet {
 
     this.graph = this.state.view.graph;
     this.marker = this.createMarker();
-    this.constraintHandler = new ConstraintHandler(this.graph);
+    this.constraintHandler = this.createConstraintHandler();
 
     // Clones the original points from the cell
     // and makes sure at least one point exists
@@ -311,6 +310,14 @@ class EdgeHandler implements MouseListenerSet {
     };
 
     this.state.view.graph.addListener(InternalEvent.ESCAPE, this.escapeHandler);
+  }
+
+  /**
+   * Hook for subclasses to change the implementation of {@link ConstraintHandler} used here.
+   * @since 0.21.0
+   */
+  protected createConstraintHandler() {
+    return new ConstraintHandler(this.graph);
   }
 
   /**

--- a/packages/core/src/view/mixins/ConnectionsMixin.ts
+++ b/packages/core/src/view/mixins/ConnectionsMixin.ts
@@ -152,7 +152,7 @@ export const ConnectionsMixin: PartialType = {
     return null;
   },
 
-  getAllConnectionConstraints(terminal, source) {
+  getAllConnectionConstraints(terminal, _source) {
     return terminal?.shape?.stencil?.constraints ?? null;
   },
 

--- a/packages/core/src/view/plugins/ConnectionHandler.ts
+++ b/packages/core/src/view/plugins/ConnectionHandler.ts
@@ -203,7 +203,7 @@ type FactoryMethod = (
  * @category Plugin
  */
 class ConnectionHandler extends EventSource implements GraphPlugin, MouseListenerSet {
-  static pluginId = 'ConnectionHandler';
+  static readonly pluginId = 'ConnectionHandler';
 
   previous: CellState | null = null;
   iconState: CellState | null = null;
@@ -285,8 +285,7 @@ class ConnectionHandler extends EventSource implements GraphPlugin, MouseListene
   marker: CellMarker;
 
   /**
-   * Holds the {@link ConstraintHandler} used for drawing and highlighting
-   * constraints.
+   * Holds the {@link ConstraintHandler} used for drawing and highlighting constraints.
    */
   constraintHandler: ConstraintHandler;
 
@@ -404,7 +403,7 @@ class ConnectionHandler extends EventSource implements GraphPlugin, MouseListene
 
     this.graph.addMouseListener(this);
     this.marker = this.createMarker();
-    this.constraintHandler = new ConstraintHandler(this.graph);
+    this.constraintHandler = this.createConstraintHandler();
 
     // Redraws the icons if the graph changes
     this.changeHandler = (sender: Listenable) => {
@@ -442,6 +441,14 @@ class ConnectionHandler extends EventSource implements GraphPlugin, MouseListene
     };
 
     this.graph.addListener(InternalEvent.ESCAPE, this.escapeHandler);
+  }
+
+  /**
+   * Hook for subclasses to change the implementation of {@link ConstraintHandler} used here.
+   * @since 0.21.0
+   */
+  protected createConstraintHandler() {
+    return new ConstraintHandler(this.graph);
   }
 
   /**
@@ -1275,7 +1282,7 @@ class ConnectionHandler extends EventSource implements GraphPlugin, MouseListene
   }
 
   /**
-   * Updates <edgeState>.
+   * Updates {@link edgeState}.
    */
   updateEdgeState(current: Point | null, constraint: ConnectionConstraint | null) {
     if (!this.edgeState) return;

--- a/packages/core/src/view/plugins/SelectionCellsHandler.ts
+++ b/packages/core/src/view/plugins/SelectionCellsHandler.ts
@@ -49,7 +49,7 @@ type Handler = EdgeHandler | VertexHandler;
  * @category Plugin
  */
 class SelectionCellsHandler extends EventSource implements GraphPlugin, MouseListenerSet {
-  static pluginId = 'SelectionCellsHandler';
+  static readonly pluginId = 'SelectionCellsHandler';
 
   constructor(graph: AbstractGraph) {
     super();

--- a/packages/core/src/view/plugins/SelectionHandler.ts
+++ b/packages/core/src/view/plugins/SelectionHandler.ts
@@ -63,7 +63,7 @@ import type { ColorValue, GraphPlugin } from '../../types';
  * @category Plugin
  */
 class SelectionHandler implements GraphPlugin {
-  static pluginId = 'SelectionHandler';
+  static readonly pluginId = 'SelectionHandler';
 
   /**
    * Constructs an event handler that creates handles for the selection cells.


### PR DESCRIPTION
Introduce a factory method in `ConnectionHandler` and `EdgeHandler` that enables you to override the `ConstraintHandler` implementation used in these classes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved naming and parameter clarity in several methods and classes.
	- Enhanced immutability by making certain static properties readonly.
	- Introduced protected factory methods for more flexible subclassing in handler classes.
- **Style**
	- Minor documentation formatting improvements for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->