### PR TITLE
refactor(stories): remove reference to Graph handler

### DIFF
--- a/packages/html/stories/Boundary.stories.js
+++ b/packages/html/stories/Boundary.stories.js
@@ -151,10 +151,10 @@ const Template = ({ label, ...args }) => {
   style.fontStyle = 1;
   graph.getStylesheet().putDefaultVertexStyle(style);
 
-  const graphHandler = graph.getPlugin('SelectionHandler');
+  const selectionHandler = graph.getPlugin('SelectionHandler');
 
   // Replaces move preview for relative children
-  graphHandler.getDelta = function (me) {
+  selectionHandler.getDelta = function (me) {
     const point = styleUtils.convertPoint(this.graph.container, me.getX(), me.getY());
     let delta = new Point(point.x - this.first.x, point.y - this.first.y);
 
@@ -178,7 +178,7 @@ const Template = ({ label, ...args }) => {
   };
 
   // Relative children cannot be removed from parent
-  graphHandler.shouldRemoveCellsFromParent = function (parent, cells, evt) {
+  selectionHandler.shouldRemoveCellsFromParent = function (parent, cells, evt) {
     return (
       cells.length === 0 &&
       !cells[0].geometry.relative &&

--- a/packages/html/stories/Constituent.stories.ts
+++ b/packages/html/stories/Constituent.stories.ts
@@ -20,16 +20,12 @@ import {
   CellEditorHandler,
   type CellStateStyle,
   ConnectionHandler,
-  FitPlugin,
   Graph,
   InternalEvent,
   InternalMouseEvent,
-  PanningHandler,
-  PopupMenuHandler,
   RubberBandHandler,
   SelectionCellsHandler,
   SelectionHandler,
-  TooltipHandler,
 } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
 import { createGraphContainer, createMainDiv } from './shared/configure.js';
@@ -77,15 +73,11 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   class MyCustomGraph extends Graph {
     constructor(container: HTMLElement) {
       super(container, undefined, [
-        // same as getDefaultPlugins, but with custom SelectionHandler
+        // part of getDefaultPlugins
         CellEditorHandler,
-        TooltipHandler,
         SelectionCellsHandler,
-        PopupMenuHandler,
         ConnectionHandler,
         MyCustomSelectionHandler, // replaces SelectionHandler
-        PanningHandler,
-        FitPlugin,
         // additional plugin for rubber band selection
         RubberBandHandler,
       ]);

--- a/packages/html/stories/Constituent.stories.ts
+++ b/packages/html/stories/Constituent.stories.ts
@@ -17,13 +17,19 @@ limitations under the License.
 
 import {
   type Cell,
+  CellEditorHandler,
   type CellStateStyle,
-  getDefaultPlugins,
+  ConnectionHandler,
+  FitPlugin,
   Graph,
   InternalEvent,
   InternalMouseEvent,
+  PanningHandler,
+  PopupMenuHandler,
   RubberBandHandler,
+  SelectionCellsHandler,
   SelectionHandler,
+  TooltipHandler,
 } from '@maxgraph/core';
 import { globalTypes, globalValues } from './shared/args.js';
 import { createGraphContainer, createMainDiv } from './shared/configure.js';
@@ -51,7 +57,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   // Disables the built-in context menu
   InternalEvent.disableContextMenu(container);
 
-  class MyCustomGraphHandler extends SelectionHandler {
+  class MyCustomSelectionHandler extends SelectionHandler {
     /**
      * Redirects start drag to parent.
      */
@@ -70,7 +76,19 @@ const Template = ({ label, ...args }: Record<string, string>) => {
 
   class MyCustomGraph extends Graph {
     constructor(container: HTMLElement) {
-      super(container, undefined, [...getDefaultPlugins(), RubberBandHandler]);
+      super(container, undefined, [
+        // same as getDefaultPlugins, but with custom SelectionHandler
+        CellEditorHandler,
+        TooltipHandler,
+        SelectionCellsHandler,
+        PopupMenuHandler,
+        ConnectionHandler,
+        MyCustomSelectionHandler, // replaces SelectionHandler
+        PanningHandler,
+        FitPlugin,
+        // additional plugin for rubber band selection
+        RubberBandHandler,
+      ]);
       this.options.foldingEnabled = false;
       this.recursiveResize = true;
     }
@@ -91,10 +109,6 @@ const Template = ({ label, ...args }: Record<string, string>) => {
       }
       super.selectCellForEvent(cell, evt);
     };
-
-    createGraphHandler() {
-      return new MyCustomGraphHandler(this);
-    }
   }
 
   // Creates the graph inside the given container

--- a/packages/html/stories/DragSource.stories.js
+++ b/packages/html/stories/DragSource.stories.js
@@ -27,12 +27,8 @@ import {
   Cell,
   Geometry,
   CellEditorHandler,
-  TooltipHandler,
   SelectionCellsHandler,
-  PopupMenuHandler,
   ConnectionHandler,
-  PanningHandler,
-  FitPlugin,
 } from '@maxgraph/core';
 
 import {
@@ -80,15 +76,11 @@ const Template = ({ label, ...args }) => {
   class MyCustomGraph extends Graph {
     constructor(container) {
       super(container, undefined, [
-        // same as getDefaultPlugins, but with custom SelectionHandler
+        // part of getDefaultPlugins
         CellEditorHandler,
-        TooltipHandler,
         SelectionCellsHandler,
-        PopupMenuHandler,
         ConnectionHandler,
         MyCustomSelectionHandler, // replaces SelectionHandler
-        PanningHandler,
-        FitPlugin,
       ]);
       this.options.foldingEnabled = false;
       this.recursiveResize = true;

--- a/packages/html/stories/DragSource.stories.js
+++ b/packages/html/stories/DragSource.stories.js
@@ -21,12 +21,18 @@ import {
   RubberBandHandler,
   DragSource,
   gestureUtils,
-  EdgeHandler,
   SelectionHandler,
   Guide,
   eventUtils,
   Cell,
   Geometry,
+  CellEditorHandler,
+  TooltipHandler,
+  SelectionCellsHandler,
+  PopupMenuHandler,
+  ConnectionHandler,
+  PanningHandler,
+  FitPlugin,
 } from '@maxgraph/core';
 
 import {
@@ -62,7 +68,7 @@ const Template = ({ label, ...args }) => {
     }
   }
 
-  class MyCustomGraphHandler extends SelectionHandler {
+  class MyCustomSelectionHandler extends SelectionHandler {
     // Enables guides
     guidesEnabled = true;
 
@@ -71,18 +77,27 @@ const Template = ({ label, ...args }) => {
     }
   }
 
-  class MyCustomEdgeHandler extends EdgeHandler {
-    // Enables snapping waypoints to terminals
-    snapToTerminals = true;
-  }
-
   class MyCustomGraph extends Graph {
-    createGraphHandler() {
-      return new MyCustomGraphHandler(this);
+    constructor(container) {
+      super(container, undefined, [
+        // same as getDefaultPlugins, but with custom SelectionHandler
+        CellEditorHandler,
+        TooltipHandler,
+        SelectionCellsHandler,
+        PopupMenuHandler,
+        ConnectionHandler,
+        MyCustomSelectionHandler, // replaces SelectionHandler
+        PanningHandler,
+        FitPlugin,
+      ]);
+      this.options.foldingEnabled = false;
+      this.recursiveResize = true;
     }
 
     createEdgeHandler(state, edgeStyle) {
-      return new MyCustomEdgeHandler(state, edgeStyle);
+      const edgeHandler = super.createEdgeHandler(state, edgeStyle);
+      edgeHandler.snapToTerminals = true; // Enables snapping waypoints to terminals
+      return edgeHandler;
     }
   }
 

--- a/packages/html/stories/Grid.stories.js
+++ b/packages/html/stories/Grid.stories.js
@@ -61,9 +61,9 @@ const Template = ({ label, ...args }) => {
   if (!args.contextMenu) InternalEvent.disableContextMenu(container);
 
   // Creates the graph inside the given container
-  var graph = new Graph(container);
-  const graphHandler = graph.getPlugin('SelectionHandler');
-  graphHandler.scaleGrid = true;
+  const graph = new Graph(container);
+  const selectionHandler = graph.getPlugin('SelectionHandler');
+  selectionHandler.scaleGrid = true;
   graph.setPanning(true);
 
   // Enables rubberband selection

--- a/packages/html/stories/Groups.stories.js
+++ b/packages/html/stories/Groups.stories.js
@@ -53,9 +53,9 @@ const Template = ({ label, ...args }) => {
   };
 
   // Don't clear selection if multiple cells selected
-  const graphHandlerMouseDown = SelectionHandler.prototype.mouseDown;
+  const selectionHandlerMouseDown = SelectionHandler.prototype.mouseDown;
   SelectionHandler.prototype.mouseDown = function (sender, me) {
-    graphHandlerMouseDown.apply(this, arguments);
+    selectionHandlerMouseDown.apply(this, arguments);
 
     if (this.graph.isCellSelected(me.getCell()) && this.graph.getSelectionCount() > 1) {
       this.delayedSelection = false;
@@ -63,13 +63,13 @@ const Template = ({ label, ...args }) => {
   };
 
   // Selects descendants before children selection mode
-  const graphHandlerGetInitialCellForEvent =
+  const selectionHandlerGetInitialCellForEvent =
     SelectionHandler.prototype.getInitialCellForEvent;
   SelectionHandler.prototype.getInitialCellForEvent = function (me) {
     const psel = this.graph.getSelectionCell()
       ? this.graph.getSelectionCell().getParent()
       : null;
-    let cell = graphHandlerGetInitialCellForEvent.apply(this, arguments);
+    let cell = selectionHandlerGetInitialCellForEvent.apply(this, arguments);
     let parent = cell.getParent();
 
     if (psel == null || (psel != cell && psel != parent)) {
@@ -88,9 +88,10 @@ const Template = ({ label, ...args }) => {
   };
 
   // Selection is delayed to mouseup if child selected
-  const graphHandlerIsDelayedSelection = SelectionHandler.prototype.isDelayedSelection;
+  const selectionHandlerIsDelayedSelection =
+    SelectionHandler.prototype.isDelayedSelection;
   SelectionHandler.prototype.isDelayedSelection = function (cell) {
-    let result = graphHandlerIsDelayedSelection.apply(this, arguments);
+    let result = selectionHandlerIsDelayedSelection.apply(this, arguments);
     const psel = this.graph.getSelectionCell()
       ? this.graph.getSelectionCell().getParent()
       : null;

--- a/packages/html/stories/Labels.stories.js
+++ b/packages/html/stories/Labels.stories.js
@@ -57,10 +57,10 @@ const Template = ({ label, ...args }) => {
 
   new KeyHandler(graph);
 
-  const graphHandler = graph.getPlugin('SelectionHandler');
+  const selectionHandler = graph.getPlugin('SelectionHandler');
 
   // Do not allow removing labels from parents
-  graphHandler.removeCellsFromParent = false;
+  selectionHandler.removeCellsFromParent = false;
 
   // Allow auto-size labels on insert
   graph.autoSizeCellsOnAdd = true;


### PR DESCRIPTION
This was the former name of `SelectionHandler` in mxGraph. So, rename variables for consistency.

Also replace createGraphHandler methods in custom graph implementation as this method no longer exist in AbstractGraph (SelectionHandler is set as a plugin).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Renamed custom selection handler classes and related variables for improved clarity and consistency across multiple stories.
  - Updated graph initialization to use explicit plugin lists, replacing default plugin retrieval and streamlining handler customization.
  - Simplified handler method overrides and property assignments to enhance maintainability.
- **Chores**
  - Removed unused or redundant methods and classes to clean up the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->