### PR TITLE
docs: fix some typedoc warnings

### DIFF
--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -193,7 +193,7 @@ import type { FitPlugin } from '../view/plugins/index.js';
  * must refer to an existing template.
  *
  * In the following example, the task node is a business object and only the
- * mxCell node and its mxGeometry child contain graph information:
+ * Cell node and its Geometry child contain graph information:
  *
  * ```javascript
  * <Task label="Task" description="">
@@ -214,7 +214,7 @@ import type { FitPlugin } from '../view/plugins/index.js';
  *
  * The Task node can have any tag name, attributes and child nodes. The
  * {@link Codec} will use the XML hierarchy as the user object, while removing the
- * "known annotations", such as the mxCell node. At save-time the cell data
+ * "known annotations", such as the Cell node. At save-time the cell data
  * will be "merged" back into the user object. The user object is only modified
  * via the properties dialog during the lifecycle of the cell.
  *

--- a/packages/core/src/serialization/Codec.ts
+++ b/packages/core/src/serialization/Codec.ts
@@ -383,7 +383,7 @@ class Codec {
    * function is in charge of adding the result into the
    * given node and has no return value.
    *
-   * @param cell {@link mxCell} to be encoded.
+   * @param cell {@link Cell} to be encoded.
    * @param node Parent XML node to add the encoded cell into.
    * @param includeChildren Optional boolean indicating if the
    * function should include all descendents. Default is true.
@@ -435,7 +435,7 @@ class Codec {
 
     // Tries to find a codec for the given node name. If that does
     // not return a codec then the node is the user object (an XML node
-    // that contains the mxCell, aka inversion).
+    // that contains the Cell, aka inversion).
     let decoder = CodecRegistry.getCodec(node.nodeName);
 
     // Tries to find the codec for the cell inside the user object.

--- a/packages/core/src/serialization/ModelXmlSerializer.ts
+++ b/packages/core/src/serialization/ModelXmlSerializer.ts
@@ -24,7 +24,6 @@ import type GraphDataModel from '../view/GraphDataModel.js';
  *
  * **WARN**: this is an experimental feature that is subject to change.
  *
- * @alpha
  * @experimental
  * @since 0.6.0
  * @category Serialization with Codecs
@@ -42,7 +41,6 @@ export type ModelExportOptions = {
  *
  * **WARN**: this is an experimental feature that is subject to change (class and method names).
  *
- * @alpha
  * @experimental
  * @since 0.6.0
  * @category Serialization with Codecs

--- a/packages/core/src/view/AbstractGraph.ts
+++ b/packages/core/src/view/AbstractGraph.ts
@@ -533,7 +533,7 @@ export abstract class AbstractGraph extends EventSource {
   }
 
   /**
-   * Returns the {@link GraphView} that contains the {@link mxCellStates}.
+   * Returns the {@link GraphView} that contains the {@link CellState}s.
    */
   getView() {
     return this.view;

--- a/packages/core/src/view/GraphDataModel.ts
+++ b/packages/core/src/view/GraphDataModel.ts
@@ -351,8 +351,8 @@ export class GraphDataModel extends EventSource {
    * Example:
    *
    * ```javascript
