### PR TITLE
feat: allow to pass more null and undefined to Multiplicity

### DIFF
--- a/packages/core/src/util/domUtils.ts
+++ b/packages/core/src/util/domUtils.ts
@@ -229,9 +229,10 @@ export const isNode = (
 ) => {
   if (
     !isNullish(value) &&
-    !isNaN(value.nodeType) &&
+    typeof value.nodeType === 'number' &&
     (isNullish(nodeName) || value.nodeName.toLowerCase() == nodeName.toLowerCase())
   ) {
+    // Intentionally using loose equality to treat null and undefined as equivalent here.
     return (
       isNullish(attributeName) || value.getAttribute(attributeName) == attributeValue
     );

--- a/packages/core/src/util/domUtils.ts
+++ b/packages/core/src/util/domUtils.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import { NODE_TYPE } from './Constants.js';
+import { isNullish } from '../internal/utils.js';
 
 /**
  * Returns the text content of the specified node.
@@ -223,15 +224,17 @@ export const para = (parent: Element, text: string) => {
 export const isNode = (
   value: any,
   nodeName: string | null = null,
-  attributeName?: string,
-  attributeValue?: string
+  attributeName?: string | null,
+  attributeValue?: string | null
 ) => {
   if (
-    value != null &&
+    !isNullish(value) &&
     !isNaN(value.nodeType) &&
-    (nodeName == null || value.nodeName.toLowerCase() == nodeName.toLowerCase())
+    (isNullish(nodeName) || value.nodeName.toLowerCase() == nodeName.toLowerCase())
   ) {
-    return attributeName == null || value.getAttribute(attributeName) == attributeValue;
+    return (
+      isNullish(attributeName) || value.getAttribute(attributeName) == attributeValue
+    );
   }
 
   return false;

--- a/packages/core/src/view/cell/Cell.ts
+++ b/packages/core/src/view/cell/Cell.ts
@@ -233,14 +233,14 @@ export class Cell implements IdentityObject {
   }
 
   /**
-   * Returns the {@link Geometry} that describes the <geometry>.
+   * Returns the {@link Geometry} that describes the {@link geometry}.
    */
   getGeometry(): Geometry | null {
     return this.geometry;
   }
 
   /**
-   * Sets the {@link Geometry} to be used as the <geometry>.
+   * Sets the {@link Geometry} to be used as the {@link geometry}.
    */
   setGeometry(geometry: Geometry | null) {
     this.geometry = geometry;

--- a/packages/core/src/view/cell/Cell.ts
+++ b/packages/core/src/view/cell/Cell.ts
@@ -207,16 +207,14 @@ export class Cell implements IdentityObject {
   }
 
   /**
-   * Returns the user object of the cell. The user
-   * object is stored in <value>.
+   * Returns the user object of the cell. The user object is stored in {@link value}.
    */
   getValue(): any {
     return this.value;
   }
 
   /**
-   * Sets the user object of the cell. The user object
-   * is stored in <value>.
+   * Sets the user object of the cell. The user object is stored in {@link value}.
    */
   setValue(value: any): void {
     this.value = value;

--- a/packages/core/src/view/mixins/ValidationMixin.ts
+++ b/packages/core/src/view/mixins/ValidationMixin.ts
@@ -18,6 +18,7 @@ import type Cell from '../cell/Cell.js';
 import { isNode } from '../../util/domUtils.js';
 import type { AbstractGraph } from '../AbstractGraph.js';
 import { translate } from '../../internal/i18n-utils.js';
+import { isNullish } from '../../internal/utils.js';
 
 type PartialGraph = Pick<
   AbstractGraph,
@@ -112,14 +113,14 @@ export const ValidationMixin: PartialType = {
           targetIn
         );
 
-        if (err != null) {
+        if (!isNullish(err)) {
           error += err;
         }
       }
 
       // Validates the source and target terminals independently
-      const err = this.validateEdge(<Cell>edge, source, target);
-      if (err != null) {
+      const err = this.validateEdge(edge!, source, target);
+      if (!isNullish(err)) {
         error += err;
       }
       return error.length > 0 ? error : null;
@@ -186,13 +187,13 @@ export const ValidationMixin: PartialType = {
           cell.getTerminal(false)
         ) || '';
     } else {
-      warning += this.getCellValidationError(<Cell>cell) || '';
+      warning += this.getCellValidationError(cell) || '';
     }
 
     // Checks custom validation rules
-    const err = this.validateCell(<Cell>cell, context);
+    const err = this.validateCell(cell, context);
 
-    if (err != null) {
+    if (!isNullish(err)) {
       warning += err;
     }
 

--- a/packages/core/src/view/mixins/ValidationMixin.type.ts
+++ b/packages/core/src/view/mixins/ValidationMixin.type.ts
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type Multiplicity from '../other/Multiplicity.js';
 import type Cell from '../cell/Cell.js';
 import type CellState from '../cell/CellState.js';
 

--- a/packages/core/src/view/mixins/ValidationMixin.type.ts
+++ b/packages/core/src/view/mixins/ValidationMixin.type.ts
@@ -20,8 +20,6 @@ import type CellState from '../cell/CellState.js';
 
 declare module '../AbstractGraph' {
   interface AbstractGraph {
-    multiplicities: Multiplicity[];
-
     /**
      * Displays the given validation error in a dialog.
      *

--- a/packages/html/stories/Guides.stories.ts
+++ b/packages/html/stories/Guides.stories.ts
@@ -142,6 +142,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   graph.container.focus();
 
   // TODO not working in storybook, work in vanilla example. This is probably due to events already installed by storybook
+  // See https://github.com/maxGraph/maxGraph/issues/910
   // Handles keystroke events
   const keyHandler = new KeyHandler(graph);
 

--- a/packages/website/docs/usage/i18n.md
+++ b/packages/website/docs/usage/i18n.md
@@ -71,7 +71,7 @@ Resource files are loaded in the [`preview.ts`](https://github.com/maxGraph/maxG
 The following stories illustrate the translation of validation messages. Try connecting the same vertices twice to trigger a validation error displayed in a browser alert:
 - **Validation story**:
   - **Live demo**: [Validation](https://maxgraph.github.io/maxGraph/demo/?path=/story/misc-validation--default)
-  - **Source code**: [Validation.stories.js](https://github.com/maxGraph/maxGraph/blob/main/packages/html/stories/Validation.stories.js)
+  - **Source code**: [Validation.stories.ts](https://github.com/maxGraph/maxGraph/blob/main/packages/html/stories/Validation.stories.ts)
 - **Permissions story**:
   - **Live demo**: [Permissions](https://maxgraph.github.io/maxGraph/demo/?path=/story/misc-permissions--default)
   - **Source code**: [Permissions.stories.js](https://github.com/maxGraph/maxGraph/blob/main/packages/html/stories/Permissions.stories.js)


### PR DESCRIPTION
Restore the behavior available in mxGraph to ease the migration.

In addition:
- Improve nullish management in various related places
- Improve JSDoc
- Validation mixin type: remove duplicated declaration of `multiplicities` already defined in AbstractGraph
- Migrate the Validation story to TypeScript to ease maintenance and detect errors earlier


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Example/demo now supports plugin-based rubber-band selection and improved demo layout/text.

- Bug Fixes
  - Standardized null/undefined handling across DOM utilities, validation, and multiplicity checks to reduce errors with missing attributes or values.

- Refactor
  - Validation and multiplicity handling made more tolerant of absent metadata and nullish inputs for safer, more consistent behavior.

- Documentation
  - Updated examples to the latest graph APIs and key handling; fixed story links and clarified cell getter/setter docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->