### PR TITLE
chore(deps-dev): bump typescript from 5.8.2 to 5.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "./packages/*"
       ],
       "devDependencies": {
-        "@types/node": "^18.19.50",
+        "@types/node": "^18.19.123",
         "eslint": "~9.34.0",
         "eslint-config-prettier": "~10.1.8",
         "eslint-plugin-import": "~2.32.0",
@@ -13588,9 +13588,10 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "18.19.50",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.50.tgz",
-      "integrity": "sha512-xonK+NRrMBRtkL1hVCc3G+uXtjh1Al4opBLjqVmipe5ZAaBYWW6cNAiBVZ1BvmkBhep698rP3UM3aRAdSALuhg==",
+      "version": "18.19.123",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.123.tgz",
+      "integrity": "sha512-K7DIaHnh0mzVxreCR9qwgNxp3MH9dltPNIEddW9MYUlcKAzm+3grKNSTe2vCJHI1FaLpvpL5JGJrz1UZDKYvDg==",
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "eslint-plugin-n": "~17.21.3",
         "eslint-plugin-prettier": "~5.5.4",
         "prettier": "~3.6.2",
-        "typescript": "~5.8.2",
+        "typescript": "~5.9.2",
         "typescript-eslint": "~8.41.0"
       }
     },
@@ -37993,9 +37993,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint-plugin-n": "~17.21.3",
     "eslint-plugin-prettier": "~5.5.4",
     "prettier": "~3.6.2",
-    "typescript": "~5.8.2",
+    "typescript": "~5.9.2",
     "typescript-eslint": "~8.41.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint:fix": "eslint --fix \"**/*.ts\""
   },
   "devDependencies": {
-    "@types/node": "^18.19.50",
+    "@types/node": "^18.19.123",
     "eslint": "~9.34.0",
     "eslint-config-prettier": "~10.1.8",
     "eslint-plugin-import": "~2.32.0",


### PR DESCRIPTION
Also bump @types/node to fix TSC 5.9 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped development dependencies: TypeScript and Node type definitions updated to newer minor/patch versions to keep tooling current.
  * No user-facing changes or UI differences; runtime behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->