-   * var root = new mxCell();
-   * root.insert(new mxCell());
+   * const root = new Cell();
+   * root.insert(new Cell());
    * model.setRoot(root);
    * ```
    *
@@ -474,7 +474,7 @@ export class GraphDataModel extends EventSource {
             collision = this.getCell(<string>cell.getId());
           }
 
-          // Lazily creates the cells dictionary
+          // Lazily creates the cells map
           if (this.cells == null) {
             this.cells = {};
           }
@@ -637,7 +637,7 @@ export class GraphDataModel extends EventSource {
         this.cellRemoved(<Cell>cell.getChildAt(i));
       }
 
-      // Removes the dictionary entry for the cell
+      // Removes the map entry for the cell
       if (this.cells != null && cell.getId() != null) {
         // @ts-ignore
         delete this.cells[cell.getId()];
@@ -689,7 +689,6 @@ export class GraphDataModel extends EventSource {
    * @param isSource  Boolean indicating if the terminal is the new source or
    * target terminal of the edge.
    */
-  // setTerminal(edge: mxCell, terminal: mxCell, isSource: boolean): mxCell;
   setTerminal(edge: Cell, terminal: Cell | null, isSource: boolean): Cell | null {
     const terminalChanged = terminal !== edge.getTerminal(isSource);
     this.execute(new TerminalChange(this, edge, terminal, isSource));
@@ -708,7 +707,6 @@ export class GraphDataModel extends EventSource {
    * @param {Cell} source  that specifies the new source terminal.
    * @param {Cell} target  that specifies the new target terminal.
    */
-  // setTerminals(edge: mxCell, source: mxCell, target: mxCell): void;
   setTerminals(edge: Cell, source: Cell | null, target: Cell | null): void {
     this.beginUpdate();
     try {
@@ -728,7 +726,6 @@ export class GraphDataModel extends EventSource {
    * @param isSource  Boolean indicating if the terminal is the new source or
    * target terminal of the edge.
    */
-  // terminalForCellChanged(edge: mxCell, terminal: mxCell, isSource: boolean): mxCell;
   terminalForCellChanged(
     edge: Cell,
     terminal: Cell | null,

--- a/packages/core/src/view/GraphSelectionModel.ts
+++ b/packages/core/src/view/GraphSelectionModel.ts
@@ -132,7 +132,7 @@ class GraphSelectionModel extends EventSource {
   /**
    * Selects the specified {@link Cell} using {@link setCells}.
    *
-   * @param cell {@link mxCell} to be selected.
+   * @param cell {@link Cell} to be selected.
    */
   setCell(cell: Cell) {
     this.setCells(cell ? [cell] : []);
@@ -172,7 +172,7 @@ class GraphSelectionModel extends EventSource {
   /**
    * Adds the given {@link Cell} to the selection and fires a {@link select} event.
    *
-   * @param cell {@link mxCell} to add to the selection.
+   * @param cell {@link Cell} to add to the selection.
    */
   addCell(cell: Cell) {
     this.addCells([cell]);
@@ -207,7 +207,7 @@ class GraphSelectionModel extends EventSource {
    * Removes the specified {@link Cell} from the selection and fires a {@link select}
    * event for the remaining cells.
    *
-   * @param cell {@link mxCell} to remove from the selection.
+   * @param cell {@link Cell} to remove from the selection.
    */
   removeCell(cell: Cell) {
     this.removeCells([cell]);
@@ -217,7 +217,7 @@ class GraphSelectionModel extends EventSource {
    * Removes the specified {@link Cell} from the selection and fires a {@link select}
    * event for the remaining cells.
    *
-   * @param cells {@link mxCell}s to remove from the selection.
+   * @param cells {@link Cell}s to remove from the selection.
    */
   removeCells(cells: Cell[]) {
     const tmp = [];
@@ -255,7 +255,7 @@ class GraphSelectionModel extends EventSource {
    *
    * Paramters:
    *
-   * @param cell {@link mxCell} to add to the selection.
+   * @param cell {@link Cell} to add to the selection.
    */
   cellAdded(cell: Cell) {
     if (!this.isSelected(cell)) {
@@ -267,7 +267,7 @@ class GraphSelectionModel extends EventSource {
    * Inner callback to remove the specified {@link Cell} from the selection. No
    * event is fired in this implementation.
    *
-   * @param cell {@link mxCell} to remove from the selection.
+   * @param cell {@link Cell} to remove from the selection.
    */
   cellRemoved(cell: Cell) {
     const index = this.cells.indexOf(cell);

--- a/packages/core/src/view/cell/CellHighlight.ts
+++ b/packages/core/src/view/cell/CellHighlight.ts
@@ -33,8 +33,8 @@ import type { ColorValue } from '../../types.js';
  * A helper class to highlight cells. Here is an example for a given cell.
  *
  * ```javascript
- * cont highlight = new CellHighlight(graph, '#ff0000', 2);
- * highlight.highlight(graph.view.getState(cell)));
+ * const highlight = new CellHighlight(graph, '#ff0000', 2);
+ * highlight.highlight(graph.view.getState(cell));
  * ```
  */
 class CellHighlight {

--- a/packages/core/src/view/cell/CellHighlight.ts
+++ b/packages/core/src/view/cell/CellHighlight.ts
@@ -33,7 +33,7 @@ import type { ColorValue } from '../../types.js';
  * A helper class to highlight cells. Here is an example for a given cell.
  *
  * ```javascript
