### PR TITLE
refactor: ensure mixins do not create shared properties in AbstractGraph

### DIFF
--- a/packages/core/__tests__/serialization/codecs/all-graph-classes.test.ts
+++ b/packages/core/__tests__/serialization/codecs/all-graph-classes.test.ts
@@ -21,6 +21,7 @@ import {
   BaseGraph,
   getDefaultPlugins,
   ImageBox,
+  Multiplicity,
   Rectangle,
   registerCoreCodecs,
   unregisterAllCodecs,
@@ -40,13 +41,24 @@ afterEach(() => {
 
 function buildXml(name: string): string {
   const xmlTemplate = `<@NAME@>
+  <Object as="alternateEdgeStyle" />
   <Array as="cells" />
   <Array as="imageBundles" />
   <Array as="mouseListeners">
     <Object />
     <Object />
   </Array>
-  <Array as="multiplicities" />
+  <Array as="multiplicities">
+    <Multiplicity type="rectangle" source="1" max="2" countError="Only 2 targets allowed" typeError="Only circle targets allowed">
+      <Array as="validNeighbors">
+        <add value="circle" />
+      </Array>
+    </Multiplicity>
+  </Array>
+  <Object foldingEnabled="1" collapseToPreferredSize="1" as="options">
+    <ImageBox src="./collapsed-new.gif" width="10" height="10" as="collapsedImage" />
+    <ImageBox src="./expanded.gif" width="9" height="9" as="expandedImage" />
+  </Object>
   <GraphDataModel as="model">
     <root>
       <Cell id="0">
@@ -78,10 +90,6 @@ function buildXml(name: string): string {
   </Stylesheet>
   <Rectangle _x="123" _y="453" _width="60" _height="60" as="pageFormat" />
   <ImageBox src="./warning.gif" width="16" height="16" as="warningImage" />
-  <Object foldingEnabled="1" collapseToPreferredSize="1" as="options">
-    <ImageBox src="./collapsed-new.gif" width="10" height="10" as="collapsedImage" />
-    <ImageBox src="./expanded.gif" width="9" height="9" as="expandedImage" />
-  </Object>
 </@NAME@>
 `;
 
@@ -97,6 +105,21 @@ describe.each([
 ])('%s', (name, graphFactory: () => AbstractGraph) => {
   test('Export', () => {
     const graph = graphFactory();
+
+    graph.multiplicities.push(
+      new Multiplicity(
+        true,
+        'rectangle',
+        null,
+        null,
+        0,
+        2,
+        ['circle'],
+        'Only 2 targets allowed',
+        'Only circle targets allowed'
+      )
+    );
+
     // override defaults to ensure it is taken into account
     graph.pageFormat = new Rectangle(123, 453, 60, 60);
     graph.options.collapsedImage = new ImageBox('./collapsed-new.gif', 10, 10);

--- a/packages/core/__tests__/view/BaseGraph.test.ts
+++ b/packages/core/__tests__/view/BaseGraph.test.ts
@@ -26,6 +26,8 @@ import {
   type EdgeStyleFunction,
   EdgeStyleRegistry,
   ElbowEdgeHandler,
+  ImageBundle,
+  Multiplicity,
   Point,
   Rectangle,
   RectangleShape,
@@ -260,3 +262,79 @@ function expectExactInstanceOfEdgeHandler(handler: EdgeHandler): void {
   expect(handler).not.toBeInstanceOf(EdgeSegmentHandler);
   expect(handler).not.toBeInstanceOf(ElbowEdgeHandler);
 }
+
+// For "complex" properties, for example: arrays or object.
+describe('Expect no global state for properties coming from mixins', () => {
+  test('alternateEdgeStyle', () => {
+    const graph1 = new BaseGraph();
+    const graph2 = new BaseGraph();
+
+    graph1.alternateEdgeStyle.arcSize = 10;
+    graph1.alternateEdgeStyle.fillColor = 'red';
+    expect(graph1.alternateEdgeStyle).not.toEqual(graph2.alternateEdgeStyle);
+    expect(graph1.alternateEdgeStyle).not.toBe(graph2.alternateEdgeStyle);
+  });
+
+  test('cells', () => {
+    const graph1 = new BaseGraph();
+    const graph2 = new BaseGraph();
+
+    graph1.cells.push(new Cell());
+    expect(graph2.cells).toStrictEqual([]);
+    expect(graph1.cells).not.toBe(graph2.cells);
+  });
+
+  test('imageBundles', () => {
+    const graph1 = new BaseGraph();
+    const graph2 = new BaseGraph();
+
+    graph1.imageBundles.push(new ImageBundle());
+    expect(graph2.imageBundles).toStrictEqual([]);
+    expect(graph1.imageBundles).not.toBe(graph2.imageBundles);
+  });
+
+  test('mouseListeners', () => {
+    const graph1 = new BaseGraph();
+    expect(graph1.mouseListeners).toHaveLength(1);
+    const graph2 = new BaseGraph();
+    expect(graph2.mouseListeners).toHaveLength(1);
+
+    graph1.mouseListeners.push({
+      mouseDown: () => {},
+      mouseMove: () => {},
+      mouseUp: () => {},
+    });
+    expect(graph2.mouseListeners).toHaveLength(1);
+    expect(graph1.mouseListeners).toHaveLength(2);
+    expect(graph1.mouseListeners).not.toBe(graph2.mouseListeners);
+  });
+
+  test('multiplicities', () => {
+    const graph1 = new BaseGraph();
+    const graph2 = new BaseGraph();
+
+    graph1.multiplicities.push(
+      new Multiplicity(
+        true,
+        'rectangle',
+        null,
+        null,
+        0,
+        2,
+        ['circle'],
+        'Only 2 targets allowed',
+        'Only circle targets allowed'
+      )
+    );
+    expect(graph2.multiplicities).toStrictEqual([]);
+    expect(graph1.multiplicities).not.toBe(graph2.multiplicities);
+  });
+
+  test('options', () => {
+    const graph1 = new BaseGraph();
+    const graph2 = new BaseGraph();
+
+    graph1.options.foldingEnabled = false;
+    expect(graph1.options).not.toBe(graph2.options);
+  });
+});

--- a/packages/core/src/internal/utils.ts
+++ b/packages/core/src/internal/utils.ts
@@ -45,7 +45,12 @@ export const isNullish = (v: unknown): v is null | undefined =>
   v === null || v === undefined;
 
 /**
- * Merge a mixin into the destination
+ * Merge a mixin into the destination.
+ *
+ * WARN: do not use "complex" properties type (object, array), as they will be shared between all instances of the destination class.
+ * This is a limitation of this simple mixin implementation, and we are not trying to fix it as the current plan is to move mixin code to dedicated plugin.
+ * See https://github.com/maxGraph/maxGraph/issues/762.
+ *
  * @param dest the destination class
  *
  * @private not part of the public API, can be removed or changed without prior notice
@@ -57,6 +62,8 @@ export const mixInto = (dest: any) => (mixin: any) => {
       Object.defineProperty(dest.prototype, key, {
         value: mixin[key],
         writable: true,
+        // enumerable should probably set to true.
+        // For example, when exporting a Graph with Codecs, properties added via mixins are not serialized whereas properties directly defined on the class are.
       });
     }
   } catch (e) {

--- a/packages/core/src/internal/utils.ts
+++ b/packages/core/src/internal/utils.ts
@@ -54,52 +54,10 @@ export const mixInto = (dest: any) => (mixin: any) => {
   const keys = Reflect.ownKeys(mixin);
   try {
     for (const key of keys) {
-      // const rawValue = mixin[key];
-      // const value = Array.isArray(rawValue) ? [...rawValue] : rawValue;
-      // Array.isArray(newValue) && (newValue = [...value]); // clone the array
-      // console.info(`${String(key)} / ${newValue} - isArray: ${Array.isArray(newValue)}`);
-
-      // Object.defineProperty(dest.prototype, key, {
-      //   value,
-      //   // value: mixin[key], // TODO should clone the object (at least for array)
-      //   writable: true,
-      // });
-
-      const rawValue = mixin[key];
-      if (Array.isArray(rawValue)) {
-        Object.defineProperty(dest.prototype, key, {
-          get() {
-            return [...rawValue];
-          },
-          set(newValue) {
-            Object.defineProperty(this, key, {
-              value: newValue,
-              writable: true,
-              configurable: true,
-            });
-          },
-          configurable: true,
-        });
-      } else if (rawValue !== null && typeof rawValue === 'object') {
-        Object.defineProperty(dest.prototype, key, {
-          get() {
-            return structuredClone(rawValue);
-          },
-          set(newValue) {
-            Object.defineProperty(this, key, {
-              value: newValue,
-              writable: true,
-              configurable: true,
-            });
-          },
-          configurable: true,
-        });
-      } else {
-        Object.defineProperty(dest.prototype, key, {
-          value: rawValue,
-          writable: true,
-        });
-      }
+      Object.defineProperty(dest.prototype, key, {
+        value: mixin[key],
+        writable: true,
+      });
     }
   } catch (e) {
     GlobalConfig.logger.error('Error while mixing', e);

--- a/packages/core/src/internal/utils.ts
+++ b/packages/core/src/internal/utils.ts
@@ -54,10 +54,52 @@ export const mixInto = (dest: any) => (mixin: any) => {
   const keys = Reflect.ownKeys(mixin);
   try {
     for (const key of keys) {
-      Object.defineProperty(dest.prototype, key, {
-        value: mixin[key],
-        writable: true,
-      });
+      // const rawValue = mixin[key];
+      // const value = Array.isArray(rawValue) ? [...rawValue] : rawValue;
+      // Array.isArray(newValue) && (newValue = [...value]); // clone the array
+      // console.info(`${String(key)} / ${newValue} - isArray: ${Array.isArray(newValue)}`);
+
+      // Object.defineProperty(dest.prototype, key, {
+      //   value,
+      //   // value: mixin[key], // TODO should clone the object (at least for array)
+      //   writable: true,
+      // });
+
+      const rawValue = mixin[key];
+      if (Array.isArray(rawValue)) {
+        Object.defineProperty(dest.prototype, key, {
+          get() {
+            return [...rawValue];
+          },
+          set(newValue) {
+            Object.defineProperty(this, key, {
+              value: newValue,
+              writable: true,
+              configurable: true,
+            });
+          },
+          configurable: true,
+        });
+      } else if (rawValue !== null && typeof rawValue === 'object') {
+        Object.defineProperty(dest.prototype, key, {
+          get() {
+            return structuredClone(rawValue);
+          },
+          set(newValue) {
+            Object.defineProperty(this, key, {
+              value: newValue,
+              writable: true,
+              configurable: true,
+            });
+          },
+          configurable: true,
+        });
+      } else {
+        Object.defineProperty(dest.prototype, key, {
+          value: rawValue,
+          writable: true,
+        });
+      }
     }
   } catch (e) {
     GlobalConfig.logger.error('Error while mixing', e);

--- a/packages/core/src/view/AbstractGraph.ts
+++ b/packages/core/src/view/AbstractGraph.ts
@@ -46,6 +46,7 @@ import VertexHandler from './handler/VertexHandler.js';
 import EdgeSegmentHandler from './handler/EdgeSegmentHandler.js';
 import ElbowEdgeHandler from './handler/ElbowEdgeHandler.js';
 import type {
+  CellStyle,
   DialectValue,
   EdgeStyleFunction,
   GraphCollaboratorsOptions,
@@ -56,7 +57,7 @@ import type {
   PluginId,
 } from '../types.js';
 import Multiplicity from './other/Multiplicity.js';
-import ImageBundle from './image/ImageBundle.js';
+import type ImageBundle from './image/ImageBundle.js';
 import { applyGraphMixins } from './mixins/_graph-mixins-apply.js';
 import { isNullish } from '../internal/utils.js';
 import { isI18nEnabled } from '../internal/i18n-utils.js';
@@ -88,8 +89,17 @@ export abstract class AbstractGraph extends EventSource {
   isConstrainedMoving = false;
 
   // ===================================================================================================================
-  // Group: Variables (that maybe should be in the mixins, but need to be created for each new class instance)
+  // Group: Variables that should be in the mixins
+  // The current implementation of the function applying mixins create a shared state for properties with "complex" type (object, array)
+  // whereas here, we need to be created a specific instance for each new class instance.
+  // See https://github.com/maxGraph/maxGraph/pull/751 and https://github.com/maxGraph/maxGraph/pull/879
   // ===================================================================================================================
+
+  /**
+   * Specifies the alternate edge style to be used if the main control point on an edge is being double-clicked.
+   * @default {}
+   */
+  alternateEdgeStyle: CellStyle = {};
 
   cells: Cell[] = [];
 
@@ -104,6 +114,18 @@ export abstract class AbstractGraph extends EventSource {
    * An array of {@link Multiplicity} describing the allowed connections in a graph.
    */
   multiplicities: Multiplicity[] = [];
+
+  /** Folding options. */
+  options: GraphFoldingOptions = {
+    foldingEnabled: true,
+    collapsedImage: new Image(`${Client.imageBasePath}/collapsed.gif`, 9, 9),
+    expandedImage: new Image(`${Client.imageBasePath}/expanded.gif`, 9, 9),
+    collapseToPreferredSize: true,
+  };
+
+  // ===================================================================================================================
+  // Group: Variables managed here (not in mixins)
+  // ===================================================================================================================
 
   /**
    * Holds the {@link GraphDataModel} that contains the cells to be displayed.
@@ -383,14 +405,6 @@ export abstract class AbstractGraph extends EventSource {
   containsValidationErrorsResource: string = isI18nEnabled()
     ? 'containsValidationErrors'
     : '';
-
-  /** Folding options. */
-  options: GraphFoldingOptions = {
-    foldingEnabled: true,
-    collapsedImage: new Image(`${Client.imageBasePath}/collapsed.gif`, 9, 9),
-    expandedImage: new Image(`${Client.imageBasePath}/expanded.gif`, 9, 9),
-    collapseToPreferredSize: true,
-  };
 
   // ===================================================================================================================
   // Group: "Create Class Instance" factory functions.

--- a/packages/core/src/view/AbstractGraph.ts
+++ b/packages/core/src/view/AbstractGraph.ts
@@ -89,9 +89,9 @@ export abstract class AbstractGraph extends EventSource {
   isConstrainedMoving = false;
 
   // ===================================================================================================================
-  // Group: Variables that should be in the mixins
-  // The current implementation of the function applying mixins create a shared state for properties with "complex" type (object, array)
-  // whereas here, we need to be created a specific instance for each new class instance.
+  // Group: Variables that should be in the mixins but requiring per-instance initialization
+  // The mixin application currently causes shared state for complex types (object/array),
+  // so these are defined here to ensure a fresh instance per Graph.
   // See https://github.com/maxGraph/maxGraph/pull/751 and https://github.com/maxGraph/maxGraph/pull/879
   // ===================================================================================================================
 

--- a/packages/core/src/view/mixins/EdgeMixin.ts
+++ b/packages/core/src/view/mixins/EdgeMixin.ts
@@ -26,6 +26,7 @@ import type Point from '../geometry/Point.js';
 
 type PartialGraph = Pick<
   AbstractGraph,
+  | 'alternateEdgeStyle'
   | 'batchUpdate'
   | 'fireEvent'
   | 'getDataModel'
@@ -46,7 +47,6 @@ type PartialEdge = Pick<
   | 'connectableEdges'
   | 'allowDanglingEdges'
   | 'cloneInvalidEdges'
-  | 'alternateEdgeStyle'
   | 'edgeLabelsMovable'
   | 'isResetEdgesOnMove'
   | 'isResetEdgesOnConnect'
@@ -103,8 +103,6 @@ export const EdgeMixin: PartialType = {
   allowDanglingEdges: true,
 
   cloneInvalidEdges: false,
-
-  alternateEdgeStyle: {},
 
   edgeLabelsMovable: true,
 

--- a/packages/core/src/view/mixins/EdgeMixin.type.ts
+++ b/packages/core/src/view/mixins/EdgeMixin.type.ts
@@ -57,13 +57,6 @@ declare module '../AbstractGraph' {
     cloneInvalidEdges: boolean;
 
     /**
-     * Specifies the alternate edge style to be used if the main control point
-     * on an edge is being double-clicked.
-     * @default {}
-     */
-    alternateEdgeStyle: CellStyle;
-
-    /**
      * Specifies the return value for edges in {@link isLabelMovable}.
      * @default true
      */

--- a/packages/core/src/view/mixins/ImageMixin.type.ts
+++ b/packages/core/src/view/mixins/ImageMixin.type.ts
@@ -18,8 +18,6 @@ import type ImageBundle from '../image/ImageBundle.js';
 
 declare module '../AbstractGraph' {
   interface AbstractGraph {
-    imageBundles: ImageBundle[];
-
     /**
      * Adds the specified {@link ImageBundle}.
      */


### PR DESCRIPTION
The current implementation of the function applying mixins creates shared state for "object" or "array" properties.
For such properties, ensure they are all defined in AbstractGraph and add tests to validate that there is no global
states. Here, this includes a fix for 'alternateEdgeStyle' which is no longer a global state.
In some mixin type files, remove properties that are already defined in AbstractGraph.


## Tasks

- [x] See #751 that workaround similar problems in the past
- [x] add tests on other properties of AbstractGraph to ensure they are not a shared state
  - [x] alternateEdgeStyle: object, currently on EdgeMixin, so probably a shared state
  - [x] multiplicities: array
  - [x] options: object
  - [x] check all mixins, they shouldn't have properties that are object or array as the mixin application currently creates shared state in the case (no other objects initialized to no nullish value in mixin)
- [x] Verify that validation stories still work (for multiplicities)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Per-graph alternate edge style when toggling an edge’s control point.
  - Configurable graph folding options with defaults (collapsed/expanded images, collapse-to-preferred-size).
  - Support for multiplicity constraints on edges with import/export serialization.

- Refactor
  - Reorganized graph-level properties (consolidation and relocation) without changing runtime behavior.

- Documentation
  - Expanded guidance on mixins and risks of shared object/array state.

- Tests
  - Added tests ensuring mixin-derived properties are per-instance and updated serialization tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->