### PR TITLE
refactor(type)!: make AbstractGraph.getPlugin return `T | undefined`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ For more details on the contents of a release, see [the GitHub release page] (ht
 _**Note:** Yet to be released breaking changes appear here._
 
 **Breaking Changes**:
-- the `AbstractGraph.fit` method moved to `FitPlugin`, as well as the `minFitScale` and `maxFitScale` properties.
-The method now accepts a single parameter, mainly to minimize the need to pass many default values.
+- The `AbstractGraph.fit` method moved to `FitPlugin`, as well as the `minFitScale` and `maxFitScale` properties.
+  The method now accepts a single parameter, mainly to minimize the need to pass many default values.
+- The `AbstractGraph.getPlugin` method now explicitly returns `undefined` when a plugin is not found.  
+  TypeScript users must update their code to handle the `undefined` case when calling this method.
 
 ## 0.20.0
 

--- a/packages/core/__tests__/view/plugins/FitPlugin.test.ts
+++ b/packages/core/__tests__/view/plugins/FitPlugin.test.ts
@@ -53,7 +53,7 @@ describe('fitCenter', () => {
     const graph = new BaseGraph({ plugins: [FitPlugin] });
     const viewMock = jest.spyOn(graph.view, 'scaleAndTranslate');
 
-    const scale = graph.getPlugin<FitPlugin>('fit').fitCenter();
+    const scale = graph.getPlugin<FitPlugin>('fit')!.fitCenter();
     expect(scale).toBe(1);
     expect(viewMock).toHaveBeenCalledWith(1, 0, 0);
     expect(viewMock).toHaveBeenCalledTimes(1);
@@ -69,7 +69,7 @@ describe('fitCenter', () => {
     graph.view.setGraphBounds(new Rectangle(30, 20, 1000, 1000));
     const viewMock = jest.spyOn(graph.view, 'scaleAndTranslate');
 
-    const scale = graph.getPlugin<FitPlugin>('fit').fitCenter();
+    const scale = graph.getPlugin<FitPlugin>('fit')!.fitCenter();
     expect(scale).toBe(0.02);
     expect(viewMock).toHaveBeenCalledWith(0.02, 95, 105);
     expect(viewMock).toHaveBeenCalledTimes(1);
@@ -85,7 +85,7 @@ describe('fitCenter', () => {
     graph.view.setGraphBounds(new Rectangle(-172, 67, 100, 200));
     const viewMock = jest.spyOn(graph.view, 'scaleAndTranslate');
 
-    const scale = graph.getPlugin<FitPlugin>('fit').fitCenter({ margin: 20 });
+    const scale = graph.getPlugin<FitPlugin>('fit')!.fitCenter({ margin: 20 });
     expect(scale).toBe(2.46);
     expect(viewMock).toHaveBeenCalledWith(2.46, 217, -59);
     expect(viewMock).toHaveBeenCalledTimes(1);
@@ -101,7 +101,7 @@ describe('fitCenter', () => {
     graph.view.setGraphBounds(new Rectangle(70, -30, 100, 100));
     const viewMock = jest.spyOn(graph.view, 'scaleAndTranslate');
 
-    const plugin = graph.getPlugin<FitPlugin>('fit');
+    const plugin = graph.getPlugin<FitPlugin>('fit')!;
     plugin.maxFitScale = 7;
     const scale = plugin.fitCenter();
     expect(scale).toBe(7);
@@ -115,7 +115,7 @@ describe('fit', () => {
     const graph = new BaseGraph({ plugins: [FitPlugin] });
     const viewMock = jest.spyOn(graph.view, 'scaleAndTranslate');
 
-    const scale = graph.getPlugin<FitPlugin>('fit').fit();
+    const scale = graph.getPlugin<FitPlugin>('fit')!.fit();
     expect(scale).toBe(1);
     expect(viewMock).not.toHaveBeenCalled();
   });
@@ -130,7 +130,7 @@ describe('fit', () => {
     graph.view.setGraphBounds(new Rectangle(30, 20, 100, 100));
     const viewMock = jest.spyOn(graph.view, 'scaleAndTranslate');
 
-    const scale = graph.getPlugin<FitPlugin>('fit').fit();
+    const scale = graph.getPlugin<FitPlugin>('fit')!.fit();
     expect(scale).toBe(0.18);
     expect(viewMock).toHaveBeenCalledWith(0.18, -30, -20);
     expect(viewMock).toHaveBeenCalledTimes(1);
@@ -146,7 +146,7 @@ describe('fit', () => {
     graph.view.setGraphBounds(new Rectangle(30, 20, 100, 100));
     const viewMock = jest.spyOn(graph.view, 'scaleAndTranslate');
 
-    const plugin = graph.getPlugin<FitPlugin>('fit');
+    const plugin = graph.getPlugin<FitPlugin>('fit')!;
     plugin.minFitScale = 0.5;
     const scale = plugin.fit();
     expect(scale).toBe(0.5);
@@ -164,7 +164,7 @@ describe('fit', () => {
     graph.view.setGraphBounds(new Rectangle(70, -60, 100, 100));
     const viewMock = jest.spyOn(graph.view, 'scaleAndTranslate');
 
-    const scale = graph.getPlugin<FitPlugin>('fit').fit();
+    const scale = graph.getPlugin<FitPlugin>('fit')!.fit();
     expect(scale).toBe(4.78);
     expect(viewMock).toHaveBeenCalledWith(4.78, -70, 60);
     expect(viewMock).toHaveBeenCalledTimes(1);
@@ -180,7 +180,7 @@ describe('fit', () => {
     graph.view.setGraphBounds(new Rectangle(70, -60, 100, 100));
     const viewMock = jest.spyOn(graph.view, 'scaleAndTranslate');
 
-    const plugin = graph.getPlugin<FitPlugin>('fit');
+    const plugin = graph.getPlugin<FitPlugin>('fit')!;
     plugin.maxFitScale = 3;
     const scale = plugin.fit();
     expect(scale).toBe(3);

--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -2389,8 +2389,7 @@ export class Editor extends EventSource {
    * - pan - Pans using the left mouse button, new connections are disabled.
    */
   setMode(modename: any): void {
-    const panningHandler: PanningHandler =
-      this.graph.getPlugin<PanningHandler>('PanningHandler');
+    const panningHandler = this.graph.getPlugin<PanningHandler>('PanningHandler');
     if (modename === 'select') {
       panningHandler && (panningHandler.useLeftButtonForPanning = false);
       this.graph.setConnectable(false);

--- a/packages/core/src/view/AbstractGraph.ts
+++ b/packages/core/src/view/AbstractGraph.ts
@@ -110,7 +110,7 @@ export abstract class AbstractGraph extends EventSource {
    */
   model!: GraphDataModel; // initialized in "initializeCollaborators"
 
-  private plugins: Record<string, GraphPlugin> = {};
+  private plugins = new Map<string, GraphPlugin>();
 
   /**
    * Holds the {@link GraphView} that caches the {@link CellState}s for the cells.
@@ -219,7 +219,7 @@ export abstract class AbstractGraph extends EventSource {
    * Specifies the page format for the background page.
    * This is used as the default in {@link PrintPreview} and for painting the background page
    * if {@link pageVisible} is `true` and the page breaks if {@link pageBreaksVisible} is `true`.
-   * @default {@link mxConstants.PAGE_FORMAT_A4_PORTRAIT}
+   * @default {@link PAGE_FORMAT_A4_PORTRAIT}
    */
   pageFormat = new Rectangle(...PAGE_FORMAT_A4_PORTRAIT);
 
@@ -476,13 +476,14 @@ export abstract class AbstractGraph extends EventSource {
     this.sizeDidChange();
 
     // Initializes plugins
-    options?.plugins?.forEach((p) => (this.plugins[p.pluginId] = new p(this)));
+    options?.plugins?.forEach((p) => this.plugins.set(p.pluginId, new p(this)));
 
     this.view.revalidate();
   }
 
   getContainer = () => this.container;
-  getPlugin = <T extends GraphPlugin>(id: PluginId): T => this.plugins[id] as T;
+  getPlugin = <T extends GraphPlugin>(id: PluginId): T | undefined =>
+    this.plugins.get(id) as T;
   getCellRenderer = () => this.cellRenderer;
   getDialect = () => this.dialect;
   isPageVisible = () => this.pageVisible;

--- a/packages/core/src/view/other/DragSource.ts
+++ b/packages/core/src/view/other/DragSource.ts
@@ -526,7 +526,7 @@ class DragSource {
     // Guide is only needed if preview element is used
     if (this.isGuidesEnabled() && this.previewElement) {
       const selectionHandler = graph.getPlugin<SelectionHandler>('SelectionHandler');
-      this.currentGuide = new Guide(graph, selectionHandler?.getGuideStates());
+      this.currentGuide = new Guide(graph, selectionHandler?.getGuideStates() ?? []);
     }
 
     if (this.highlightDropTargets) {

--- a/packages/html/stories/AutoLayout.stories.ts
+++ b/packages/html/stories/AutoLayout.stories.ts
@@ -147,7 +147,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
 
   graph.setAllowDanglingEdges(false);
 
-  const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler');
+  const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler')!;
   connectionHandler.select = false;
 
   graph.view.setTranslate(20, 20);
@@ -219,7 +219,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
       const evt2 = eo.getProperty('event');
       const state = eo.getProperty('state');
 
-      const popupMenuHandler = graph.getPlugin<PopupMenuHandler>('PopupMenuHandler');
+      const popupMenuHandler = graph.getPlugin<PopupMenuHandler>('PopupMenuHandler')!;
       popupMenuHandler.hideMenu();
 
       graph.stopEditing(false);

--- a/packages/html/stories/Codec.stories.ts
+++ b/packages/html/stories/Codec.stories.ts
@@ -111,7 +111,7 @@ const Template = ({ label, ...args }: Record<string, any>) => {
   style.edgeStyle = 'elbowEdgeStyle';
 
   // Enables panning with left mouse button
-  const panningHandler = graph.getPlugin<PanningHandler>('PanningHandler');
+  const panningHandler = graph.getPlugin<PanningHandler>('PanningHandler')!;
   panningHandler.useLeftButtonForPanning = true;
   panningHandler.ignoreCell = true;
   graph.container.style.cursor = 'move';

--- a/packages/html/stories/ContextIcons.stories.ts
+++ b/packages/html/stories/ContextIcons.stories.ts
@@ -118,16 +118,16 @@ const Template = ({ label, ...args }: Record<string, any>) => {
       img.style.width = '16px';
       img.style.height = '16px';
 
-      const graphHandler = graph.getPlugin<SelectionHandler>('SelectionHandler');
-      const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler');
+      const selectionHandler = graph.getPlugin<SelectionHandler>('SelectionHandler')!;
+      const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler')!;
 
       InternalEvent.addGestureListeners(img, (evt) => {
-        graphHandler.start(
+        selectionHandler.start(
           this.state.cell,
           eventUtils.getClientX(evt),
           eventUtils.getClientY(evt)
         );
-        graphHandler.cellWasClicked = true;
+        selectionHandler.cellWasClicked = true;
         this.graph.isMouseDown = true;
         this.graph.isMouseTrigger = eventUtils.isMouseEvent(evt);
         InternalEvent.consume(evt);
@@ -202,7 +202,7 @@ const Template = ({ label, ...args }: Record<string, any>) => {
   const graph = new MyCustomGraph(container, plugins);
   graph.setConnectable(true);
 
-  const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler');
+  const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler')!;
   connectionHandler.createTarget = true;
 
   // Uncomment the following if you want the container

--- a/packages/html/stories/CustomHandlesConfiguration.stories.ts
+++ b/packages/html/stories/CustomHandlesConfiguration.stories.ts
@@ -105,7 +105,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   graph.setVertexLabelsMovable(true);
   graph.setEdgeLabelsMovable(true);
 
-  const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler');
+  const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler')!;
   connectionHandler.outlineConnect = true;
 
   // Changes default styles to increase the contrast with the custom handle colors

--- a/packages/html/stories/CustomStyleDefaults.stories.ts
+++ b/packages/html/stories/CustomStyleDefaults.stories.ts
@@ -79,7 +79,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   graph.setVertexLabelsMovable(true);
   graph.setEdgeLabelsMovable(true);
 
-  const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler');
+  const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler')!;
   connectionHandler.outlineConnect = true;
 
   // Changes default styles to increase the contrast

--- a/packages/html/stories/DynamicToolbar.stories.ts
+++ b/packages/html/stories/DynamicToolbar.stories.ts
@@ -88,7 +88,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
 
   // Defines an icon for creating new connections in the connection handler.
   // This will automatically disable the highlighting of the source vertex.
-  const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler');
+  const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler')!;
   connectionHandler.connectImage = new ImageBox(
     `${Client.imageBasePath}/connector.gif`,
     16,

--- a/packages/html/stories/Events.stories.ts
+++ b/packages/html/stories/Events.stories.ts
@@ -98,7 +98,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   const graph = new MyCustomGraph(container, plugins);
 
   // Sets the image to be used for creating new connections
-  const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler');
+  const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler')!;
   connectionHandler.connectImage = new ImageBox(
     `${Client.imageBasePath}/green-dot.gif`,
     14,
@@ -128,7 +128,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   style.edgeStyle = EdgeStyle.ElbowConnector;
   graph.alternateEdgeStyle = { elbow: 'vertical' };
 
-  const popupMenuHandler = graph.getPlugin<PopupMenuHandler>('PopupMenuHandler');
+  const popupMenuHandler = graph.getPlugin<PopupMenuHandler>('PopupMenuHandler')!;
   // Installs a popupmenu handler using local function (see below).
   popupMenuHandler.factoryMethod = (menu, cell, evt) => {
     return createPopupMenu(graph, menu, cell, evt);

--- a/packages/html/stories/FileIO.stories.ts
+++ b/packages/html/stories/FileIO.stories.ts
@@ -70,7 +70,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   graph.setEnabled(false);
   graph.setPanning(true);
   graph.setTooltips(true);
-  graph.getPlugin<PanningHandler>('PanningHandler').useLeftButtonForPanning = true;
+  graph.getPlugin<PanningHandler>('PanningHandler')!.useLeftButtonForPanning = true;
 
   // Adds a highlight on the cell under the mouse pointer
   new CellTracker(graph, undefined!);

--- a/packages/html/stories/FixedPoints.stories.ts
+++ b/packages/html/stories/FixedPoints.stories.ts
@@ -146,7 +146,7 @@ const Template = ({ ...args }: Record<string, any>) => {
     // Disables floating connections (only use with no connect image)
     override isConnectableCell(cell: Cell) {
       return this.graph
-        .getPlugin<ConnectionHandler>('ConnectionHandler')
+        .getPlugin<ConnectionHandler>('ConnectionHandler')!
         .isConnectableCell(cell);
     }
   }

--- a/packages/html/stories/Manhattan.stories.ts
+++ b/packages/html/stories/Manhattan.stories.ts
@@ -45,7 +45,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   const graph = new Graph(container);
 
   // Enables guides
-  graph.getPlugin<SelectionHandler>('SelectionHandler').guidesEnabled = true;
+  graph.getPlugin<SelectionHandler>('SelectionHandler')!.guidesEnabled = true;
 
   // Hack to rerender edge on any node move
   graph.model.addListener(InternalEvent.CHANGE, (_sender: unknown, evt: EventObject) => {

--- a/packages/html/stories/Orthogonal.stories.ts
+++ b/packages/html/stories/Orthogonal.stories.ts
@@ -96,7 +96,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   };
 
   // Enables guides
-  const selectionHandler = graph.getPlugin<SelectionHandler>('SelectionHandler');
+  const selectionHandler = graph.getPlugin<SelectionHandler>('SelectionHandler')!;
   selectionHandler.guidesEnabled = true;
 
   // Alt disables guides
@@ -109,7 +109,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
     return guide;
   };
 
-  const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler');
+  const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler')!;
   // Implements the connect preview, using the configured edge style
   connectionHandler.createEdgeState = function (_me) {
     const edge = graph.createEdge(null, null!, null, null, null);

--- a/packages/html/stories/PageBreaks.stories.ts
+++ b/packages/html/stories/PageBreaks.stories.ts
@@ -76,10 +76,10 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   // Removes header and footer from page height
   graph.pageFormat.height -= headerSize + footerSize;
 
-  const graphHandler = graph.getPlugin<SelectionHandler>('SelectionHandler');
+  const selectionHandler = graph.getPlugin<SelectionHandler>('SelectionHandler')!;
 
   // Takes zoom into account for moving cells
-  graphHandler.scaleGrid = true;
+  selectionHandler.scaleGrid = true;
 
   // Enables rubberband selection
   if (args.rubberBand) new RubberBandHandler(graph);

--- a/packages/html/stories/ShowRegion.stories.ts
+++ b/packages/html/stories/ShowRegion.stories.ts
@@ -106,7 +106,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
 
     override mouseUp(sender: EventSource, me: InternalMouseEvent) {
       if (eventUtils.isPopupTrigger(me.getEvent())) {
-        if (!graph.getPlugin<PopupMenuHandler>('PopupMenuHandler').isMenuShowing()) {
+        if (!graph.getPlugin<PopupMenuHandler>('PopupMenuHandler')!.isMenuShowing()) {
           const origin = styleUtils.getScrollOrigin();
           this.popupMenu.popup(
             me.getX() + origin.x + 1,

--- a/packages/html/stories/SwimLanes.stories.ts
+++ b/packages/html/stories/SwimLanes.stories.ts
@@ -81,12 +81,12 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   graph.setResizeContainer(true);
   configureExpandedAndCollapsedImages(graph);
 
-  const graphHandler = graph.getPlugin<SelectionHandler>('SelectionHandler');
-  graphHandler.setRemoveCellsFromParent(false);
+  const selectionHandler = graph.getPlugin<SelectionHandler>('SelectionHandler')!;
+  selectionHandler.setRemoveCellsFromParent(false);
 
   // Defines an icon for creating new connections in the connection handler.
   // This will automatically disable the highlighting of the source vertex.
-  const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler');
+  const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler')!;
   connectionHandler.connectImage = new ImageBox(
     `${Client.imageBasePath}/connector.gif`,
     16,

--- a/packages/html/stories/Toolbar.stories.ts
+++ b/packages/html/stories/Toolbar.stories.ts
@@ -98,7 +98,7 @@ const Template = ({ label, ...args }: { [p: string]: any }) => {
 
   // Defines an icon for creating new connections in the connection handler.
   // This will automatically disable the highlighting of the source vertex.
-  const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler');
+  const connectionHandler = graph.getPlugin<ConnectionHandler>('ConnectionHandler')!;
   connectionHandler.connectImage = new ImageBox(
     `${Client.imageBasePath}/connector.gif`,
     16,

--- a/packages/ts-support/src/index.ts
+++ b/packages/ts-support/src/index.ts
@@ -33,8 +33,10 @@ const graph = new Graph(container);
 graph.setPanning(true); // Use mouse right button for panning
 
 const rubberBandHandler = graph.getPlugin<RubberBandHandler>('RubberBandHandler');
-rubberBandHandler.defaultOpacity = 50;
-rubberBandHandler.fadeOut = true;
+if (rubberBandHandler) {
+  rubberBandHandler.defaultOpacity = 50;
+  rubberBandHandler.fadeOut = true;
+}
 
 // call methods and properties defined in mixins to ensure that interface augmentation is correctly defined
 graph.getAllConnectionConstraints(new CellState(), true);


### PR DESCRIPTION
Explicitly state that a plugin may not be available.

BREAKING CHANGE: The `AbstractGraph.getPlugin` method now explicitly returns `undefined` when a plugin is not found.
TypeScript users must update their code to handle the `undefined` case when calling this method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved type safety by asserting plugin presence during retrievals, reducing potential runtime errors.
	- Fixed initialization of drag-and-drop guides to prevent issues from undefined values.
	- Added safeguards for optional plugin handling to avoid runtime errors.
	- Clarified variable names in UI components for better readability.
- **Documentation**
	- Updated changelog to clarify breaking changes in plugin management and method signatures.
- **Refactor**
	- Enhanced internal plugin storage and access using a map structure for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->