- * var highlight = new mxCellHighlight(graph, '#ff0000', 2);
+ * cont highlight = new CellHighlight(graph, '#ff0000', 2);
  * highlight.highlight(graph.view.getState(cell)));
  * ```
  */

--- a/packages/core/src/view/event/EventSource.ts
+++ b/packages/core/src/view/event/EventSource.ts
@@ -121,19 +121,18 @@ class EventSource {
   }
 
   /**
-   * Dispatches the given event to the listeners which are registered for
-   * the event. The sender argument is optional. The current execution scope
-   * ("this") is used for the listener invocation (see {@link Utils#bind}).
+   * Dispatches the given event to the listeners which are registered for the event.
+   * The sender argument is optional.
+   * The current execution scope ("this") is used for the listener invocation.
    *
    * Example:
    *
    * ```javascript
-   * fireEvent(new mxEventObject("eventName", key1, val1, .., keyN, valN))
+   * fireEvent(new EventObject("eventName", key1, val1, .., keyN, valN))
    * ```
    *
    * @param evt {@link EventObject} that represents the event.
-   * @param sender Optional sender to be passed to the listener. Default value is
-   * the return value of <getEventSource>.
+   * @param sender Optional sender to be passed to the listener. Default value is the return value of {@link getEventSource}.
    */
   fireEvent(evt: EventObject, sender: EventTarget | null = null) {
     if (this.isEventsEnabled()) {

--- a/packages/core/src/view/event/InternalEvent.ts
+++ b/packages/core/src/view/event/InternalEvent.ts
@@ -68,9 +68,7 @@ try {
  */
 class InternalEvent {
   /**
-   * Binds the function to the specified event on the given element. Use
-   * {@link mxUtils.bind} in order to bind the "this" keyword inside the function
-   * to a given execution scope.
+   * Binds the function to the specified event on the given element.
    */
   static addListener(
     element: Listenable,

--- a/packages/core/src/view/layout/CompactTreeLayout.ts
+++ b/packages/core/src/view/layout/CompactTreeLayout.ts
@@ -229,10 +229,10 @@ export class CompactTreeLayout extends GraphLayout {
   node: _mxCompactTreeLayoutNode | null = null;
 
   /**
-   * Returns a boolean indicating if the given {@link mxCell} should be ignored as a
+   * Returns a boolean indicating if the given {@link Cell} should be ignored as a
    * vertex. This returns true if the cell has no connections.
    *
-   * @param vertex {@link mxCell} whose ignored state should be returned.
+   * @param vertex {@link Cell} whose ignored state should be returned.
    */
   isVertexIgnored(vertex: Cell): boolean {
     return super.isVertexIgnored(vertex) || vertex.getConnections().length === 0;
@@ -252,8 +252,8 @@ export class CompactTreeLayout extends GraphLayout {
    * the tree. Else, {@link mxGraph.findTreeRoots} will be used to find a suitable
    * root node within the set of children of the given parent.
    *
-   * @param parent  {@link mxCell} whose children should be laid out.
-   * @param root    Optional {@link mxCell} that will be used as the root of the tree. Overrides {@link root} if specified.
+   * @param parent  {@link Cell} whose children should be laid out.
+   * @param root    Optional {@link Cell} that will be used as the root of the tree. Overrides {@link root} if specified.
    */
   execute(parent: Cell, root?: Cell): void {
     this.parent = parent;

--- a/packages/core/src/view/layout/FastOrganicLayout.ts
+++ b/packages/core/src/view/layout/FastOrganicLayout.ts
@@ -34,7 +34,7 @@ import type Cell from '../cell/Cell.js';
  *
  * @category Layout
  */
-class MxFastOrganicLayout extends GraphLayout {
+class FastOrganicLayout extends GraphLayout {
   constructor(graph: AbstractGraph) {
     super(graph);
   }
@@ -250,7 +250,7 @@ class MxFastOrganicLayout extends GraphLayout {
             this.setEdgeStyleEnabled(edges[j], false);
           }
 
-          // Looks the cell up in the indices map
+          // Looks the cell up in the indices lookup table
           const id = <string>ObjectIdentity.get(cells[j]);
           const index = this.indices[id];
 
@@ -483,4 +483,4 @@ class MxFastOrganicLayout extends GraphLayout {
   }
 }
 
-export default MxFastOrganicLayout;
+export default FastOrganicLayout;

--- a/packages/core/src/view/layout/FastOrganicLayout.ts
+++ b/packages/core/src/view/layout/FastOrganicLayout.ts
@@ -250,7 +250,7 @@ class MxFastOrganicLayout extends GraphLayout {
             this.setEdgeStyleEnabled(edges[j], false);
           }
 
-          // Looks the cell up in the indices dictionary
+          // Looks the cell up in the indices map
           const id = <string>ObjectIdentity.get(cells[j]);
           const index = this.indices[id];
 

--- a/packages/core/src/view/layout/RadialTreeLayout.ts
+++ b/packages/core/src/view/layout/RadialTreeLayout.ts
@@ -118,9 +118,9 @@ class RadialTreeLayout extends CompactTreeLayout {
   row: _mxCompactTreeLayoutNode[][] = [];
 
   /**
-   * Returns a boolean indicating if the given {@link mxCell} should be ignored as a vertex.
+   * Returns a boolean indicating if the given {@link Cell} should be ignored as a vertex.
    *
-   * @param vertex {@link mxCell} whose ignored state should be returned.
+   * @param vertex {@link Cell} whose ignored state should be returned.
    * @return true if the cell has no connections.
    */
   isVertexIgnored(vertex: Cell): boolean {
@@ -136,8 +136,8 @@ class RadialTreeLayout extends CompactTreeLayout {
    * the tree. Else, {@link AbstractGraph.findTreeRoots} will be used to find a suitable
    * root node within the set of children of the given parent.
    *
-   * @param parent    {@link mxCell} whose children should be laid out.
-   * @param root      Optional {@link mxCell} that will be used as the root of the tree.
+   * @param parent    {@link Cell} whose children should be laid out.
+   * @param root      Optional {@link Cell} that will be used as the root of the tree.
    */
   execute(parent: Cell, root: Cell | null = null): void {
     this.parent = parent;

--- a/packages/core/src/view/layout/SwimlaneManager.ts
+++ b/packages/core/src/view/layout/SwimlaneManager.ts
@@ -225,7 +225,7 @@ class SwimlaneManager extends EventSource {
    * Updates the size of the given swimlane to match that of any existing
    * siblings swimlanes.
    *
-   * @param swimlane {@link mxCell} that represents the new swimlane.
+   * @param swimlane {@link Cell} that represents the new swimlane.
    */
   swimlaneAdded(swimlane: Cell) {
     const parent = <Cell>swimlane.getParent();
@@ -296,7 +296,7 @@ class SwimlaneManager extends EventSource {
    * the size of the siblings and the size of the parent swimlanes, recursively,
    * if {@link bubbling} is true.
    *
-   * @param swimlane {@link mxCell} whose size has changed.
+   * @param swimlane {@link Cell} whose size has changed.
    */
   resizeSwimlane(swimlane: Cell, w: number, h: number, parentHorizontal: boolean) {
     const model = this.graph.getDataModel();

--- a/packages/core/src/view/mixins/CellsMixin.ts
+++ b/packages/core/src/view/mixins/CellsMixin.ts
@@ -456,7 +456,7 @@ export const CellsMixin: PartialType = {
   cloneCells(cells, allowInvalidEdges = true, mapping = {}, keepPosition = false) {
     let clones: Cell[];
 
-    // Creates a dictionary for fast lookups
+    // Creates a map for fast lookups
     const dict = new Map<Cell, boolean>();
     const tmp = [];
 

--- a/packages/core/src/view/mixins/CellsMixin.type.ts
+++ b/packages/core/src/view/mixins/CellsMixin.type.ts
@@ -290,8 +290,8 @@ declare module '../AbstractGraph' {
      *
      * This is a shortcut method.
      *
-     * @param cell {@link mxCell} to be inserted into the given parent.
-     * @param parent {@link mxCell} that represents the new parent. If no parent is given then the default parent is used.
+     * @param cell {@link Cell} to be inserted into the given parent.
+     * @param parent {@link Cell} that represents the new parent. If no parent is given then the default parent is used.
      * @param index Optional index to insert the cells at. Default is 'to append'.
      * @param source Optional {@link Cell} that represents the source terminal.
      * @param target Optional {@link Cell} that represents the target terminal.
@@ -345,7 +345,7 @@ declare module '../AbstractGraph' {
     /**
      * Resizes the specified cell to just fit around its label and/or children.
      *
-     * @param cell {@link mxCell} to be resized.
+     * @param cell {@link Cell} to be resized.
      * @param recurse Optional boolean which specifies if all descendants should be auto-sized. Default is `true`.
      */
     autoSizeCell: (cell: Cell, recurse?: boolean) => void;
@@ -428,7 +428,7 @@ declare module '../AbstractGraph' {
      * };
      * ```
      *
