### PR TITLE
refactor: simplify signature of the isNullish internal function

### DIFF
--- a/packages/core/src/internal/utils.ts
+++ b/packages/core/src/internal/utils.ts
@@ -34,9 +34,15 @@ export const isElement = (node?: Node | UserObject | null): node is Element =>
   node?.nodeType === NODE_TYPE.ELEMENT;
 
 /**
+ * Use this function to check for null or undefined values for objects having falsy values in addition to nullish values:
+ *
+ * - boolean (false)
+ * - number (0)
+ * - string (empty)
+ *
  * @private not part of the public API, can be removed or changed without prior notice
  */
-export const isNullish = (v: string | object | null | undefined | number | boolean) =>
+export const isNullish = (v: unknown): v is null | undefined =>
   v === null || v === undefined;
 
 /**

--- a/packages/core/src/internal/utils.ts
+++ b/packages/core/src/internal/utils.ts
@@ -34,11 +34,10 @@ export const isElement = (node?: Node | UserObject | null): node is Element =>
   node?.nodeType === NODE_TYPE.ELEMENT;
 
 /**
- * Use this function to check for null or undefined values for objects having falsy values in addition to nullish values:
+ * Returns true if the input is null or undefined.
  *
- * - boolean (false)
- * - number (0)
- * - string (empty)
+ * **Note**: falsy-but-defined values (false, 0, '') are NOT considered nullish.
+ * Use this when you must allow falsy values but reject absent ones, generally when the parameter is boolean, number or string.
  *
  * @private not part of the public API, can be removed or changed without prior notice
  */


### PR DESCRIPTION
Use a single type for the input parameter and declare the returned type explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal TypeScript typings to enhance type safety and editor tooling without changing runtime behavior or user-facing outcomes.
* **Documentation**
  * Clarified inline developer guidance about nullish vs. falsy values to improve readability and maintenance for contributors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->