### PR TITLE
refactor: remove reference to legacy insert cells methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ yarn add @maxgraph/core
 `maxGraph` is written in TypeScript and provides type definitions for seamless integration into TypeScript applications.
 
 Compatibility of the npm package:
-- The JavaScript code conforms to `ES2020` and is provided as ES Modules only
+- The JavaScript code conforms to the `ES2020` standard and is available in both CommonJS and ES Module formats
 - TypeScript integration requires **TypeScript 3.8** or higher
 
 <!-- END OF 'copied into packages/website/docs/getting-started.mdx' -->
@@ -87,20 +87,15 @@ InternalEvent.disableContextMenu(container);
 
 const graph = new Graph(container);
 graph.setPanning(true); // Use mouse right button for panning
-// Gets the default parent for inserting new cells.
-// This is normally the first child of the root (ie. layer 0).
-const parent = graph.getDefaultParent();
 
 // Adds cells to the model in a single step
 graph.batchUpdate(() => {
   const vertex01 = graph.insertVertex({
-    parent,
     position: [10, 10],
     size: [100, 100],
     value: 'rectangle',
   });
   const vertex02 = graph.insertVertex({
-    parent,
     position: [350, 90],
     size: [50, 50],
     style: {
@@ -112,7 +107,6 @@ graph.batchUpdate(() => {
     value: 'ellipse',
   });
   graph.insertEdge({
-    parent,
     source: vertex01,
     target: vertex02,
     value: 'edge',

--- a/packages/core/__tests__/view/image/ImageExport.test.ts
+++ b/packages/core/__tests__/view/image/ImageExport.test.ts
@@ -55,7 +55,7 @@ const createGraphWithVerticesAndOverlays = () => {
       new CellOverlay(new ImageBox('element.png', 16, 16), 'Information')
     );
 
-    graph.insertEdge(parent, null, '', v1, v2);
+    graph.insertEdge({ parent, value: '', source: v1, target: v2 });
     const e1 = graph.insertEdge({
       parent,
       id: 'e1',

--- a/packages/core/__tests__/view/layout/HierarchicalLayout.test.ts
+++ b/packages/core/__tests__/view/layout/HierarchicalLayout.test.ts
@@ -27,25 +27,65 @@ describe('layout execute', () => {
 
     // execute test
     graph.batchUpdate(() => {
-      const v1 = graph.insertVertex(parent, null, '1', 0, 0, 80, 30);
-      const v2 = graph.insertVertex(parent, null, '2', 0, 0, 80, 30);
-      const v3 = graph.insertVertex(parent, 'v3', '3', 0, 0, 80, 30);
-      const v4 = graph.insertVertex(parent, null, '4', 0, 0, 80, 30);
-      const v5 = graph.insertVertex(parent, null, '5', 0, 0, 80, 30);
-      const v6 = graph.insertVertex(parent, null, '6', 0, 0, 80, 30);
-      const v7 = graph.insertVertex(parent, 'v7', '7', 0, 0, 80, 30);
-      const v8 = graph.insertVertex(parent, null, '8', 0, 0, 80, 30);
-      const v9 = graph.insertVertex(parent, 'v9', '9', 0, 0, 80, 30);
+      const size: [number, number] = [80, 30];
+      const v1 = graph.insertVertex({
+        parent,
+        value: '1',
+        size,
+      });
+      const v2 = graph.insertVertex({
+        parent,
+        value: '2',
+        size,
+      });
+      const v3 = graph.insertVertex({
+        parent,
+        id: 'v3',
+        value: '3',
+        size,
+      });
+      const v4 = graph.insertVertex({
+        parent,
+        value: '4',
+        size,
+      });
+      const v5 = graph.insertVertex({
+        parent,
+        value: '5',
+        size,
+      });
+      const v6 = graph.insertVertex({
+        parent,
+        value: '6',
+        size,
+      });
+      const v7 = graph.insertVertex({
+        parent,
+        id: 'v7',
+        value: '7',
+        size,
+      });
+      const v8 = graph.insertVertex({
+        parent,
+        value: '8',
+        size,
+      });
+      const v9 = graph.insertVertex({
+        parent,
+        id: 'v9',
+        value: '9',
+        size,
+      });
 
-      graph.insertEdge(parent, null, '', v1, v2);
-      graph.insertEdge(parent, null, '', v2, v3);
-      graph.insertEdge(parent, null, '', v3, v4);
-      graph.insertEdge(parent, null, '', v4, v5);
-      graph.insertEdge(parent, null, '', v5, v3); // this introduces the circular path
-      graph.insertEdge(parent, null, '', v5, v6);
-      graph.insertEdge(parent, null, '', v6, v7);
-      graph.insertEdge(parent, null, '', v7, v8);
-      graph.insertEdge(parent, null, '', v8, v9);
+      graph.insertEdge({ parent, value: '', source: v1, target: v2 });
+      graph.insertEdge({ parent, value: '', source: v2, target: v3 });
+      graph.insertEdge({ parent, value: '', source: v3, target: v4 });
+      graph.insertEdge({ parent, value: '', source: v4, target: v5 });
+      graph.insertEdge({ parent, value: '', source: v5, target: v3 }); // this introduces the circular path
+      graph.insertEdge({ parent, value: '', source: v5, target: v6 });
+      graph.insertEdge({ parent, value: '', source: v6, target: v7 });
+      graph.insertEdge({ parent, value: '', source: v7, target: v8 });
+      graph.insertEdge({ parent, value: '', source: v8, target: v9 });
 
       // Execute the layout
       layout.execute(parent);
@@ -74,29 +114,69 @@ describe('layout execute', () => {
 
     // execute test - graph is based on HierarchicalLayout.stories.js
     graph.batchUpdate(() => {
-      const v1 = graph.insertVertex(parent, 'v1', '1', 0, 0, 80, 30);
-      const v2 = graph.insertVertex(parent, null, '2', 0, 0, 80, 30);
-      const v3 = graph.insertVertex(parent, null, '3', 0, 0, 80, 30);
-      const v4 = graph.insertVertex(parent, null, '4', 0, 0, 80, 30);
-      const v5 = graph.insertVertex(parent, null, '5', 0, 0, 80, 30);
-      const v6 = graph.insertVertex(parent, 'v6', '6', 0, 0, 80, 30);
-      const v7 = graph.insertVertex(parent, null, '7', 0, 0, 80, 30);
-      const v8 = graph.insertVertex(parent, 'v8', '8', 0, 0, 80, 30);
-      const v9 = graph.insertVertex(parent, null, '9', 0, 0, 80, 30);
+      const size: [number, number] = [80, 30];
+      const v1 = graph.insertVertex({
+        parent,
+        id: 'v1',
+        value: '1',
+        size,
+      });
+      const v2 = graph.insertVertex({
+        parent,
+        value: '2',
+        size,
+      });
+      const v3 = graph.insertVertex({
+        parent,
+        value: '3',
+        size,
+      });
+      const v4 = graph.insertVertex({
+        parent,
+        value: '4',
+        size,
+      });
+      const v5 = graph.insertVertex({
+        parent,
+        value: '5',
+        size,
+      });
+      const v6 = graph.insertVertex({
+        parent,
+        id: 'v6',
+        value: '6',
+        size,
+      });
+      const v7 = graph.insertVertex({
+        parent,
+        value: '7',
+        size,
+      });
+      const v8 = graph.insertVertex({
+        parent,
+        id: 'v8',
+        value: '8',
+        size,
+      });
+      const v9 = graph.insertVertex({
+        parent,
+        value: '9',
+        size,
+      });
 
-      graph.insertEdge(parent, null, '', v1, v2);
-      graph.insertEdge(parent, null, '', v1, v3);
-      graph.insertEdge(parent, null, '', v3, v4);
-      graph.insertEdge(parent, null, '', v2, v5);
-      graph.insertEdge(parent, null, '', v1, v6);
-      graph.insertEdge(parent, null, '', v2, v3);
-      graph.insertEdge(parent, null, '', v6, v4);
-      graph.insertEdge(parent, null, '', v6, v1);
-      graph.insertEdge(parent, null, '', v6, v7);
-      graph.insertEdge(parent, null, '', v7, v8);
-      graph.insertEdge(parent, null, '', v7, v9);
-      graph.insertEdge(parent, null, '', v7, v6);
-      graph.insertEdge(parent, null, '', v7, v5);
+      graph.insertEdge({ parent, value: '', source: v1, target: v2 });
+      graph.insertEdge({ parent, value: '', source: v1, target: v3 });
+      graph.insertEdge({ parent, value: '', source: v3, target: v4 });
+      graph.insertEdge({ parent, value: '', source: v2, target: v5 });
+      graph.insertEdge({ parent, value: '', source: v1, target: v6 });
+      graph.insertEdge({ parent, value: '', source: v2, target: v3 });
+      graph.insertEdge({ parent, value: '', source: v6, target: v4 });
+      graph.insertEdge({ parent, value: '', source: v6, target: v1 });
+      graph.insertEdge({ parent, value: '', source: v6, target: v7 });
+      graph.insertEdge({ parent, value: '', source: v7, target: v8 });
+      graph.insertEdge({ parent, value: '', source: v7, target: v9 });
+      graph.insertEdge({ parent, value: '', source: v7, target: v6 });
+      graph.insertEdge({ parent, value: '', source: v7, target: v5 });
 
       // Execute the layout
       layout.execute(parent);

--- a/packages/core/__tests__/view/mixins/EdgeMixin.test.ts
+++ b/packages/core/__tests__/view/mixins/EdgeMixin.test.ts
@@ -19,12 +19,13 @@ import { createGraphWithoutContainer } from '../../utils';
 import { Cell, type CellStyle, Geometry } from '../../../src';
 
 describe('insertEdge', () => {
-  test('with several parameters', () => {
+  test('Legacy method (with several parameters)', () => {
     const graph = createGraphWithoutContainer();
     const source = new Cell();
     const target = new Cell();
 
     const style: CellStyle = { rounded: true, shape: 'line' };
+    // Use the legacy method here as it is the method under test
     const cell = graph.insertEdge(null, 'edge_1', 'a value', source, target, style);
     expect(cell.getId()).toBe('edge_1');
     expect(cell.vertex).toBeFalsy();

--- a/packages/core/__tests__/view/mixins/VertexMixin.test.ts
+++ b/packages/core/__tests__/view/mixins/VertexMixin.test.ts
@@ -57,7 +57,7 @@ const relativeGeometry = (x: number, y: number, width: number, height: number) =
 };
 
 describe('insertVertex', () => {
-  describe('with several parameters', () => {
+  describe('Legacy method (with several parameters)', () => {
     test('with position, size and style', () => {
       const graph = createGraphWithoutContainer();
       const style: CellStyle = { rounded: true, shape: 'cloud' };

--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -289,7 +289,7 @@ import type { FitPlugin } from '../view/plugins/index.js';
  * const model = editor.graph.model;
  * model.beginUpdate();
  * try {
- *   editor.graph.insertVertex(parent, null, userObject, 20, 20, 80, 30);
+ *   editor.graph.insertVertex({parent, value: userObject, position: [20, 20], size: [80, 30]});
  * } finally
  *   model.endUpdate();
  * }

--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -285,11 +285,10 @@ import type { FitPlugin } from '../view/plugins/index.js';
  *
  * ```javascript
  * const userObject = new Object();
- * const parent = editor.graph.getDefaultParent();
  * const model = editor.graph.model;
  * model.beginUpdate();
  * try {
- *   editor.graph.insertVertex({parent, value: userObject, position: [20, 20], size: [80, 30]});
+ *   editor.graph.insertVertex({value: userObject, position: [20, 20], size: [80, 30]});
  * } finally
  *   model.endUpdate();
  * }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1095,7 +1095,7 @@ export type VertexParameters = {
    */
   geometryClass?: typeof Geometry;
   /**
-   * It is mandatory to set this value or the {@link size} property.
+   * If not set, falls back to the {@link size} property.
    */
   height?: number;
   /**
@@ -1132,15 +1132,15 @@ export type VertexParameters = {
    */
   value?: any;
   /**
-   * It is mandatory to set this value or the {@link size} property.
+   * If not set, falls back to the {@link size} property.
    */
   width?: number;
   /**
-   * It is mandatory to set this value or the {@link position} property.
+   * If not set, falls back to the {@link position} property.
    */
   x?: number;
   /**
-   * It is mandatory to set this value or the {@link position} property.
+   * If not set, falls back to the {@link position} property.
    */
   y?: number;
 };

--- a/packages/core/src/util/gestureUtils.ts
+++ b/packages/core/src/util/gestureUtils.ts
@@ -30,20 +30,20 @@ import type { DropHandler } from '../types.js';
  * Example:
  *
  * ```javascript
- * let funct = (graph, evt, cell, x, y)=>
- * {
- *   if (graph.canImportCell(cell))
- *   {
- *     let parent = graph.getDefaultParent();
+ * const funct = (graph, evt, cell, x, y) => {
+ *   if (graph.canImportCell(cell)) {
+ *     const parent = graph.getDefaultParent();
  *     let vertex = null;
  *
  *     graph.getDataModel().beginUpdate();
- *     try
- *     {
- *        vertex = graph.insertVertex(parent, null, 'Hello', x, y, 80, 30);
- *     }
- *     finally
- *     {
+ *     try {
+ *        vertex = graph.insertVertex({
+ *          parent,
+ *          value: 'Hello',
+ *          position: [x, y],
+ *          size: [80, 30],
+ *        });
+ *     } finally {
  *       graph.getDataModel().endUpdate();
  *     }
  *
@@ -51,7 +51,7 @@ import type { DropHandler } from '../types.js';
  *   }
  * }
  *
- * let img = document.createElement('img');
+ * const img = document.createElement('img');
  * img.setAttribute('src', 'editors/images/rectangle.gif');
  * img.style.position = 'absolute';
  * img.style.left = '0px';
@@ -59,10 +59,10 @@ import type { DropHandler } from '../types.js';
  * img.style.width = '16px';
  * img.style.height = '16px';
  *
- * let dragImage = img.cloneNode(true);
+ * const dragImage = img.cloneNode(true);
  * dragImage.style.width = '32px';
  * dragImage.style.height = '32px';
- * mxUtils.makeDraggable(img, graph, funct, dragImage);
+ * gestureUtils.makeDraggable(img, graph, funct, dragImage);
  * document.body.appendChild(img);
  * ```
  *

--- a/packages/core/src/view/GraphDataModel.ts
+++ b/packages/core/src/view/GraphDataModel.ts
@@ -229,38 +229,39 @@ export class GraphDataModel extends EventSource {
   cells: { [key: string]: Cell } | null = {};
 
   /**
-   * Specifies if edges should automatically be moved into the nearest common
-   * ancestor of their terminals. Default is true.
+   * Specifies if edges should automatically be moved into the nearest common ancestor of their terminals.
+   * @default true
    */
   maintainEdgeParent = true;
 
   /**
-   * Specifies if relative edge parents should be ignored for finding the nearest
-   * common ancestors of an edge's terminals. Default is true.
+   * Specifies if relative edge parents should be ignored for finding the nearest common ancestors of an edge's terminals.
+   * @default true
    */
   ignoreRelativeEdgeParent = true;
 
   /**
    * Specifies if the model should automatically create Ids for new cells.
-   * Default is true.
+   * @default true.
    */
   createIds = true;
 
   /**
    * Defines the prefix of new Ids. Default is an empty string.
+   * @default ''
    */
   prefix = '';
 
   /**
-   * Defines the postfix of new Ids. Default is an empty string.
+   * Defines the postfix of new Ids.
+   * @default ''
    */
   postfix = '';
 
   /**
    * Specifies the next Id to be created. Initial value is 0.
    */
-  // nextId: number | string;
-  nextId = 0;
+  nextId: number = 0;
 
   /**
    * Holds the changes for the current transaction. If the transaction is
@@ -503,7 +504,7 @@ export class GraphDataModel extends EventSource {
    *
    * @param {Cell} cell  to create the Id for.
    */
-  createId(cell: Cell) {
+  createId(cell: Cell): string {
     const id = this.nextId;
     this.nextId++;
     return this.prefix + id + this.postfix;
@@ -518,16 +519,16 @@ export class GraphDataModel extends EventSource {
     const childCount = cell.getChildCount();
 
     for (let i = 0; i < childCount; i += 1) {
-      const child = <Cell>cell.getChildAt(i);
+      const child = cell.getChildAt(i);
       this.updateEdgeParents(child, root);
     }
 
     // Updates the parents of all connected edges
     const edgeCount = cell.getEdgeCount();
-    const edges = [];
+    const edges: Cell[] = [];
 
     for (let i = 0; i < edgeCount; i += 1) {
-      edges.push(<Cell>cell.getEdgeAt(i));
+      edges.push(cell.getEdgeAt(i));
     }
 
     for (let i = 0; i < edges.length; i += 1) {

--- a/packages/core/src/view/cell/Cell.ts
+++ b/packages/core/src/view/cell/Cell.ts
@@ -37,7 +37,7 @@ import { isElement, isNullish } from '../../internal/utils.js';
  * const node = doc.createElement('MyNode')
  * node.setAttribute('label', 'MyLabel');
  * node.setAttribute('attribute1', 'value1');
- * graph.insertVertex(graph.getDefaultParent(), null, node, 40, 40, 80, 30);
+ * graph.insertVertex({parent: graph.getDefaultParent(), value: node, position: [40, 40], size: [80, 30]});
  * ```
  *
  * For the label to work, {@link AbstractGraph.convertValueToString} and

--- a/packages/core/src/view/handler/VertexHandler.ts
+++ b/packages/core/src/view/handler/VertexHandler.ts
@@ -1492,13 +1492,12 @@ class VertexHandler implements MouseListenerSet {
    * the following code can be used.
    *
    * ```javascript
-   * let vertexHandlerUnion = union;
-   * union = (bounds, dx, dy, index, gridEnabled, scale, tr, constrained)=>
-   * {
-   *   let result = vertexHandlerUnion.apply(this, arguments);
+   * const vertexHandlerUnion = union;
+   * vertexHandler.union = (bounds, dx, dy, index, gridEnabled, scale, tr, constrained) => {
+   *   const result = vertexHandlerUnion.apply(this, arguments);
    *
-   *   result.width = Math.max(result.width, mxUtils.getNumber(this.state.style, 'minWidth', 0));
-   *   result.height = Math.max(result.height, mxUtils.getNumber(this.state.style, 'minHeight', 0));
+   *   result.width = Math.max(result.width, this.state.style.minWidth ?? 0));
+   *   result.height = Math.max(result.height, this.state.style.minHeight ?? 0));
    *
    *   return result;
    * };
@@ -1507,27 +1506,35 @@ class VertexHandler implements MouseListenerSet {
    * The minWidth/-Height style can then be used as follows:
    *
    * ```javascript
-   * graph.insertVertex(parent, null, 'Hello,', 20, 20, 80, 30, 'minWidth=100;minHeight=100;');
+   * graph.insertVertex({
+   *   parent,
+   *   value: 'Hello,',
+   *   position: [20, 20],
+   *   size: [80, 30],
+   *   style: {
+   *     minWidth: 100,
+   *     minHeight: 100,
+   *   },
+   * });
    * ```
    *
    * To override this to update the height for a wrapped text if the width of a vertex is
    * changed, the following can be used.
    *
    * ```javascript
-   * let mxVertexHandlerUnion = union;
-   * union = (bounds, dx, dy, index, gridEnabled, scale, tr, constrained)=>
-   * {
-   *   let result = mxVertexHandlerUnion.apply(this, arguments);
-   *   let s = this.state;
+   * const vertexHandlerUnion = union;
+   * vertexHandler.union = (bounds, dx, dy, index, gridEnabled, scale, tr, constrained) => {
+   *   const result = vertexHandlerUnion.apply(this, arguments);
+   *   const s = this.state;
    *
-   *   if (this.graph.isHtmlLabel(s.cell) && (index == 3 || index == 4) &&
-   *       s.text != null && s.style.whiteSpace == 'wrap')
-   *   {
-   *     let label = this.graph.getLabel(s.cell);
-   *     let fontSize = mxUtils.getNumber(s.style, 'fontSize', mxConstants.DEFAULT_FONTSIZE);
-   *     let ww = result.width / s.view.scale - s.text.spacingRight - s.text.spacingLeft
+   *   if (this.graph.isHtmlLabel(s.cell)
+   *        && (index == 3 || index == 4)
+   *        && s.text != null && s.style.whiteSpace == 'wrap') {
+   *     const label = this.graph.getLabel(s.cell);
+   *     const fontSize = s.style.fontSize ?? constants.DEFAULT_FONTSIZE;
+   *     const ww = result.width / s.view.scale - s.text.spacingRight - s.text.spacingLeft
    *
-   *     result.height = mxUtils.getSizeForString(label, fontSize, s.style.fontFamily, ww).height;
+   *     result.height = styleUtils.getSizeForString(label, fontSize, s.style.fontFamily, ww).height;
    *   }
    *
    *   return result;

--- a/packages/core/src/view/layout/SwimlaneLayout.ts
+++ b/packages/core/src/view/layout/SwimlaneLayout.ts
@@ -238,15 +238,11 @@ class SwimlaneLayout extends GraphLayout {
       const children = this.graph.getChildCells(swimlanes[i]);
 
       if (children == null || children.length === 0) {
-        const vertex = this.graph.insertVertex(
-          swimlanes[i],
-          null,
-          null,
-          0,
-          0,
-          this.dummyVertexWidth,
-          0
-        );
+        const vertex = this.graph.insertVertex({
+          parent: swimlanes[i],
+          position: [0, 0],
+          size: [this.dummyVertexWidth, 0],
+        });
         dummyVertices.push(vertex);
       }
     }

--- a/packages/core/src/view/mixins/CellsMixin.type.ts
+++ b/packages/core/src/view/mixins/CellsMixin.type.ts
@@ -811,7 +811,9 @@ declare module '../AbstractGraph' {
      * ```javascript
      * isCellSelectable(cell) {
      *   const style = this.getCurrentCellStyle(cell);
-     *   return this.isCellsSelectable() && !this.isCellLocked(cell) && style.selectable ?? true;
+     *   return this.isCellsSelectable() &&
+     *     !this.isCellLocked(cell) &&
+     *     (style.selectable ?? true);
      * };
      * ```
      *

--- a/packages/core/src/view/mixins/CellsMixin.type.ts
+++ b/packages/core/src/view/mixins/CellsMixin.type.ts
@@ -809,18 +809,24 @@ declare module '../AbstractGraph' {
      * To add a new style for making cells (un)selectable, use the following code.
      *
      * ```javascript
-     * isCellSelectable(cell)
-     * {
-     *   var style = this.getCurrentCellStyle(cell);
-     *
-     *   return this.isCellsSelectable() && !this.isCellLocked(cell) && style.selectable != 0;
+     * isCellSelectable(cell) {
+     *   const style = this.getCurrentCellStyle(cell);
+     *   return this.isCellsSelectable() && !this.isCellLocked(cell) && style.selectable ?? true;
      * };
      * ```
      *
      * You can then use the new style as shown in this example.
      *
      * ```javascript
-     * graph.insertVertex(parent, null, 'Hello,', 20, 20, 80, 30, 'selectable=0');
+     * graph.insertVertex({
+     *   parent,
+     *   value: 'Hello,',
+     *   position: [20, 20],
+     *   size: [80, 30],
+     *   style: {
+     *     selectable: false,
+     *   },
+     * });
      * ```
      *
      * @param cell {@link Cell} whose selectable state should be returned.

--- a/packages/core/src/view/mixins/VertexMixin.type.ts
+++ b/packages/core/src/view/mixins/VertexMixin.type.ts
@@ -58,7 +58,12 @@ declare module '../AbstractGraph' {
      * ```javascript
      * const pt = graph.getPointForEvent(evt);
      * const parent = graph.getDefaultParent();
-     * graph.insertVertex(parent, null, 'Hello, World!', pt.x, pt.y, 220, 30);
+     * graph.insertVertex({
+     *   parent,
+     *   value: 'Hello, World!',
+     *   position: [pt.x, pt.y],
+     *   size: [220, 30]
+     * });
      * ```
      *
      * For adding image cells, the style parameter can be assigned as
@@ -100,6 +105,11 @@ declare module '../AbstractGraph' {
      * Adds a new vertex into the given parent {@link Cell} using value as the user
      * object and the given coordinates as the {@link Geometry} of the new vertex.
      * The id and style are used for the respective properties of the new `Cell`, which is returned.
+     *
+     * **IMPORTANT**:
+     * - If the position of the vertex is not set at vertex creation (by setting the `x` and `y` properties, or the `position` property), it is advised to use a {@link GraphLayout} or a {@link LayoutManager} to automatically compute the actual position.
+     * - If the size of the vertex is not set at vertex creation (by setting the `width` and the `height` properties, or the `size` property), it is advised to later set the size on the geometry of the vertex instance.
+     * Otherwise, the vertex has no size and it is not displayed.
      *
      * When adding new vertices from a mouse event, one should take into
      * account the offset of the graph container and the scale and translation

--- a/packages/core/src/view/plugins/ConnectionHandler.ts
+++ b/packages/core/src/view/plugins/ConnectionHandler.ts
@@ -1841,7 +1841,7 @@ class ConnectionHandler extends EventSource implements GraphPlugin, MouseListene
 
   /**
    * Creates, inserts and returns the new edge for the given parameters. This
-   * implementation does only use <createEdge> if <factoryMethod> is defined,
+   * implementation does only use {@link createEdge} if {@link factoryMethod} is defined,
    * otherwise {@link AbstractGraph.insertEdge} will be used.
    */
   insertEdge(
@@ -1853,7 +1853,7 @@ class ConnectionHandler extends EventSource implements GraphPlugin, MouseListene
     style: CellStyle
   ): Cell {
     if (!this.factoryMethod) {
-      return this.graph.insertEdge(parent, id, value, source, target, style);
+      return this.graph.insertEdge({ parent, id, value, source, target, style });
     }
     let edge = this.createEdge(value, source, target, style);
     edge = this.graph.addEdge(edge, parent, source, target);
@@ -1925,14 +1925,14 @@ class ConnectionHandler extends EventSource implements GraphPlugin, MouseListene
   }
 
   /**
-   * Creates and returns a new edge using <factoryMethod> if one exists. If
+   * Creates and returns a new edge using {@link factoryMethod} if one exists. If
    * no factory method is defined, then a new default edge is returned. The
    * source and target arguments are informal, the actual connection is
-   * setup later by the caller of this function.
+   * set up later by the caller of this function.
    *
    * @param value Value to be used for creating the edge.
-   * @param source <Cell> that represents the source terminal.
-   * @param target <Cell> that represents the target terminal.
+   * @param source {@link Cell} that represents the source terminal.
+   * @param target {@link Cell} that represents the target terminal.
    * @param style Optional style from the preview edge.
    */
   createEdge(

--- a/packages/ts-example/src/main.ts
+++ b/packages/ts-example/src/main.ts
@@ -47,52 +47,39 @@ const initializeGraph = (container: HTMLElement) => {
     verticalLabelPosition: 'bottom',
   });
 
-  // Gets the default parent for inserting new cells. This
-  // is normally the first child of the root (ie. layer 0).
-  const parent = graph.getDefaultParent();
-
   // Adds cells to the model in a single step
   graph.batchUpdate(() => {
-    // use the legacy insertVertex method
-    const vertex01 = graph.insertVertex(
-      parent,
-      null,
-      'a regular rectangle',
-      10,
-      10,
-      100,
-      100
-    );
-    const vertex02 = graph.insertVertex(
-      parent,
-      null,
-      'a regular ellipse',
-      350,
-      90,
-      50,
-      50,
-      {
+    const vertex01 = graph.insertVertex({
+      value: 'a regular rectangle',
+      position: [10, 10],
+      size: [100, 100],
+    });
+    const vertex02 = graph.insertVertex({
+      value: 'a regular ellipse',
+      position: [350, 90],
+      size: [50, 50],
+      style: {
         baseStyleNames: ['myEllipse'],
         fillColor: 'orange',
-      }
-    );
-    // use the legacy insertEdge method
-    graph.insertEdge(parent, null, 'an orthogonal style edge', vertex01, vertex02, {
-      edgeStyle: 'orthogonalEdgeStyle',
-      rounded: true,
+      },
+    });
+    graph.insertEdge({
+      value: 'an orthogonal style edge',
+      source: vertex01,
+      target: vertex02,
+      style: {
+        edgeStyle: 'orthogonalEdgeStyle',
+        rounded: true,
+      },
     });
 
-    // insert vertex using custom shapes using the new insertVertex method
     const vertex11 = graph.insertVertex({
-      parent,
       value: 'a custom rectangle',
       position: [20, 200],
       size: [100, 100],
       style: { shape: 'customRectangle' },
     });
-    // use the new insertVertex method using position and size parameters
     const vertex12 = graph.insertVertex({
-      parent,
       value: 'a custom ellipse',
       x: 150,
       y: 350,
@@ -103,9 +90,7 @@ const initializeGraph = (container: HTMLElement) => {
         shape: 'customEllipse',
       },
     });
-    // use the new insertEdge method
     graph.insertEdge({
-      parent,
       value: 'another edge',
       source: vertex11,
       target: vertex12,

--- a/packages/website/docs/getting-started.mdx
+++ b/packages/website/docs/getting-started.mdx
@@ -40,7 +40,7 @@ Install the latest version of `maxGraph` from the [npm registry](https://www.npm
 `maxGraph` is written in TypeScript and provides type definitions for seamless integration into TypeScript applications.
 
 Compatibility of the npm package:
-- The JavaScript code conforms to `ES2020` and is provided as ES Modules only
+- The JavaScript code conforms to the `ES2020` standard and is available in both CommonJS and ES Module formats
 - TypeScript integration requires **TypeScript 3.8** or higher
 :::
 
@@ -72,20 +72,15 @@ InternalEvent.disableContextMenu(container);
 
 const graph = new Graph(container);
 graph.setPanning(true); // Use mouse right button for panning
-// Gets the default parent for inserting new cells.
-// This is normally the first child of the root (ie. layer 0).
-const parent = graph.getDefaultParent();
 
 // Adds cells to the model in a single step
 graph.batchUpdate(() => {
   const vertex01 = graph.insertVertex({
-    parent,
     position: [10, 10],
     size: [100, 100],
     value: 'rectangle',
   });
   const vertex02 = graph.insertVertex({
-    parent,
     position: [350, 90],
     size: [50, 50],
     style: {
@@ -97,7 +92,6 @@ graph.batchUpdate(() => {
     value: 'ellipse',
   });
   graph.insertEdge({
-    parent,
     source: vertex01,
     target: vertex02,
     value: 'edge',
@@ -157,7 +151,6 @@ For example, you might use groups to:
 1. **Adding Vertices**:
 ```javascript
 const vertex01 = graph.insertVertex({
-    parent,
     position: [10, 10], // 0,0 is the top-left corner. So this is 10 pixels from the top and 10 pixels from the left.
     size: [100, 100], // width and height of your vertex
     value: 'rectangle', // The text to display in the vertex
@@ -167,7 +160,6 @@ const vertex01 = graph.insertVertex({
 2. **Adding Edges**:
 ```javascript
   graph.insertEdge({
-    parent,
     source: vertex01, // Source vertex
     target: vertex02, // Second vertex that edge should point to
     style: {
@@ -187,7 +179,7 @@ graph.addListener(InternalEvent.CLICK, (sender, evt) => {
     console.log('Clicked cell:', cell);
   }
 });
-graph.addListener(InternalEvent.CELLS_MOVED, (sender, evt) =>{
+graph.addListener(InternalEvent.CELLS_MOVED, (sender, evt) => {
     const cells = evt.getProperty('cells');
     console.log(`Number of cells moved is: ${cells.length}`);
 })

--- a/packages/website/docs/manual/cells.md
+++ b/packages/website/docs/manual/cells.md
@@ -72,36 +72,52 @@ Note that the base style names and the other style properties may be in any orde
 Below are examples to demonstrate this concept, adapting the `insertVertex` call we saw in the [hello world example](../tutorials/the-hello-world-example.md):
 - A new style called _ROUNDED_ has been created, to apply this to a vertex:
 ```javascript
-const v1 = graph.insertVertex(parent, null, 'Hello', 20, 20, 80, 30,
-    {
-      baseStyleNames: ['ROUNDED'],
-    });
+const v1 = graph.insertVertex({
+  value: 'Hello',
+  position: [20, 20],
+  size: [80, 30],
+  style: {
+    baseStyleNames: ['ROUNDED'],
+  },
+});
 ```
 - To create a new vertex with the _ROUNDED_ style, overriding the stroke and fill colors:
 ```javascript
-const v1 = graph.insertVertex(parent, null, 'Hello', 20, 20, 80, 30,
-    {
-      baseStyleNames: ['ROUNDED'],
-      strokeColor: 'red',
-      fillColor: 'green',
-    });
+const v1 = graph.insertVertex({
+  value: 'Hello',
+  position: [20, 20],
+  size: [80, 30],
+  style: {
+    baseStyleNames: ['ROUNDED'],
+    strokeColor: 'red',
+    fillColor: 'green',
+  },
+});
 ```
 - To create a new vertex with no global style, but with local stroke and fill colors:
 ```javascript
-const v1 = graph.insertVertex(parent, null, 'Hello', 20, 20, 80, 30,
-    {
-      ignoreDefaultStyle: true,
-      strokeColor: 'red',
-      fillColor: 'green',
-    });
+const v1 = graph.insertVertex({
+  value: 'Hello',
+  position: [20, 20],
+  size: [80, 30],
+  style: {
+    ignoreDefaultStyle: true,
+    strokeColor: 'red',
+    fillColor: 'green',
+  },
+});
 ```
 - To create a vertex that uses the _defaultVertex_ style, but a local value of the fill color:
 ```javascript
-const v1 = graph.insertVertex(parent, null, 'Hello', 20, 20, 80, 30,
-  {
+const v1 = graph.insertVertex({
+  value: 'Hello',
+  position: [20, 20],
+  size: [80, 30],
+  style: {
     baseStyleNames: ['defaultVertex'], // This can be ommited, as it is the default style applied for vertices
     fillColor: 'blue',
-  });
+  },
+});
 ```
 
 Again, the `maxGraph` class provides utility functions that form the core API for accessing and changing the styles of cells:

--- a/packages/website/docs/manual/cells.md
+++ b/packages/website/docs/manual/cells.md
@@ -69,6 +69,12 @@ If you wanted to specify a style other than the default for a cell, you must pas
 The style that you pass has the form style name, and it must be stored in the `baseStyleNames` property of the `CellStyle` object representing the entire style.
 Note that the base style names and the other style properties may be in any order.
 
+By default, even if it is not set in the `baseStyleNames` property, a default style is used for style computation:
+- for vertices, the default style is `defaultVertex`
+- for edges, the default style is `defaultEdge`
+
+This behavior can be disabled by setting the `ignoreDefaultStyle` property to true in the style object passed to the cell. In this case, the style will not be merged with the default style for that cell type.
+
 Below are examples to demonstrate this concept, adapting the `insertVertex` call we saw in the [hello world example](../tutorials/the-hello-world-example.md):
 - A new style called _ROUNDED_ has been created, to apply this to a vertex:
 ```javascript
@@ -94,28 +100,17 @@ const v1 = graph.insertVertex({
   },
 });
 ```
-- To create a new vertex with no global style, but with local stroke and fill colors:
+- To create a new vertex with no default style but the _ROUNDED_ style, and with local stroke and fill colors:
 ```javascript
 const v1 = graph.insertVertex({
   value: 'Hello',
   position: [20, 20],
   size: [80, 30],
   style: {
+    baseStyleNames: ['ROUNDED'],
     ignoreDefaultStyle: true,
-    strokeColor: 'red',
-    fillColor: 'green',
-  },
-});
-```
-- To create a vertex that uses the _defaultVertex_ style, but a local value of the fill color:
-```javascript
-const v1 = graph.insertVertex({
-  value: 'Hello',
-  position: [20, 20],
-  size: [80, 30],
-  style: {
-    baseStyleNames: ['defaultVertex'], // This can be ommited, as it is the default style applied for vertices
-    fillColor: 'blue',
+    strokeColor: 'yellow',
+    fillColor: 'orange',
   },
 });
 ```

--- a/packages/website/docs/manual/model-and-transactions.md
+++ b/packages/website/docs/manual/model-and-transactions.md
@@ -34,11 +34,22 @@ So, though many of the main API calls are through the `maxGraph` class, keep in 
 // Adds cells to the model in a single step
 graph.getModel().beginUpdate();
 try {
-   const v1 = graph.insertVertex(parent, null, 'Hello,', 20, 20, 80, 30);
-   const v2 = graph.insertVertex(parent, null, 'World!', 200, 150, 80, 30);
-   graph.insertEdge(parent, null, '', v1, v2);
-}
-finally {
+    const v1 = graph.insertVertex({
+        value: 'Hello',
+        position: [20, 20],
+        size: [80, 30],
+    });
+    const v2 = graph.insertVertex({
+        value: 'World!',
+        position: [200, 150],
+        size: [80, 30],
+    });
+    graph.insertEdge({
+        value: '', 
+        source: v1,
+        target: v2
+    });
+} finally {
    // Updates the display
    graph.getModel().endUpdate();
 }
@@ -135,21 +146,18 @@ The function of the model requires that the cell to be added is already created,
 
 **Core API functions:**
 
-- **Graph.insertVertex(parent, id, value, x, y, width, height, style)** - creates and inserts a new vertex into the model, within a begin/end update call.
-- **Graph.insertEdge(parent, id, value, source, target, style)** - creates and inserts a new edge into the model, within a begin/end update call.
+- **Graph.insertVertex(params)** - creates and inserts a new vertex into the model, within a begin/end update call.
+- **Graph.insertEdge(params)** - creates and inserts a new edge into the model, within a begin/end update call.
 
-
-`Graph.insertVertex()` will create an `Cell` object and return it from the method used. The parameters of the function are:
+`Graph.insertVertex()` will create an `Cell` object and return it from the method used. The properties of of the parameter of the function are:
 - `parent`: the cell which is the immediate parent of the new cell in the group structure.
 We will address the group structure shortly, but for now use `graph.getDefaultParent()` as your default parent, as used in the HelloWorld example.
 - `id`: this is a global unique identifier that describes the cell, it is always a string. This is primarily for referencing the cells in the persistent output externally.
-If you do not wish to maintain ids yourself, pass null into this parameter and ensure that GraphDataModel.isCreateIds() returns true. This way the model will manage the ids and ensure they are unique.
+If you do not wish to maintain ids yourself, pass null into this parameter and ensure that `GraphDataModel.isCreateIds()` returns true. This way the model will manage the ids and ensure they are unique.
 - `value`: this is the user object of the cell. User object are simply that, just objects, but form the objects that allow you to associate the business logic of an application with the visual representation of `maxGraph`.
 They will be described in more detail later in this manual, however, to start with if you use a string as the user object, this will be displayed as the label on the vertex or edge.
-- `x, y, width, height`: as the names suggest, these are the x and y position of the top left corner of the vertex and its width and height.
-- `style`: the style description to be applied to this vertex. Styles will be described in more detail shortly, but at a simple level this parameter is a string that follows a particular format.
-In the string appears zero or more style names and some number of key/value pairs that override the global style or set a  new style.
-Until we create custom styles, we will just use those currently available.
+- `x, y, width, height`: as the names suggest, these are the x and y position of the top left corner of the vertex and its width and height. The position and size properties can be used as well.
+- `style`: the style description to be applied to this vertex. Styles will be described in more detail shortly, but until we create custom styles, we will just use those currently available.
 
 With the edge addition method, the identically named parameters perform the same function as in the vertex addition method.
 The source and target parameters define the vertices to which the edge is connected.

--- a/packages/website/docs/tutorials/the-hello-world-example.md
+++ b/packages/website/docs/tutorials/the-hello-world-example.md
@@ -68,9 +68,9 @@ const parent = graph.getDefaultParent();
 // Adds cells to the model in a single step
 model.beginUpdate();
 try  {
-    const v1 = graph.insertVertex(parent, null, 'Hello,', 20, 20, 80, 30);
-    const v2 = graph.insertVertex(parent, null, 'World!', 200, 150, 80, 30);
-    graph.insertEdge(parent, null, '', v1, v2);
+    const v1 = graph.insertVertex({ parent, value: 'Hello,', position: [20, 20], size: [80, 30] });
+    const v2 = graph.insertVertex({ parent, value: 'World!', position:[200, 150], size: [80, 30] });
+    graph.insertEdge({ parent, source: v1, target: v2 });
 }
 finally {
     // Updates the display


### PR DESCRIPTION
These legacy methods have a large number of parameters, are hard to read and hard to evolve.

So, to prepare the deprecation of these methods, use the new methods that take a single object parameter in code, examples and documentation.
The storybook stories will be updated later.

Also simplify some calls by not always setting the parent when it was set to the default parent (this is the default
value, so no need to pass it in this case), nor setting an empty string value (same result as not setting it).

In addition, apply various JSDoc improvements.


## Notes

Covers #856



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated all code examples and documentation to use a new object-based parameter style for `insertVertex` and `insertEdge` methods, replacing the previous positional argument approach.
  * Clarified npm package compatibility, specifying ES2020 standard and support for both CommonJS and ES Module formats.
  * Enhanced documentation on default cell styles and introduced the `ignoreDefaultStyle` flag.
  * Added important usage notes about vertex position and size requirements.
  * Improved and modernized code snippets, added important usage notes, and enhanced formatting for clarity.

* **Refactor**
  * Refactored test and example code to adopt the new object-based API for graph element insertion, simplifying usage and improving consistency.

* **Style**
  * Modernized example code syntax throughout documentation and comments for better readability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->