-     * @param cell {@link mxCell} for which the preferred size should be returned.
+     * @param cell {@link Cell} for which the preferred size should be returned.
      * @param textWidth Optional maximum text width for word wrapping.
      */
     getPreferredSizeForCell: (cell: Cell, textWidth?: number | null) => Rectangle | null;
@@ -463,28 +463,23 @@ declare module '../AbstractGraph' {
      * that all child cells stay within the group.
      *
      * ```javascript
-     * graph.addListener(mxEvent.CELLS_RESIZED, function(sender, evt)
-     * {
-     *   var cells = evt.getProperty('cells');
+     * graph.addListener(InternalEvent.CELLS_RESIZED, function(sender, evt) {
+     *   const cells = evt.getProperty('cells');
      *
-     *   if (cells != null)
-     *   {
-     *     for (var i = 0; i < cells.length; i++)
-     *     {
-     *       if (graph.getDataModel().getChildCount(cells[i]) > 0)
-     *       {
-     *         var geo = cells[i].getGeometry();
+     *   if (cells) {
+     *     for (const cell of cells) {
+     *       if (graph.getDataModel().getChildCount(cell) > 0) {
+     *         const geo = cell.getGeometry();
      *
-     *         if (geo != null)
-     *         {
-     *           var children = graph.getChildCells(cells[i], true, true);
-     *           var bounds = graph.getBoundingBoxFromGeometry(children, true);
+     *         if (geo) {
+     *           const children = graph.getChildCells(cell, true, true);
+     *           const bounds = graph.getBoundingBoxFromGeometry(children, true);
      *
      *           geo = geo.clone();
      *           geo.width = Math.max(geo.width, bounds.width);
      *           geo.height = Math.max(geo.height, bounds.height);
      *
-     *           graph.getDataModel().setGeometry(cells[i], geo);
+     *           graph.getDataModel().setGeometry(cell, geo);
      *         }
      *       }
      *     }
@@ -638,7 +633,7 @@ declare module '../AbstractGraph' {
      *
      * If vertices and edges is `false`, then all children are returned.
      *
-     * @param parent {@link mxCell} whose children should be returned.
+     * @param parent {@link Cell} whose children should be returned.
      * @param vertices Optional boolean that specifies if child vertices should be returned. Default is `false`.
      * @param edges Optional boolean that specifies if child edges should be returned. Default is `false`.
      */
@@ -653,7 +648,7 @@ declare module '../AbstractGraph' {
      *
      * @param x X-coordinate of the location to be checked.
      * @param y Y-coordinate of the location to be checked.
-     * @param parent {@link mxCell} that should be used as the root of the recursion. Default is current root of the view or the root of the model.
+     * @param parent {@link Cell} that should be used as the root of the recursion. Default is current root of the view or the root of the model.
      * @param vertices Optional boolean indicating if vertices should be returned. Default is `true`.
      * @param edges Optional boolean indicating if edges should be returned. Default is `true`.
      * @param ignoreFn Optional function that returns true if cell should be ignored. The function is passed the cell state and the x and y parameter. Default is `null`.
@@ -677,7 +672,7 @@ declare module '../AbstractGraph' {
      * @param y Y-coordinate of the rectangle.
      * @param width Width of the rectangle.
      * @param height Height of the rectangle.
-     * @param parent {@link mxCell} that should be used as the root of the recursion. Default is current root of the view or the root of the model.
+     * @param parent {@link Cell} that should be used as the root of the recursion. Default is current root of the view or the root of the model.
      * @param result Optional array to store the result in. Default is an empty Array.
      * @param intersection Default is `null`.
      * @param ignoreFn Default is `null`.
@@ -697,7 +692,7 @@ declare module '../AbstractGraph' {
 
     /**
      * Returns the children of the given parent that are contained in the half-pane from the given point (x0, y0) rightwards or downwards
-     * depending on rightHalfpane and bottomHalfpane.
+     * depending on `rightHalfpane` and `bottomHalfpane`.
      *
      * @param x0 X-coordinate of the origin.
      * @param y0 Y-coordinate of the origin.

--- a/packages/core/src/view/mixins/CellsMixin.type.ts
+++ b/packages/core/src/view/mixins/CellsMixin.type.ts
@@ -469,7 +469,7 @@ declare module '../AbstractGraph' {
      *   if (cells) {
      *     for (const cell of cells) {
      *       if (graph.getDataModel().getChildCount(cell) > 0) {
-     *         const geo = cell.getGeometry();
+     *         let geo = cell.getGeometry();
      *
      *         if (geo) {
      *           const children = graph.getChildCells(cell, true, true);

--- a/packages/core/src/view/mixins/ConnectionsMixin.type.ts
+++ b/packages/core/src/view/mixins/ConnectionsMixin.type.ts
@@ -204,8 +204,8 @@ declare module '../AbstractGraph' {
      * Returns true if the given cell is disconnectable from the source or target terminal.
      * This returns {@link isCellsDisconnectable} for all given cells if {@link isCellLocked} does not return `true` for the given cell.
      *
-     * @param cell {@link mxCell} whose disconnectable state should be returned.
-     * @param terminal {@link mxCell} that represents the source or target terminal.
+     * @param cell {@link Cell} whose disconnectable state should be returned.
+     * @param terminal {@link Cell} that represents the source or target terminal.
      * @param source Boolean indicating if the source or target terminal is to be disconnected.
      */
     isCellDisconnectable: (cell: Cell, terminal: Cell | null, source: boolean) => boolean;
@@ -225,14 +225,14 @@ declare module '../AbstractGraph' {
      *
      * This implementation returns `true` for all non-null values and is called by is called by {@link isValidConnection}.
      *
-     * @param cell {@link mxCell} that represents a possible source or `null`.
+     * @param cell {@link Cell} that represents a possible source or `null`.
      */
     isValidSource: (cell: Cell | null) => boolean;
 
     /**
      * Returns {@link isValidSource} for the given cell. This is called by {@link isValidConnection}.
      *
-     * @param cell {@link mxCell} that represents a possible target or `null`.
+     * @param cell {@link Cell} that represents a possible target or `null`.
      */
     isValidTarget: (cell: Cell | null) => boolean;
 

--- a/packages/core/src/view/mixins/EdgeMixin.type.ts
+++ b/packages/core/src/view/mixins/EdgeMixin.type.ts
@@ -318,7 +318,7 @@ declare module '../AbstractGraph' {
     /**
      * Resets the control points of the given edge.
      *
-     * @param edge {@link mxCell} whose points should be reset.
+     * @param edge {@link Cell} whose points should be reset.
      */
     resetEdge: (edge: Cell) => Cell;
   }

--- a/packages/core/src/view/mixins/LabelMixin.type.ts
+++ b/packages/core/src/view/mixins/LabelMixin.type.ts
@@ -69,7 +69,7 @@ declare module '../AbstractGraph' {
      * });
      * ```
      *
-     * @param cell {@link mxCell} whose label should be returned.
+     * @param cell {@link Cell} whose label should be returned.
      */
     getLabel: (cell: Cell) => string | null;
 

--- a/packages/core/src/view/mixins/SwimlaneMixin.type.ts
+++ b/packages/core/src/view/mixins/SwimlaneMixin.type.ts
@@ -50,7 +50,7 @@ declare module '../AbstractGraph' {
      *
      * @param x X-coordinate of the location to be checked.
      * @param y Y-coordinate of the location to be checked.
-     * @param parent {@link mxCell} that should be used as the root of the recursion. Default is {@link defaultParent}.
+     * @param parent {@link Cell} that should be used as the root of the recursion. Default is {@link defaultParent}.
      */
     getSwimlaneAt: (x: number, y: number, parent?: Cell | null) => Cell | null;
 
@@ -67,7 +67,7 @@ declare module '../AbstractGraph' {
      * Returns the start size of the given swimlane, that is, the width or height of the part that contains the title, depending on the horizontal style.
      * The return value is an {@link Rectangle} with either width or height set as appropriate.
      *
-     * @param swimlane {@link mxCell} whose start size should be returned.
+     * @param swimlane {@link Cell} whose start size should be returned.
      * @param ignoreState Optional boolean that specifies if cell state should be ignored.
      */
     getStartSize: (swimlane: Cell, ignoreState?: boolean) => Rectangle;
@@ -81,7 +81,7 @@ declare module '../AbstractGraph' {
      * Returns the actual start size of the given swimlane taking into account direction and horizontal and vertical flip styles.
      * The start size is returned as an {@link Rectangle} where top, left, bottom, right start sizes are returned as x, y, height and width, respectively.
      *
-     * @param swimlane {@link mxCell} whose start size should be returned.
+     * @param swimlane {@link Cell} whose start size should be returned.
      * @param ignoreState Optional boolean that specifies if cell state should be ignored.
      */
     getActualStartSize: (swimlane: Cell, ignoreState: boolean) => Rectangle;

--- a/packages/core/src/view/other/DragSource.ts
+++ b/packages/core/src/view/other/DragSource.ts
@@ -130,12 +130,12 @@ class DragSource {
   currentPoint: Point | null = null;
 
   /**
-   * Holds an {@link Guide} for the {@link currentGraph} if {@link dragElement} is not `null`.
+   * Holds a {@link Guide} for the {@link currentGraph} (only created when {@link dragElement} exists).
    */
   currentGuide: Guide | null = null;
 
   /**
-   * Holds an {@link CellHighlight} for the {@link currentGraph}.
+   * Holds a {@link CellHighlight} for the {@link currentGraph}.
    */
   currentHighlight: CellHighlight | null = null;
 

--- a/packages/core/src/view/other/DragSource.ts
+++ b/packages/core/src/view/other/DragSource.ts
@@ -95,13 +95,12 @@ class DragSource {
 
   /**
    * Holds the DOM node that is used to represent the drag preview. If this is
-   * null then the source element will be cloned and used for the drag preview.
+   * `null` then the source element will be cloned and used for the drag preview.
    */
   dragElement: HTMLElement | null = null;
 
   /**
-   * TODO - wrong description
-   * Optional {@link Rectangle} that specifies the unscaled size of the preview.
+   * Holds the DOM node that is used to represent the drag preview in the graph.
    */
   previewElement: HTMLElement | null = null;
 
@@ -131,13 +130,12 @@ class DragSource {
   currentPoint: Point | null = null;
 
   /**
-   * Holds an {@link Guide} for the {@link currentGraph} if {@link dragPreview} is not null.
+   * Holds an {@link Guide} for the {@link currentGraph} if {@link dragElement} is not `null`.
    */
   currentGuide: Guide | null = null;
 
   /**
-   * Holds an {@link Guide} for the {@link currentGraph} if {@link dragPreview} is not null.
-   * @note wrong doc
+   * Holds an {@link CellHighlight} for the {@link currentGraph}.
    */
   currentHighlight: CellHighlight | null = null;
 

--- a/packages/core/src/view/plugins/SelectionCellsHandler.ts
+++ b/packages/core/src/view/plugins/SelectionCellsHandler.ts
@@ -95,7 +95,7 @@ class SelectionCellsHandler extends EventSource implements GraphPlugin, MouseLis
   maxHandlers = 100;
 
   /**
-   * {@link Dictionary} that maps from cells to handlers.
+   * Maps from cells to handlers.
    */
   handlers: Map<Cell, Handler>;
 

--- a/packages/core/src/view/shape/Shape.ts
+++ b/packages/core/src/view/shape/Shape.ts
@@ -53,7 +53,7 @@ import { StyleDefaultsConfig } from '../../util/config.js';
  * the browser and the configuration of the graph (see maxGraph rendering hint).
  *
  * For each supported shape in SVG and VML, a corresponding shape exists in
- * mxGraph, namely for text, image, rectangle, rhombus, ellipse and polyline.
+ * maxGraph, namely for text, image, rectangle, rhombus, ellipse and polyline.
  * The other shapes are a combination of these shapes (e.g. label and swimlane)
  * or they consist of one or more (filled) path objects (e.g. actor and cylinder).
  * The HTML implementation is optional but may be required for a HTML-only view
@@ -96,7 +96,7 @@ class Shape {
   indicator: Shape | null = null;
   indicatorShape: typeof Shape | null = null;
 
-  // Assigned in CellHighlight
+  /** @see CellHighlight */
   opacity = 100;
   isDashed = false;
 

--- a/packages/core/src/view/shape/Shape.ts
+++ b/packages/core/src/view/shape/Shape.ts
@@ -46,16 +46,16 @@ import { StyleDefaultsConfig } from '../../util/config.js';
 
 /**
  * Base class for all shapes.
- * A shape in mxGraph is a separate implementation for SVG, VML and HTML.
+ * A shape in maxGraph is a separate implementation for SVG, VML and HTML.
  * Which implementation to use is controlled by the dialect property which
- * is assigned from within the mxCellRenderer when the shape is created.
+ * is assigned from within the CellRenderer when the shape is created.
  * The dialect must be assigned for a shape, and it does normally depend on
- * the browser and the configuration of the graph (see mxGraph rendering hint).
+ * the browser and the configuration of the graph (see maxGraph rendering hint).
  *
  * For each supported shape in SVG and VML, a corresponding shape exists in
  * mxGraph, namely for text, image, rectangle, rhombus, ellipse and polyline.
- * The other shapes are a combination of these shapes (eg. label and swimlane)
- * or they consist of one or more (filled) path objects (eg. actor and cylinder).
+ * The other shapes are a combination of these shapes (e.g. label and swimlane)
+ * or they consist of one or more (filled) path objects (e.g. actor and cylinder).
  * The HTML implementation is optional but may be required for a HTML-only view
  * of the graph.
  *
@@ -73,14 +73,14 @@ import { StyleDefaultsConfig } from '../../util/config.js';
  * To register a custom shape in an existing graph instance, one must register the
  * shape under a new name in the graph’s cell renderer as follows:
  * ```javascript
- * mxCellRenderer.registerShape('customShape', CustomShape);
+ * ShapeRegistry.add('customShape', CustomShape);
  * ```
  * The second argument is the name of the constructor.
  * In order to use the shape you can refer to the given name above in a stylesheet.
  * For example, to change the shape for the default vertex style, the following code
  * is used:
  * ```javascript
- * var style = graph.getStylesheet().getDefaultVertexStyle();
+ * const style = graph.getStylesheet().getDefaultVertexStyle();
  * style.shape = 'customShape';
  * ```
  *
@@ -96,7 +96,7 @@ class Shape {
   indicator: Shape | null = null;
   indicatorShape: typeof Shape | null = null;
 
-  // Assigned in mxCellHighlight
+  // Assigned in CellHighlight
   opacity = 100;
   isDashed = false;
 

--- a/packages/core/src/view/undoable_changes/ChildChange.ts
+++ b/packages/core/src/view/undoable_changes/ChildChange.ts
@@ -65,11 +65,9 @@ export class ChildChange implements UndoableChange {
   }
 
   /**
-   * Disconnects the given cell recursively from its
-   * terminals and stores the previous terminal in the
-   * cell's terminals.
+   * Connects the source and the target of the given cell.
    *
-   * @warning doc from mxGraph source code is incorrect
+   * If {@link isConnect} is true, the source and target terminals are referenced  as such in the model. Otherwise, they are removed.
    */
   connect(cell: Cell, isConnect = true) {
     const source = cell.getTerminal(true);

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -49,5 +49,20 @@
     "navigation": {
       "includeCategories": true, // not enough categories to warrant this
     },
+    // add some languages for syntax highlighting to the typedoc defaults
+    "highlightLanguages": [
+      "bash",
+      "console",
+      "csharp", // added
+      "css",
+      "html",
+      "java", // added
+      "javascript",
+      "json",
+      "jsonc",
+      "json5",
+      "typescript",
+      "xml", // added
+    ],
   }
 }


### PR DESCRIPTION
Reduce the number of warning from 671 to 569.

The fixes include:
- use correct reference in links
- remove ref to mxCell in function parameters
- update and fix code examples
- add some languages for syntax highlighting to the typedoc defaults


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated all documentation comments to replace outdated type references (e.g., `mxCell`, `mxGeometry`) with current names (`Cell`, `Geometry`) for improved clarity and consistency.
  * Improved and clarified example code and parameter descriptions in comments across various classes and interfaces.
  * Removed the `@alpha` annotation from certain types and classes to reflect updated documentation status.
  * Enhanced TypeDoc configuration to support syntax highlighting for additional languages, including C#, Java, and XML.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->