### PR TITLE
docs: add badge to DeepWiki in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/@maxgraph/core?color=blue&style=flat)](https://www.npmjs.com/package/@maxgraph/core)
 [![build status](https://github.com/maxGraph/maxGraph/workflows/Build/badge.svg)](https://github.com/maxGraph/maxGraph/actions/workflows/build.yml)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/maxGraph/maxGraph)
 
 <!-- copied into packages/core/README.md and packages/website/docs/intro.md -->
 `maxGraph` is a TypeScript library which can display and allow interaction with vector diagrams. At a high level, it provides: 


### PR DESCRIPTION
DeepWiki use the contents of the repository to create convenient documentation that can be requested. It provides complementary information to what the source code and the website provide.

Adding the badge to the README let people know about it and allow automatic refresh of the wiki every week.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a DeepWiki badge to the README next to the build status badge, improving discoverability and providing one-click access to documentation.
  * No code, runtime, or build changes; purely a content update.
  * Public APIs and user workflows remain unchanged.
  * Development setup and CI are unaffected.
  * No migrations or configuration changes required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->