### PR TITLE
chore(typescript): always use explicit override

### DIFF
--- a/packages/core/__tests__/utils.ts
+++ b/packages/core/__tests__/utils.ts
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 import { Cell, type CellStateStyle, Graph } from '../src';
-import { jest } from '@jest/globals';
 
 /**
  * Creates a new {@link Graph} without `container` (use the default value of the parameters).

--- a/packages/core/__tests__/view/mixins/ConnectionsMixin.test.ts
+++ b/packages/core/__tests__/view/mixins/ConnectionsMixin.test.ts
@@ -47,10 +47,10 @@ describe('getAllConnectionConstraints', () => {
         super(null!);
         this.constraints = constraints;
       }
-      parseDescription() {
+      override parseDescription() {
         // do nothing
       }
-      parseConstraints() {
+      override parseConstraints() {
         // do nothing, constraints passed in constructor
       }
     }

--- a/packages/core/src/serialization/codecs/CellCodec.ts
+++ b/packages/core/src/serialization/codecs/CellCodec.ts
@@ -72,14 +72,14 @@ export class CellCodec extends ObjectCodec {
   /**
    * Overridden to disable conversion of value to number.
    */
-  isNumericAttribute(dec: Codec, attr: Element, obj: Cell) {
+  override isNumericAttribute(dec: Codec, attr: Element, obj: Cell) {
     return attr.nodeName !== 'value' && super.isNumericAttribute(dec, attr, obj);
   }
 
   /**
    * Excludes user objects that are XML nodes.
    */
-  isExcluded(obj: Cell, attr: string, value: Element, isWrite: boolean) {
+  override isExcluded(obj: Cell, attr: string, value: Element, isWrite: boolean) {
     return (
       super.isExcluded(obj, attr, value, isWrite) ||
       (isWrite && attr === 'value' && isElement(value))
@@ -89,7 +89,7 @@ export class CellCodec extends ObjectCodec {
   /**
    * Encodes a {@link Cell} and wraps the XML up inside the XML of the user object (inversion).
    */
-  afterEncode(enc: Codec, obj: Cell, node: Element) {
+  override afterEncode(enc: Codec, obj: Cell, node: Element) {
     if (isElement(obj.value)) {
       // Wraps the graphical annotation up in the user object (inversion)
       // by putting the result of the default encoding into a clone of the
@@ -111,7 +111,7 @@ export class CellCodec extends ObjectCodec {
   /**
    * Decodes an {@link Cell} and uses the enclosing XML node as the user object for the cell (inversion).
    */
-  beforeDecode(dec: Codec, node: Element, obj: Cell): Element | null {
+  override beforeDecode(dec: Codec, node: Element, obj: Cell): Element | null {
     let inner: Element | null = <Element>node.cloneNode(true);
     const classname = this.getName();
 

--- a/packages/core/src/serialization/codecs/ChildChangeCodec.ts
+++ b/packages/core/src/serialization/codecs/ChildChangeCodec.ts
@@ -51,7 +51,7 @@ export class ChildChangeCodec extends ObjectCodec {
    * Returns `true` for the child attribute if the child cell had a previous parent or if we're reading the
    * child as an attribute rather than a child node, in which case it's always a reference.
    */
-  isReference(obj: any, attr: string | null, value: any, isWrite: boolean) {
+  override isReference(obj: any, attr: string | null, value: any, isWrite: boolean) {
     if (attr === 'child' && (!isWrite || obj.model.contains(obj.previous))) {
       return true;
     }
@@ -61,7 +61,7 @@ export class ChildChangeCodec extends ObjectCodec {
   /**
    * Excludes references to parent or previous if not in the model.
    */
-  isExcluded(obj: any, attr: string, value: any, write: boolean) {
+  override isExcluded(obj: any, attr: string, value: any, write: boolean) {
     return (
       super.isExcluded(obj, attr, value, write) ||
       (write &&
@@ -74,7 +74,7 @@ export class ChildChangeCodec extends ObjectCodec {
   /**
    * Encodes the child recursively and adds the result to the given node.
    */
-  afterEncode(enc: Codec, obj: any, node: Element) {
+  override afterEncode(enc: Codec, obj: any, node: Element) {
     if (this.isReference(obj, 'child', obj.child, true)) {
       // Encodes as reference (id)
       node.setAttribute('child', enc.getId(obj.child));
@@ -92,7 +92,7 @@ export class ChildChangeCodec extends ObjectCodec {
   /**
    * Decodes any child nodes as using the respective codec from the registry.
    */
-  beforeDecode(dec: Codec, _node: Element, obj: any): any {
+  override beforeDecode(dec: Codec, _node: Element, obj: any): any {
     if (isElement(_node.firstChild)) {
       // Makes sure the original node isn't modified
       const node = _node.cloneNode(true);
@@ -135,7 +135,7 @@ export class ChildChangeCodec extends ObjectCodec {
   /**
    * Restores object state in the child change.
    */
-  afterDecode(dec: Codec, node: Element, obj: any): any {
+  override afterDecode(dec: Codec, node: Element, obj: any): any {
     // Cells are decoded here after a complete transaction so the previous
     // parent must be restored on the cell for the case where the cell was
     // added. This is needed for the local model to identify the cell as a

--- a/packages/core/src/serialization/codecs/GenericChangeCodec.ts
+++ b/packages/core/src/serialization/codecs/GenericChangeCodec.ts
@@ -52,7 +52,7 @@ export class GenericChangeCodec extends ObjectCodec {
   /**
    * Restores the state by assigning the previous value.
    */
-  afterDecode(dec: Codec, _node: Element, obj: any): any {
+  override afterDecode(dec: Codec, _node: Element, obj: any): any {
     // Allows forward references in sessions. This is a workaround
     // for the sequence of edits in mxGraph.moveCells and cellsAdded.
     if (isNode(obj.cell)) {

--- a/packages/core/src/serialization/codecs/ModelCodec.ts
+++ b/packages/core/src/serialization/codecs/ModelCodec.ts
@@ -36,7 +36,7 @@ export class ModelCodec extends ObjectCodec {
    * Encodes the given {@link GraphDataModel} by writing a (flat) XML sequence of cell nodes as produced by the {@link CellCodec}.
    * The sequence is wrapped-up in a node with the name `root`.
    */
-  encodeObject(enc: Codec, obj: Cell, node: Element) {
+  override encodeObject(enc: Codec, obj: Cell, node: Element) {
     const rootNode = enc.document.createElement('root');
     enc.encodeCell(obj.getRoot(), rootNode);
     node.appendChild(rootNode);
@@ -45,7 +45,7 @@ export class ModelCodec extends ObjectCodec {
   /**
    * Overrides decode child to handle special child nodes.
    */
-  decodeChild(dec: Codec, child: Element, obj: Cell | GraphDataModel) {
+  override decodeChild(dec: Codec, child: Element, obj: Cell | GraphDataModel) {
     if (child.nodeName === 'root') {
       this.decodeRoot(dec, child, <GraphDataModel>obj);
     } else {

--- a/packages/core/src/serialization/codecs/RootChangeCodec.ts
+++ b/packages/core/src/serialization/codecs/RootChangeCodec.ts
@@ -43,7 +43,7 @@ export class RootChangeCodec extends ObjectCodec {
   /**
    * Encodes the child recursively.
    */
-  afterEncode(enc: Codec, obj: any, node: Element) {
+  override afterEncode(enc: Codec, obj: any, node: Element) {
     enc.encodeCell(obj.root, node);
     return node;
   }
@@ -51,7 +51,7 @@ export class RootChangeCodec extends ObjectCodec {
   /**
    * Decodes the optional children as cells using the respective decoder.
    */
-  beforeDecode(dec: Codec, node: Element, obj: any): any {
+  override beforeDecode(dec: Codec, node: Element, obj: any): any {
     if (isElement(node.firstChild)) {
       // Makes sure the original node isn't modified
       node = <Element>node.cloneNode(true);
@@ -76,7 +76,7 @@ export class RootChangeCodec extends ObjectCodec {
   /**
    * Restores the state by assigning the previous value.
    */
-  afterDecode(_dec: Codec, _node: Element, obj: any): any {
+  override afterDecode(_dec: Codec, _node: Element, obj: any): any {
     obj.previous = obj.root;
 
     return obj;

--- a/packages/core/src/serialization/codecs/StylesheetCodec.ts
+++ b/packages/core/src/serialization/codecs/StylesheetCodec.ts
@@ -44,12 +44,12 @@ export class StylesheetCodec extends ObjectCodec {
    *
    * @default false
    */
-  static allowEval = false;
+  static override allowEval = false;
 
   /**
    * Encodes a stylesheet. See {@link decode} for a description of the format.
    */
-  encode(enc: Codec, obj: Stylesheet): Element {
+  override encode(enc: Codec, obj: Stylesheet): Element {
     const node = enc.document.createElement(this.getName());
 
     for (const styleName of obj.styles.keys()) {
@@ -127,7 +127,7 @@ export class StylesheetCodec extends ObjectCodec {
    * </Stylesheet>
    * ```
    */
-  decode(dec: Codec, _node: Element, into: any): any {
+  override decode(dec: Codec, _node: Element, into: any): any {
     const obj = into || new this.template.constructor();
     const id = _node.getAttribute('id');
 

--- a/packages/core/src/serialization/codecs/TerminalChangeCodec.ts
+++ b/packages/core/src/serialization/codecs/TerminalChangeCodec.ts
@@ -48,7 +48,7 @@ export class TerminalChangeCodec extends ObjectCodec {
   /**
    * Restores the state by assigning the previous value.
    */
-  afterDecode(_dec: Codec, _node: Element, obj: any): any {
+  override afterDecode(_dec: Codec, _node: Element, obj: any): any {
     obj.previous = obj.terminal;
     return obj;
   }

--- a/packages/core/src/serialization/codecs/editor/EditorCodec.ts
+++ b/packages/core/src/serialization/codecs/editor/EditorCodec.ts
@@ -103,7 +103,7 @@ export class EditorCodec extends ObjectCodec {
    * </ui>
    * ```
    */
-  afterDecode(_dec: Codec, node: Element, obj: Editor) {
+  override afterDecode(_dec: Codec, node: Element, obj: Editor) {
     // Assigns the specified templates for edges
     const defaultEdge = node.getAttribute('defaultEdge');
 
@@ -119,13 +119,14 @@ export class EditorCodec extends ObjectCodec {
       node.removeAttribute('defaultGroup');
       obj.defaultGroup = obj.templates[defaultGroup];
     }
+
     return obj;
   }
 
   /**
    * Overrides decode child to handle special child nodes.
    */
-  decodeChild(dec: Codec, child: Element, obj: Editor) {
+  override decodeChild(dec: Codec, child: Element, obj: Editor) {
     if (child.nodeName === 'Array') {
       const role = child.getAttribute('as');
 

--- a/packages/core/src/serialization/codecs/editor/EditorKeyHandlerCodec.ts
+++ b/packages/core/src/serialization/codecs/editor/EditorKeyHandlerCodec.ts
@@ -35,7 +35,7 @@ export class EditorKeyHandlerCodec extends ObjectCodec {
   /**
    * Returns `null`.
    */
-  encode(_enc: Codec, _obj: EditorKeyHandler) {
+  override encode(_enc: Codec, _obj: EditorKeyHandler) {
     return null;
   }
 
@@ -67,7 +67,7 @@ export class EditorKeyHandlerCodec extends ObjectCodec {
    *
    * See also: <EditorKeyHandler.bindAction>, http://www.js-examples.com/page/tutorials__key_codes.html
    */
-  decode(dec: Codec, _node: Element, into: any) {
+  override decode(dec: Codec, _node: Element, into: any) {
     if (into != null) {
       const { editor } = into;
       let node: Element | null = <Element | null>_node.firstChild;

--- a/packages/core/src/serialization/codecs/editor/EditorPopupMenuCodec.ts
+++ b/packages/core/src/serialization/codecs/editor/EditorPopupMenuCodec.ts
@@ -37,14 +37,14 @@ export class EditorPopupMenuCodec extends ObjectCodec {
   /**
    * Returns null.
    */
-  encode(_enc: Codec, _obj: Element): Element | null {
+  override encode(_enc: Codec, _obj: Element): Element | null {
     return null;
   }
 
   /**
    * Uses the given node as the config for {@link EditorPopupMenu}.
    */
-  decode(dec: Codec, node: Element, into: EditorPopupMenu) {
+  override decode(dec: Codec, node: Element, into: EditorPopupMenu) {
     const inc = node.getElementsByTagName('include')[0];
 
     if (inc != null) {

--- a/packages/core/src/serialization/codecs/editor/EditorToolbarCodec.ts
+++ b/packages/core/src/serialization/codecs/editor/EditorToolbarCodec.ts
@@ -45,7 +45,7 @@ export class EditorToolbarCodec extends ObjectCodec {
   /**
    * Returns `null`.
    */
-  encode(_enc: any, _obj: any) {
+  override encode(_enc: any, _obj: any) {
     return null;
   }
 
@@ -130,7 +130,7 @@ export class EditorToolbarCodec extends ObjectCodec {
    * </EditorToolbar>
    * ```
    */
-  decode(dec: Codec, _node: Element, into: EditorToolbar) {
+  override decode(dec: Codec, _node: Element, into: EditorToolbar) {
     if (into != null) {
       const editor: Editor = into.editor!;
       let node: Element | null = <Element | null>_node.firstChild;

--- a/packages/core/src/serialization/codecs/mxGraph/mxCellCodec.ts
+++ b/packages/core/src/serialization/codecs/mxGraph/mxCellCodec.ts
@@ -24,11 +24,11 @@ import type Codec from '../../Codec.js';
  * @category Serialization with Codecs
  */
 export class mxCellCodec extends CellCodec {
-  getName(): string {
+  override getName(): string {
     return 'mxCell';
   }
 
-  decodeAttribute(dec: Codec, attr: any, obj?: any) {
+  override decodeAttribute(dec: Codec, attr: any, obj?: any) {
     const attributeNodeName = attr.nodeName;
     if (obj && attributeNodeName == 'style') {
       obj['style'] = convertStyleFromString(attr.value);

--- a/packages/core/src/serialization/codecs/mxGraph/mxGeometryCodec.ts
+++ b/packages/core/src/serialization/codecs/mxGraph/mxGeometryCodec.ts
@@ -25,7 +25,7 @@ import Point from '../../../view/geometry/Point.js';
  * @category Serialization with Codecs
  */
 export class mxGeometryCodec extends ObjectCodec {
-  getName(): string {
+  override getName(): string {
     return 'mxGeometry';
   }
 
@@ -33,7 +33,7 @@ export class mxGeometryCodec extends ObjectCodec {
     super(new Geometry());
   }
 
-  afterDecode(dec: Codec, node: Element | null, obj?: any): any {
+  override afterDecode(dec: Codec, node: Element | null, obj?: any): any {
     // Convert points to the right form
     // input: [ { x: 420, y: 60 }, ... ]
     // output: [ Point { _x: 420, _y: 60 }, ... ]

--- a/packages/core/src/view/animate/Morphing.ts
+++ b/packages/core/src/view/animate/Morphing.ts
@@ -89,7 +89,7 @@ class Morphing extends Animation {
   /**
    * Animation step.
    */
-  updateAnimation() {
+  override updateAnimation() {
     super.updateAnimation();
     const move = new CellStatePreview(this.graph);
 

--- a/packages/core/src/view/canvas/SvgCanvas2D.ts
+++ b/packages/core/src/view/canvas/SvgCanvas2D.ts
@@ -235,7 +235,7 @@ class SvgCanvas2D extends AbstractCanvas2D {
    * Default value for active pointer events.
    * @default all
    */
-  pointerEventsValue = 'all';
+  override pointerEventsValue = 'all';
 
   /**
    * Padding to be added for text that is not wrapped to account for differences in font metrics on different platforms in pixels.
@@ -346,7 +346,7 @@ class SvgCanvas2D extends AbstractCanvas2D {
   /**
    * Rounds all numbers to 2 decimal points.
    */
-  format(value: number) {
+  override format(value: number) {
     return parseFloat(value.toFixed(2));
   }
 
@@ -370,7 +370,7 @@ class SvgCanvas2D extends AbstractCanvas2D {
   /**
    * Returns any offsets for rendering pixels.
    */
-  reset() {
+  override reset() {
     super.reset();
     this.gradients = {};
   }
@@ -879,7 +879,7 @@ class SvgCanvas2D extends AbstractCanvas2D {
   /**
    * Experimental implementation for hyperlinks.
    */
-  setLink(link: string) {
+  override setLink(link: string) {
     if (!link) {
       this.root = this.originalRoot;
     } else {
@@ -903,7 +903,7 @@ class SvgCanvas2D extends AbstractCanvas2D {
   /**
    * Sets the rotation of the canvas. Note that rotation cannot be concatenated.
    */
-  rotate(theta: number, flipH: boolean, flipV: boolean, cx: number, cy: number) {
+  override rotate(theta: number, flipH: boolean, flipV: boolean, cx: number, cy: number) {
     if (theta !== 0 || flipH || flipV) {
       const s = this.state;
       cx += s.dx;
@@ -948,9 +948,9 @@ class SvgCanvas2D extends AbstractCanvas2D {
   }
 
   /**
-   * Extends superclass to create path.
+   * Begins a new path.
    */
-  begin() {
+  override begin() {
     super.begin();
     this.node = this.createElement('path');
   }

--- a/packages/core/src/view/canvas/XmlCanvas2D.ts
+++ b/packages/core/src/view/canvas/XmlCanvas2D.ts
@@ -123,7 +123,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
   /**
    * Scales the output.
    *
-   * @param scale Number that represents the scale where 1 is equal to 100%.
+   * @param value Number that represents the scale where 1 is equal to 100%.
    */
   override scale(value: number): void {
     const elem = this.createElement('scale');
@@ -350,9 +350,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
    * Enables or disables dashed lines.
    *
    * @param value Boolean that specifies if dashed lines should be enabled.
-   * @param value Boolean that specifies if the stroke width should be ignored
-   * for the dash pattern.
-   * @default false
+   * @param fixDash Boolean that specifies if the stroke width should be ignored for the dash pattern. Default is false.
    */
   override setDashed(value: boolean, fixDash: boolean): void {
     if (this.compressed) {

--- a/packages/core/src/view/canvas/XmlCanvas2D.ts
+++ b/packages/core/src/view/canvas/XmlCanvas2D.ts
@@ -572,8 +572,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
   /**
    * Sets the current font style.
    *
-   * @param value Numeric representation of the font family. This is the sum of the
-   * font styles from {@link mxConstants}.
+   * @param value Numeric representation of the font style. This is the sum of the font styles from {@link FONT_STYLE_MASK}.
    */
   override setFontStyle(value: number | null = 0): void {
     if (this.textEnabled) {

--- a/packages/core/src/view/canvas/XmlCanvas2D.ts
+++ b/packages/core/src/view/canvas/XmlCanvas2D.ts
@@ -85,7 +85,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
   /**
    * Returns a formatted number with 2 decimal places.
    */
-  format(value: string | number): number {
+  override format(value: string | number): number {
     if (typeof value === 'string') {
       return parseFloat(parseFloat(value).toFixed(2));
     } else {
@@ -103,7 +103,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
   /**
    * Saves the drawing state.
    */
-  save(): void {
+  override save(): void {
     if (this.compressed) {
       super.save();
     }
@@ -113,7 +113,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
   /**
    * Restores the drawing state.
    */
-  restore(): void {
+  override restore(): void {
     if (this.compressed) {
       super.restore();
     }
@@ -125,7 +125,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
    *
    * @param scale Number that represents the scale where 1 is equal to 100%.
    */
-  scale(value: number): void {
+  override scale(value: number): void {
     const elem = this.createElement('scale');
     elem.setAttribute('scale', String(value));
     this.root.appendChild(elem);
@@ -137,7 +137,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
    * @param dx Number that specifies the horizontal translation.
    * @param dy Number that specifies the vertical translation.
    */
-  translate(dx: number, dy: number): void {
+  override translate(dx: number, dy: number): void {
     const elem = this.createElement('translate');
     elem.setAttribute('dx', String(this.format(dx)));
     elem.setAttribute('dy', String(this.format(dy)));
@@ -154,9 +154,14 @@ class XmlCanvas2D extends AbstractCanvas2D {
    * @param cx Number that represents the x-coordinate of the rotation center.
    * @param cy Number that represents the y-coordinate of the rotation center.
    */
-  rotate(theta: number, flipH: boolean, flipV: boolean, cx: number, cy: number): void {
+  override rotate(
+    theta: number,
+    flipH: boolean,
+    flipV: boolean,
+    cx: number,
+    cy: number
+  ): void {
     const elem = this.createElement('rotate');
-
     if (theta !== 0 || flipH || flipV) {
       elem.setAttribute('theta', String(this.format(theta)));
       elem.setAttribute('flipH', flipH ? '1' : '0');
@@ -173,7 +178,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
    * @param value Number that represents the new alpha. Possible values are between
    * 1 (opaque) and 0 (transparent).
    */
-  setAlpha(value: number): void {
+  override setAlpha(value: number): void {
     if (this.compressed) {
       if (this.state.alpha === value) {
         return;
@@ -192,7 +197,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
    * @param value Number that represents the new fill alpha. Possible values are between
    * 1 (opaque) and 0 (transparent).
    */
-  setFillAlpha(value: number): void {
+  override setFillAlpha(value: number): void {
     if (this.compressed) {
       if (this.state.fillAlpha === value) {
         return;
@@ -211,7 +216,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
    * @param value Number that represents the new stroke alpha. Possible values are between
    * 1 (opaque) and 0 (transparent).
    */
-  setStrokeAlpha(value: number): void {
+  override setStrokeAlpha(value: number): void {
     if (this.compressed) {
       if (this.state.strokeAlpha === value) {
         return;
@@ -229,7 +234,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
    *
    * @param value Hexadecimal representation of the color or 'none'.
    */
-  setFillColor(value: string | null = null): void {
+  override setFillColor(value: string | null = null): void {
     if (value === NONE) {
       value = null;
     }
@@ -262,7 +267,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
    * @param alpha2 Optional alpha of the end color. Default is 1. Possible values
    * are between 1 (opaque) and 0 (transparent).
    */
-  setGradient(
+  override setGradient(
     color1: string | null,
     color2: string | null,
     x: number,
@@ -306,7 +311,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
    *
    * @param value Hexadecimal representation of the color or 'none'.
    */
-  setStrokeColor(value: string | null = null): void {
+  override setStrokeColor(value: string | null = null): void {
     if (value === NONE) {
       value = null;
     }
@@ -328,7 +333,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
    *
    * @param value Numeric representation of the stroke width.
    */
-  setStrokeWidth(value: number): void {
+  override setStrokeWidth(value: number): void {
     if (this.compressed) {
       if (this.state.strokeWidth === value) {
         return;
@@ -349,7 +354,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
    * for the dash pattern.
    * @default false
    */
-  setDashed(value: boolean, fixDash: boolean): void {
+  override setDashed(value: boolean, fixDash: boolean): void {
     if (this.compressed) {
       if (this.state.dashed === value) {
         return;
@@ -376,7 +381,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
    * between the dashes. The lengths are relative to the line width - a length
    * of 1 is equals to the line width.
    */
-  setDashPattern(value: string): void {
+  override setDashPattern(value: string): void {
     if (this.compressed) {
       if (this.state.dashPattern === value) {
         return;
@@ -396,7 +401,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
    * @param value String that represents the line cap. Possible values are flat, round
    * and square.
    */
-  setLineCap(value: string): void {
+  override setLineCap(value: string): void {
     if (this.compressed) {
       if (this.state.lineCap === value) {
         return;
@@ -416,7 +421,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
    * @param value String that represents the line join. Possible values are miter,
    * round and bevel.
    */
-  setLineJoin(value: string): void {
+  override setLineJoin(value: string): void {
     if (this.compressed) {
       if (this.state.lineJoin === value) {
         return;
@@ -435,7 +440,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
    *
    * @param value Number that represents the miter limit.
    */
-  setMiterLimit(value: number): void {
+  override setMiterLimit(value: number): void {
     if (this.compressed) {
       if (this.state.miterLimit === value) {
         return;
@@ -454,7 +459,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
    *
    * @param value Hexadecimal representation of the color or 'none'.
    */
-  setFontColor(value: string | null = null): void {
+  override setFontColor(value: string | null = null): void {
     if (this.textEnabled) {
       if (value === NONE) {
         value = null;
@@ -478,7 +483,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
    *
    * @param value Hexadecimal representation of the color or 'none'.
    */
-  setFontBackgroundColor(value: string | null = null): void {
+  override setFontBackgroundColor(value: string | null = null): void {
     if (this.textEnabled) {
       if (value === NONE) {
         value = null;
@@ -502,7 +507,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
    *
    * @param value Hexadecimal representation of the color or 'none'.
    */
-  setFontBorderColor(value: string | null = null): void {
+  override setFontBorderColor(value: string | null = null): void {
     if (this.textEnabled) {
       if (value === NONE) {
         value = null;
@@ -527,7 +532,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
    *
    * @param value Numeric representation of the font size.
    */
-  setFontSize(value: number): void {
+  override setFontSize(value: number): void {
     if (this.textEnabled) {
       if (this.compressed) {
         if (this.state.fontSize === value) {
@@ -549,7 +554,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
    * @param value String representation of the font family. This handles the same
    * values as the CSS font-family property.
    */
-  setFontFamily(value: string): void {
+  override setFontFamily(value: string): void {
     if (this.textEnabled) {
       if (this.compressed) {
         if (this.state.fontFamily === value) {
@@ -570,7 +575,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
    * @param value Numeric representation of the font family. This is the sum of the
    * font styles from {@link mxConstants}.
    */
-  setFontStyle(value: number | null = 0): void {
+  override setFontStyle(value: number | null = 0): void {
     if (this.textEnabled) {
       if (value == null) {
         value = 0;
@@ -594,7 +599,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
    *
    * @param value Boolean that specifies if shadows should be enabled.
    */
-  setShadow(value: boolean): void {
+  override setShadow(value: boolean): void {
     if (this.compressed) {
       if (this.state.shadow === value) {
         return;
@@ -607,12 +612,8 @@ class XmlCanvas2D extends AbstractCanvas2D {
     this.root.appendChild(elem);
   }
 
-  setShadowColor(value: string | null = null): void {
+  override setShadowColor(value: string | null = null): void {
     if (this.compressed) {
-      if (value === NONE) {
-        value = null;
-      }
-
       if (this.state.shadowColor === value) {
         return;
       }
@@ -625,7 +626,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
     this.root.appendChild(elem);
   }
 
-  setShadowAlpha(value: number): void {
+  override setShadowAlpha(value: number): void {
     if (this.compressed) {
       if (this.state.shadowAlpha === value) {
         return;
@@ -638,7 +639,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
     this.root.appendChild(elem);
   }
 
-  setShadowOffset(dx: number, dy: number): void {
+  override setShadowOffset(dx: number, dy: number): void {
     if (this.compressed) {
       if (this.state.shadowDx === dx && this.state.shadowDy === dy) {
         return;
@@ -751,7 +752,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
   /**
    * Starts a new path and puts it into the drawing buffer.
    */
-  begin(): void {
+  override begin(): void {
     this.root.appendChild(this.createElement('begin'));
     this.lastX = 0;
     this.lastY = 0;
@@ -767,7 +768,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
    * @param x Number that represents the x-coordinate of the point.
    * @param y Number that represents the y-coordinate of the point.
    */
-  moveTo(x: number, y: number): void {
+  override moveTo(x: number, y: number): void {
     const elem = this.createElement('move');
     elem.setAttribute('x', String(this.format(x)));
     elem.setAttribute('y', String(this.format(y)));
@@ -782,7 +783,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
    * @param x Number that represents the x-coordinate of the endpoint.
    * @param y Number that represents the y-coordinate of the endpoint.
    */
-  lineTo(x: number, y: number): void {
+  override lineTo(x: number, y: number): void {
     const elem = this.createElement('line');
     elem.setAttribute('x', String(this.format(x)));
     elem.setAttribute('y', String(this.format(y)));
@@ -799,7 +800,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
    * @param x2 Number that represents the x-coordinate of the endpoint.
    * @param y2 Number that represents the y-coordinate of the endpoint.
    */
-  quadTo(x1: number, y1: number, x2: number, y2: number): void {
+  override quadTo(x1: number, y1: number, x2: number, y2: number): void {
     const elem = this.createElement('quad');
     elem.setAttribute('x1', String(this.format(x1)));
     elem.setAttribute('y1', String(this.format(y1)));
@@ -820,7 +821,14 @@ class XmlCanvas2D extends AbstractCanvas2D {
    * @param x3 Number that represents the x-coordinate of the endpoint.
    * @param y3 Number that represents the y-coordinate of the endpoint.
    */
-  curveTo(x1: number, y1: number, x2: number, y2: number, x3: number, y3: number): void {
+  override curveTo(
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    x3: number,
+    y3: number
+  ): void {
     const elem = this.createElement('curve');
     elem.setAttribute('x1', String(this.format(x1)));
     elem.setAttribute('y1', String(this.format(y1)));
@@ -836,7 +844,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
   /**
    * Closes the current path.
    */
-  close(): void {
+  override close(): void {
     this.root.appendChild(this.createElement('close'));
   }
 

--- a/packages/core/src/view/cell/CellOverlay.ts
+++ b/packages/core/src/view/cell/CellOverlay.ts
@@ -215,7 +215,7 @@ class CellOverlay extends EventSource implements ObjectIdentity {
    *
    * This implementation returns {@link tooltip}.
    */
-  toString(): string | null | undefined {
+  override toString(): string | null | undefined {
     return this.tooltip;
   }
 }

--- a/packages/core/src/view/cell/CellState.ts
+++ b/packages/core/src/view/cell/CellState.ts
@@ -335,9 +335,6 @@ class CellState extends Rectangle {
     this.unscaledHeight = state.unscaledHeight;
   }
 
-  /**
-   * Returns a clone of this {@link Point}.
-   */
   override clone() {
     const clone = new CellState(this.view, this.cell, this.style);
 

--- a/packages/core/src/view/cell/CellState.ts
+++ b/packages/core/src/view/cell/CellState.ts
@@ -338,7 +338,7 @@ class CellState extends Rectangle {
   /**
    * Returns a clone of this {@link Point}.
    */
-  clone() {
+  override clone() {
     const clone = new CellState(this.view, this.cell, this.style);
 
     // Clones the absolute points

--- a/packages/core/src/view/cell/CellTracker.ts
+++ b/packages/core/src/view/cell/CellTracker.ts
@@ -111,7 +111,7 @@ class CellTracker extends CellMarker implements MouseListenerSet {
    * Destroys the object and all its resources and DOM nodes. This doesn't normally need to be called.
    * It is called automatically when the window unloads.
    */
-  destroy() {
+  override destroy() {
     if (!this.destroyed) {
       this.destroyed = true;
 

--- a/packages/core/src/view/geometry/Geometry.ts
+++ b/packages/core/src/view/geometry/Geometry.ts
@@ -342,7 +342,7 @@ class Geometry extends Rectangle {
   /**
    * Returns true if the given object equals this geometry.
    */
-  equals(geom: Geometry | null) {
+  override equals(geom: Geometry | null) {
     if (!geom) return false;
 
     return (
@@ -360,7 +360,7 @@ class Geometry extends Rectangle {
     );
   }
 
-  clone() {
+  override clone() {
     return clone(this) as Geometry;
   }
 }

--- a/packages/core/src/view/geometry/Rectangle.ts
+++ b/packages/core/src/view/geometry/Rectangle.ts
@@ -163,7 +163,7 @@ class Rectangle extends Point {
   /**
    * Returns true if the given object equals this rectangle.
    */
-  equals(rect: Rectangle | null) {
+  override equals(rect: Rectangle | null) {
     if (!rect) return false;
 
     return (
@@ -174,7 +174,7 @@ class Rectangle extends Point {
     );
   }
 
-  clone() {
+  override clone() {
     return new Rectangle(this.x, this.y, this.width, this.height);
   }
 }

--- a/packages/core/src/view/handler/EdgeHandler.ts
+++ b/packages/core/src/view/handler/EdgeHandler.ts
@@ -2270,7 +2270,7 @@ class EdgeHandlerCellMarker extends CellMarker {
   }
   // Only returns edges if they are connectable and never returns
   // the edge that is currently being modified
-  getCell = (me: InternalMouseEvent) => {
+  override getCell = (me: InternalMouseEvent) => {
     let cell = super.getCell(me);
 
     // Checks for cell at preview point (with grid)
@@ -2319,7 +2319,7 @@ class EdgeHandlerCellMarker extends CellMarker {
   };
 
   // Sets the highlight color according to validateConnection
-  isValidState = (state: CellState) => {
+  override isValidState = (state: CellState) => {
     const cell = this.edgeHandler.state.cell.getTerminal(
       !this.edgeHandler.isSource
     ) as Cell;

--- a/packages/core/src/view/handler/EdgeSegmentHandler.ts
+++ b/packages/core/src/view/handler/EdgeSegmentHandler.ts
@@ -31,7 +31,7 @@ class EdgeSegmentHandler extends ElbowEdgeHandler {
     super(state);
   }
 
-  points: Point[] = [];
+  override points: Point[] = [];
 
   /**
    * Returns the current absolute points.
@@ -63,7 +63,7 @@ class EdgeSegmentHandler extends ElbowEdgeHandler {
   /**
    * Updates the given preview state taking into account the state of the constraint handler.
    */
-  getPreviewPoints(point: Point) {
+  override getPreviewPoints(point: Point) {
     if (this.isSource || this.isTarget) {
       return super.getPreviewPoints(point);
     }
@@ -118,7 +118,7 @@ class EdgeSegmentHandler extends ElbowEdgeHandler {
   /**
    * Overridden to perform optimization of the edge style result.
    */
-  updatePreviewState(
+  override updatePreviewState(
     edge: CellState,
     point: Point,
     terminalState: CellState,
@@ -221,7 +221,7 @@ class EdgeSegmentHandler extends ElbowEdgeHandler {
   /**
    * Overriden to merge edge segments.
    */
-  connect(
+  override connect(
     edge: Cell,
     terminal: Cell,
     isSource: boolean,
@@ -278,14 +278,14 @@ class EdgeSegmentHandler extends ElbowEdgeHandler {
   /**
    * Returns no tooltips.
    */
-  getTooltipForNode(node: Element): string | null {
+  override getTooltipForNode(node: Element): string | null {
     return null;
   }
 
   /**
    * Adds custom bends for the center of each segment.
    */
-  start(x: number, y: number, index: number) {
+  override start(x: number, y: number, index: number) {
     super.start(x, y, index);
 
     if (
@@ -301,7 +301,7 @@ class EdgeSegmentHandler extends ElbowEdgeHandler {
   /**
    * Adds custom bends for the center of each segment.
    */
-  createBends() {
+  override createBends() {
     const bends = [];
 
     // Source
@@ -345,7 +345,7 @@ class EdgeSegmentHandler extends ElbowEdgeHandler {
   /**
    * Overridden to invoke <refresh> before the redraw.
    */
-  redraw() {
+  override redraw() {
     this.refresh();
     super.redraw();
   }
@@ -353,7 +353,7 @@ class EdgeSegmentHandler extends ElbowEdgeHandler {
   /**
    * Updates the position of the custom bends.
    */
-  redrawInnerBends(p0: Point, pe: Point) {
+  override redrawInnerBends(p0: Point, pe: Point) {
     if (this.graph.isCellBendable(this.state.cell)) {
       const pts = this.getCurrentPoints();
 

--- a/packages/core/src/view/handler/ElbowEdgeHandler.ts
+++ b/packages/core/src/view/handler/ElbowEdgeHandler.ts
@@ -60,7 +60,7 @@ class ElbowEdgeHandler extends EdgeHandler {
   /**
    * Overrides {@link EdgeHandler.createBends} to create custom bends.
    */
-  createBends() {
+  override createBends() {
     const bends = [];
 
     // Source
@@ -142,7 +142,7 @@ class ElbowEdgeHandler extends EdgeHandler {
    * @param point {@link Point} to be converted.
    * @param gridEnabled Boolean that specifies if the grid should be applied.
    */
-  convertPoint(point: Point, gridEnabled: boolean) {
+  override convertPoint(point: Point, gridEnabled: boolean) {
     const scale = this.graph.getView().getScale();
     const tr = this.graph.getView().getTranslate();
     const { origin } = this.state;
@@ -164,7 +164,7 @@ class ElbowEdgeHandler extends EdgeHandler {
    * @param p0 {@link Point} that represents the location of the first point.
    * @param pe {@link Point} that represents the location of the last point.
    */
-  redrawInnerBends(p0: Point, pe: Point) {
+  override redrawInnerBends(p0: Point, pe: Point) {
     const g = this.state.cell.getGeometry();
     const pts = this.state.absolutePoints;
     let pt = null;

--- a/packages/core/src/view/layout/CircleLayout.ts
+++ b/packages/core/src/view/layout/CircleLayout.ts
@@ -84,7 +84,7 @@ class CircleLayout extends GraphLayout {
   /**
    * Implements {@link GraphLayout#execute}.
    */
-  execute(parent: Cell) {
+  override execute(parent: Cell) {
     // Moves the vertices to build a circle. Makes sure the
     // radius is large enough for the vertices to not
     // overlap

--- a/packages/core/src/view/layout/CompactTreeLayout.ts
+++ b/packages/core/src/view/layout/CompactTreeLayout.ts
@@ -234,7 +234,7 @@ export class CompactTreeLayout extends GraphLayout {
    *
    * @param vertex {@link Cell} whose ignored state should be returned.
    */
-  isVertexIgnored(vertex: Cell): boolean {
+  override isVertexIgnored(vertex: Cell): boolean {
     return super.isVertexIgnored(vertex) || vertex.getConnections().length === 0;
   }
 
@@ -249,13 +249,13 @@ export class CompactTreeLayout extends GraphLayout {
    * Implements {@link GraphLayout.execute}.
    *
    * If the parent has any connected edges, then it is used as the root of
-   * the tree. Else, {@link mxGraph.findTreeRoots} will be used to find a suitable
+   * the tree. Else, {@link findTreeRoots} will be used to find a suitable
    * root node within the set of children of the given parent.
    *
    * @param parent  {@link Cell} whose children should be laid out.
    * @param root    Optional {@link Cell} that will be used as the root of the tree. Overrides {@link root} if specified.
    */
-  execute(parent: Cell, root?: Cell): void {
+  override execute(parent: Cell, root?: Cell): void {
     this.parent = parent;
     const model = this.graph.getDataModel();
 

--- a/packages/core/src/view/layout/CompositeLayout.ts
+++ b/packages/core/src/view/layout/CompositeLayout.ts
@@ -66,7 +66,7 @@ class CompositeLayout extends GraphLayout {
   /**
    * Calls `move` on {@link master} or the first layout in {@link layouts}.
    */
-  moveCell(cell: Cell, x: number, y: number) {
+  override moveCell(cell: Cell, x: number, y: number) {
     if (this.master != null) {
       this.master.moveCell.apply(this.master, [cell, x, y]);
     } else {
@@ -77,7 +77,7 @@ class CompositeLayout extends GraphLayout {
   /**
    * Implements {@link GraphLayout#execute} by executing all {@link layouts} in a single transaction.
    */
-  execute(parent: Cell): void {
+  override execute(parent: Cell): void {
     this.graph.batchUpdate(() => {
       for (let i = 0; i < this.layouts.length; i += 1) {
         this.layouts[i].execute.apply(this.layouts[i], [parent]);

--- a/packages/core/src/view/layout/EdgeLabelLayout.ts
+++ b/packages/core/src/view/layout/EdgeLabelLayout.ts
@@ -46,7 +46,7 @@ class EdgeLabelLayout extends GraphLayout {
   /**
    * Implements {@link GraphLayout.execute}
    */
-  execute(parent: Cell): void {
+  override execute(parent: Cell): void {
     const { view } = this.graph;
     const model = this.graph.getDataModel();
 

--- a/packages/core/src/view/layout/FastOrganicLayout.ts
+++ b/packages/core/src/view/layout/FastOrganicLayout.ts
@@ -157,7 +157,7 @@ class FastOrganicLayout extends GraphLayout {
    *
    * @param vertex <Cell> whose ignored state should be returned.
    */
-  isVertexIgnored(vertex: Cell) {
+  override isVertexIgnored(vertex: Cell) {
     return (
       super.isVertexIgnored(vertex) || this.graph.getConnections(vertex).length === 0
     );
@@ -167,7 +167,7 @@ class FastOrganicLayout extends GraphLayout {
    * Implements {@link GraphLayout#execute}. This operates on all children of the
    * given parent where <isVertexIgnored> returns false.
    */
-  execute(parent: Cell) {
+  override execute(parent: Cell) {
     this.vertexArray = [];
     let cells = this.graph.getChildVertices(parent);
 

--- a/packages/core/src/view/layout/HierarchicalLayout.ts
+++ b/packages/core/src/view/layout/HierarchicalLayout.ts
@@ -177,7 +177,7 @@ class HierarchicalLayout extends GraphLayout {
    * @param parent Parent <Cell> that contains the children to be laid out.
    * @param roots Optional starting roots of the layout.
    */
-  execute(parent: Cell, roots: Cell[] | Cell | null = null): void {
+  override execute(parent: Cell, roots: Cell[] | Cell | null = null): void {
     this.parent = parent;
     this.edgesCache = new Map();
     this.edgeSourceTermCache = new Map();
@@ -592,7 +592,7 @@ class HierarchicalLayout extends GraphLayout {
    * null for the first step of the traversal.
    * @param allVertices Array of cell paths for the visited cells.
    */
-  traverse({
+  override traverse({
     vertex,
     directed,
     allVertices,

--- a/packages/core/src/view/layout/ParallelEdgeLayout.ts
+++ b/packages/core/src/view/layout/ParallelEdgeLayout.ts
@@ -78,9 +78,9 @@ class ParallelEdgeLayout extends GraphLayout {
   checkOverlap = false;
 
   /**
-   * Implements {@link GraphLayout#execute}.
+   * Implements {@link GraphLayout.execute}.
    */
-  execute(parent: Cell, cells: Cell[] | null = null): void {
+  override execute(parent: Cell, cells: Cell[] | null = null): void {
     const lookup = this.findParallels(parent, cells);
 
     this.graph.batchUpdate(() => {

--- a/packages/core/src/view/layout/PartitionLayout.ts
+++ b/packages/core/src/view/layout/PartitionLayout.ts
@@ -77,7 +77,7 @@ class PartitionLayout extends GraphLayout {
     return this.horizontal;
   }
 
-  moveCell(cell: Cell, x: number, y: number): void {
+  override moveCell(cell: Cell, x: number, y: number): void {
     const model = this.graph.getDataModel();
     const parent = cell.getParent();
 
@@ -115,7 +115,7 @@ class PartitionLayout extends GraphLayout {
    * Implements {@link GraphLayout#execute}. All children where <isVertexIgnored>
    * returns false and <isVertexMovable> returns true are modified.
    */
-  execute(parent: Cell): void {
+  override execute(parent: Cell): void {
     const horizontal = this.isHorizontal();
     const model = this.graph.getDataModel();
     let pgeo = <Rectangle>parent.getGeometry();

--- a/packages/core/src/view/layout/RadialTreeLayout.ts
+++ b/packages/core/src/view/layout/RadialTreeLayout.ts
@@ -66,13 +66,13 @@ class RadialTreeLayout extends CompactTreeLayout {
    * Holds the levelDistance.
    * @default 120
    */
-  levelDistance = 120;
+  override levelDistance = 120;
 
   /**
    * Holds the nodeDistance.
    * @default 10
    */
-  nodeDistance = 10;
+  override nodeDistance = 10;
 
   /**
    * Specifies if the radios should be computed automatically
@@ -85,7 +85,7 @@ class RadialTreeLayout extends CompactTreeLayout {
    * opposite terminal cell in the model.
    * @default false
    */
-  sortEdges = false;
+  override sortEdges = false;
 
   /**
    * Array of leftmost x coordinate of each row
@@ -123,7 +123,7 @@ class RadialTreeLayout extends CompactTreeLayout {
    * @param vertex {@link Cell} whose ignored state should be returned.
    * @return true if the cell has no connections.
    */
-  isVertexIgnored(vertex: Cell): boolean {
+  override isVertexIgnored(vertex: Cell): boolean {
     return (
       super.isVertexIgnored(vertex) || this.graph.getConnections(vertex).length === 0
     );
@@ -139,7 +139,7 @@ class RadialTreeLayout extends CompactTreeLayout {
    * @param parent    {@link Cell} whose children should be laid out.
    * @param root      Optional {@link Cell} that will be used as the root of the tree.
    */
-  execute(parent: Cell, root: Cell | null = null): void {
+  override execute(parent: Cell, root: Cell | null = null): void {
     this.parent = parent;
 
     this.useBoundingBox = false;

--- a/packages/core/src/view/layout/StackLayout.ts
+++ b/packages/core/src/view/layout/StackLayout.ts
@@ -152,7 +152,7 @@ class StackLayout extends GraphLayout {
   /**
    * Implements mxGraphLayout.moveCell.
    */
-  moveCell(cell: Cell, x: number, y: number): void {
+  override moveCell(cell: Cell, x: number, y: number): void {
     const model = this.graph.getDataModel();
     const parent = cell.getParent();
     const horizontal = this.isHorizontal();
@@ -275,7 +275,7 @@ class StackLayout extends GraphLayout {
   /**
    * Implements mxGraphLayout.execute.
    */
-  execute(parent: Cell): void {
+  override execute(parent: Cell): void {
     if (parent != null) {
       const pgeo = this.getParentSize(parent);
       const horizontal = this.isHorizontal();

--- a/packages/core/src/view/layout/SwimlaneLayout.ts
+++ b/packages/core/src/view/layout/SwimlaneLayout.ts
@@ -189,7 +189,7 @@ class SwimlaneLayout extends GraphLayout {
    * @param parent Parent <Cell> that contains the children to be laid out.
    * @param swimlanes Ordered array of swimlanes to be laid out
    */
-  execute(parent: Cell, swimlanes: Cell[] | null = null): void {
+  override execute(parent: Cell, swimlanes: Cell[] | null = null): void {
     this.parent = parent;
     const { model } = this.graph;
     this.edgesCache = new Map();
@@ -719,7 +719,7 @@ class SwimlaneLayout extends GraphLayout {
    * @param allVertices Array of cell paths for the visited cells.
    * @param swimlaneIndex the laid out order index of the swimlane vertex is contained in
    */
-  traverse({
+  override traverse({
     vertex,
     directed,
     allVertices,

--- a/packages/core/src/view/layout/datatypes/GraphAbstractHierarchyCell.ts
+++ b/packages/core/src/view/layout/datatypes/GraphAbstractHierarchyCell.ts
@@ -100,14 +100,14 @@ abstract class GraphAbstractHierarchyCell extends Cell {
   /**
    * Returns whether or not this cell is an edge
    */
-  isEdge() {
+  override isEdge() {
     return false;
   }
 
   /**
    * Returns whether or not this cell is a node
    */
-  isVertex() {
+  override isVertex() {
     return false;
   }
 

--- a/packages/core/src/view/layout/datatypes/GraphHierarchyEdge.ts
+++ b/packages/core/src/view/layout/datatypes/GraphHierarchyEdge.ts
@@ -31,7 +31,7 @@ class GraphHierarchyEdge extends GraphAbstractHierarchyCell {
    * The graph edge(s) this object represents. Parallel edges are all grouped
    * together within one hierarchy edge.
    */
-  edges: Cell[];
+  override edges: Cell[];
 
   /**
    * The object identities of the wrapped cells
@@ -41,12 +41,12 @@ class GraphHierarchyEdge extends GraphAbstractHierarchyCell {
   /**
    * The node this edge is sourced at
    */
-  source: GraphHierarchyNode | null = null;
+  override source: GraphHierarchyNode | null = null;
 
   /**
    * The node this edge targets
    */
-  target: GraphHierarchyNode | null = null;
+  override target: GraphHierarchyNode | null = null;
 
   /**
    * Whether or not the direction of this edge has been reversed
@@ -82,7 +82,7 @@ class GraphHierarchyEdge extends GraphAbstractHierarchyCell {
   /**
    * Returns the cells this cell connects to on the next layer up
    */
-  getNextLayerConnectedCells(layer: number): GraphAbstractHierarchyCell[] {
+  override getNextLayerConnectedCells(layer: number): GraphAbstractHierarchyCell[] {
     if (this.nextLayerConnectedCells == null) {
       this.nextLayerConnectedCells = [];
 
@@ -102,7 +102,7 @@ class GraphHierarchyEdge extends GraphAbstractHierarchyCell {
   /**
    * Returns the cells this cell connects to on the next layer down
    */
-  getPreviousLayerConnectedCells(layer: number) {
+  override getPreviousLayerConnectedCells(layer: number) {
     if (this.previousLayerConnectedCells == null) {
       this.previousLayerConnectedCells = [];
 
@@ -124,7 +124,7 @@ class GraphHierarchyEdge extends GraphAbstractHierarchyCell {
   /**
    * Returns true.
    */
-  isEdge() {
+  override isEdge() {
     return true;
   }
 

--- a/packages/core/src/view/layout/datatypes/GraphHierarchyNode.ts
+++ b/packages/core/src/view/layout/datatypes/GraphHierarchyNode.ts
@@ -53,7 +53,7 @@ class GraphHierarchyNode extends GraphAbstractHierarchyCell {
   /**
    * The object identity of the wrapped cell
    */
-  id: string;
+  override id: string;
 
   /**
    * Collection of hierarchy edges that have this node as a target
@@ -130,7 +130,7 @@ class GraphHierarchyNode extends GraphAbstractHierarchyCell {
   /**
    * Returns true.
    */
-  isVertex(): boolean {
+  override isVertex(): boolean {
     return true;
   }
 
@@ -148,7 +148,7 @@ class GraphHierarchyNode extends GraphAbstractHierarchyCell {
     this.temp[0] = value;
   }
 
-  isAncestor(otherNode: GraphHierarchyNode): boolean {
+  override isAncestor(otherNode: GraphHierarchyNode): boolean {
     // Firstly, the hash code of this node needs to be shorter than the
     // other node
     if (

--- a/packages/core/src/view/plugins/ConnectionHandler.ts
+++ b/packages/core/src/view/plugins/ConnectionHandler.ts
@@ -2020,7 +2020,7 @@ export default class ConnectionHandler
 export class ConnectionHandlerCellMarker extends CellMarker {
   connectionHandler: ConnectionHandler;
 
-  hotspotEnabled = true;
+  override hotspotEnabled = true;
 
   constructor(
     graph: AbstractGraph,
@@ -2035,7 +2035,7 @@ export class ConnectionHandlerCellMarker extends CellMarker {
 
   // Overrides to return cell at location only if valid (so that
   // there is no highlight for invalid cells)
-  getCell(me: InternalMouseEvent) {
+  override getCell(me: InternalMouseEvent) {
     let cell = super.getCell(me);
     this.connectionHandler.error = null;
 
@@ -2106,7 +2106,7 @@ export class ConnectionHandlerCellMarker extends CellMarker {
   }
 
   // Sets the highlight color according to validateConnection
-  isValidState(state: CellState) {
+  override isValidState(state: CellState) {
     if (this.connectionHandler.isConnecting()) {
       return !this.connectionHandler.error;
     }
@@ -2115,7 +2115,7 @@ export class ConnectionHandlerCellMarker extends CellMarker {
 
   // Overrides to use marker color only in highlight mode or for
   // target selection
-  getMarkerColor(evt: Event, state: CellState, isValid: boolean) {
+  override getMarkerColor(evt: Event, state: CellState, isValid: boolean) {
     return !this.connectionHandler.connectImage || this.connectionHandler.isConnecting()
       ? super.getMarkerColor(evt, state, isValid)
       : NONE;
@@ -2123,7 +2123,7 @@ export class ConnectionHandlerCellMarker extends CellMarker {
 
   // Overrides to use hotspot only for source selection otherwise
   // intersects always returns true when over a cell
-  intersects(state: CellState, evt: InternalMouseEvent) {
+  override intersects(state: CellState, evt: InternalMouseEvent) {
     if (this.connectionHandler.connectImage || this.connectionHandler.isConnecting()) {
       return true;
     }

--- a/packages/core/src/view/shape/edge/ArrowConnectorShape.ts
+++ b/packages/core/src/view/shape/edge/ArrowConnectorShape.ts
@@ -62,19 +62,19 @@ class ArrowConnectorShape extends Shape {
    * Allows to use the SVG bounding box in SVG.
    * @defaultValue `false` for performance reasons.
    */
-  useSvgBoundingBox = true;
+  override useSvgBoundingBox = true;
 
   /**
    * Hook for subclassers.
    */
-  isRoundable() {
+  override isRoundable() {
     return true;
   }
 
   /**
    * Overrides mxShape to reset spacing.
    */
-  resetStyles() {
+  override resetStyles() {
     super.resetStyles();
     this.arrowSpacing = ARROW_SPACING;
   }
@@ -82,7 +82,7 @@ class ArrowConnectorShape extends Shape {
   /**
    * Overrides apply to get smooth transition from default start- and endsize.
    */
-  apply(state: CellState): void {
+  override apply(state: CellState): void {
     super.apply(state);
 
     if (this.style && this.style.startSize != null && this.style.endSize != null) {
@@ -94,7 +94,7 @@ class ArrowConnectorShape extends Shape {
   /**
    * Augments the bounding box with the edge width and markers.
    */
-  augmentBoundingBox(bbox: Rectangle): void {
+  override augmentBoundingBox(bbox: Rectangle): void {
     super.augmentBoundingBox(bbox);
 
     let w = this.getEdgeWidth();
@@ -113,7 +113,7 @@ class ArrowConnectorShape extends Shape {
   /**
    * Paints the line shape.
    */
-  paintEdgeShape(c: AbstractCanvas2D, pts: Point[]): void {
+  override paintEdgeShape(c: AbstractCanvas2D, pts: Point[]): void {
     // Geometry of arrow
     let strokeWidth = this.strokeWidth;
 

--- a/packages/core/src/view/shape/edge/ArrowShape.ts
+++ b/packages/core/src/view/shape/edge/ArrowShape.ts
@@ -57,7 +57,7 @@ class ArrowShape extends Shape {
   /**
    * Augments the bounding box with the edge width and markers.
    */
-  augmentBoundingBox(bbox: Rectangle) {
+  override augmentBoundingBox(bbox: Rectangle) {
     super.augmentBoundingBox(bbox);
 
     const w = Math.max(this.arrowWidth, this.endSize);
@@ -67,7 +67,7 @@ class ArrowShape extends Shape {
   /**
    * Paints the line shape.
    */
-  paintEdgeShape(c: AbstractCanvas2D, pts: Point[]) {
+  override paintEdgeShape(c: AbstractCanvas2D, pts: Point[]) {
     // Geometry of arrow
     const spacing = ARROW_SPACING;
     const width = ARROW_WIDTH;

--- a/packages/core/src/view/shape/edge/ConnectorShape.ts
+++ b/packages/core/src/view/shape/edge/ConnectorShape.ts
@@ -43,7 +43,7 @@ class ConnectorShape extends PolylineShape {
    * Updates the {@link boundingBox} for this shape using {@link createBoundingBox}
    * and {@link augmentBoundingBox} and stores the result in {@link boundingBox}.
    */
-  updateBoundingBox() {
+  override updateBoundingBox() {
     this.useSvgBoundingBox = this.style?.curved ?? false;
     super.updateBoundingBox();
   }
@@ -51,7 +51,7 @@ class ConnectorShape extends PolylineShape {
   /**
    * Paints the line shape.
    */
-  paintEdgeShape(c: AbstractCanvas2D, pts: Point[]): void {
+  override paintEdgeShape(c: AbstractCanvas2D, pts: Point[]): void {
     // The indirection via functions for markers is needed in
     // order to apply the offsets before painting the line and
     // paint the markers after painting the line.
@@ -141,7 +141,7 @@ class ConnectorShape extends PolylineShape {
   /**
    * Augments the bounding box with the strokewidth and shadow offsets.
    */
-  augmentBoundingBox(bbox: Rectangle) {
+  override augmentBoundingBox(bbox: Rectangle) {
     super.augmentBoundingBox(bbox);
 
     if (!this.style) return;

--- a/packages/core/src/view/shape/edge/LineShape.ts
+++ b/packages/core/src/view/shape/edge/LineShape.ts
@@ -52,7 +52,13 @@ class LineShape extends Shape {
    * @param {number} w
    * @param {number} h
    */
-  paintVertexShape(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
+  override paintVertexShape(
+    c: AbstractCanvas2D,
+    x: number,
+    y: number,
+    w: number,
+    h: number
+  ) {
     c.begin();
 
     if (this.vertical) {

--- a/packages/core/src/view/shape/edge/PolylineShape.ts
+++ b/packages/core/src/view/shape/edge/PolylineShape.ts
@@ -48,28 +48,28 @@ class PolylineShape extends Shape {
   /**
    * Returns 0.
    */
-  getRotation() {
+  override getRotation() {
     return 0;
   }
 
   /**
    * Returns 0.
    */
-  getShapeRotation() {
+  override getShapeRotation() {
     return 0;
   }
 
   /**
    * Returns false.
    */
-  isPaintBoundsInverted() {
+  override isPaintBoundsInverted() {
     return false;
   }
 
   /**
    * Paints the line shape.
    */
-  paintEdgeShape(c: AbstractCanvas2D, pts: Point[]) {
+  override paintEdgeShape(c: AbstractCanvas2D, pts: Point[]) {
     const prev = c.pointerEventsValue;
     c.pointerEventsValue = 'stroke';
 

--- a/packages/core/src/view/shape/node/ActorShape.ts
+++ b/packages/core/src/view/shape/node/ActorShape.ts
@@ -60,7 +60,13 @@ class ActorShape extends Shape {
   /**
    * Redirects to redrawPath for subclasses to work.
    */
-  paintVertexShape(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
+  override paintVertexShape(
+    c: AbstractCanvas2D,
+    x: number,
+    y: number,
+    w: number,
+    h: number
+  ) {
     c.translate(x, y);
     c.begin();
     this.redrawPath(c, x, y, w, h);

--- a/packages/core/src/view/shape/node/CloudShape.ts
+++ b/packages/core/src/view/shape/node/CloudShape.ts
@@ -39,7 +39,7 @@ class CloudShape extends ActorShape {
   /**
    * Draws the path for this shape.
    */
-  redrawPath(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
+  override redrawPath(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
     c.moveTo(0.25 * w, 0.25 * h);
     c.curveTo(0.05 * w, 0.25 * h, 0, 0.5 * h, 0.16 * w, 0.55 * h);
     c.curveTo(0, 0.66 * h, 0.18 * w, 0.9 * h, 0.31 * w, 0.8 * h);

--- a/packages/core/src/view/shape/node/CylinderShape.ts
+++ b/packages/core/src/view/shape/node/CylinderShape.ts
@@ -47,12 +47,18 @@ class CylinderShape extends Shape {
   /**
    * Sets stroke tolerance to 0 for SVG.
    */
-  svgStrokeTolerance = 0;
+  override svgStrokeTolerance = 0;
 
   /**
    * Redirects to redrawPath for subclasses to work.
    */
-  paintVertexShape(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
+  override paintVertexShape(
+    c: AbstractCanvas2D,
+    x: number,
+    y: number,
+    w: number,
+    h: number
+  ) {
     c.translate(x, y);
     c.begin();
     this.redrawPath(c, x, y, w, h, false);

--- a/packages/core/src/view/shape/node/DoubleEllipseShape.ts
+++ b/packages/core/src/view/shape/node/DoubleEllipseShape.ts
@@ -63,7 +63,13 @@ class DoubleEllipseShape extends Shape {
   /**
    * Paints the background.
    */
-  paintBackground(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
+  override paintBackground(
+    c: AbstractCanvas2D,
+    x: number,
+    y: number,
+    w: number,
+    h: number
+  ) {
     c.ellipse(x, y, w, h);
     c.fillAndStroke();
   }
@@ -71,7 +77,13 @@ class DoubleEllipseShape extends Shape {
   /**
    * Paints the foreground.
    */
-  paintForeground(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
+  override paintForeground(
+    c: AbstractCanvas2D,
+    x: number,
+    y: number,
+    w: number,
+    h: number
+  ) {
     if (!this.outline) {
       const margin =
         this.style?.margin ?? Math.min(3 + this.strokeWidth, Math.min(w / 5, h / 5));
@@ -93,7 +105,7 @@ class DoubleEllipseShape extends Shape {
   /**
    * @returns the bounds for the label.
    */
-  getLabelBounds(rect: Rectangle) {
+  override getLabelBounds(rect: Rectangle) {
     const margin =
       this.style?.margin ??
       Math.min(

--- a/packages/core/src/view/shape/node/EllipseShape.ts
+++ b/packages/core/src/view/shape/node/EllipseShape.ts
@@ -39,7 +39,13 @@ class EllipseShape extends Shape {
   /**
    * Paints the ellipse shape.
    */
-  paintVertexShape(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
+  override paintVertexShape(
+    c: AbstractCanvas2D,
+    x: number,
+    y: number,
+    w: number,
+    h: number
+  ) {
     c.ellipse(x, y, w, h);
     c.fillAndStroke();
   }

--- a/packages/core/src/view/shape/node/HexagonShape.ts
+++ b/packages/core/src/view/shape/node/HexagonShape.ts
@@ -35,7 +35,7 @@ class HexagonShape extends ActorShape {
   /**
    * Draws the path for this shape.
    */
-  redrawPath(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
+  override redrawPath(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
     const arcSize = this.getBaseArcSize();
 
     this.addPoints(

--- a/packages/core/src/view/shape/node/ImageShape.ts
+++ b/packages/core/src/view/shape/node/ImageShape.ts
@@ -77,10 +77,6 @@ class ImageShape extends RectangleShape {
     }
   }
 
-  /**
-   * Returns true if HTML is allowed for this shape. This implementation always
-   * returns false.
-   */
   override isHtmlAllowed() {
     return !this.preserveImageAspect;
   }

--- a/packages/core/src/view/shape/node/ImageShape.ts
+++ b/packages/core/src/view/shape/node/ImageShape.ts
@@ -51,7 +51,7 @@ class ImageShape extends RectangleShape {
   /**
    * Disables offset in IE9 for crisper image output.
    */
-  getSvgScreenOffset() {
+  override getSvgScreenOffset() {
     return 0;
   }
 
@@ -65,7 +65,7 @@ class ImageShape extends RectangleShape {
    *
    * @param {CellState} state   {@link CellState} of the corresponding cell.
    */
-  apply(state: CellState) {
+  override apply(state: CellState) {
     super.apply(state);
 
     this.fill = NONE;
@@ -81,21 +81,27 @@ class ImageShape extends RectangleShape {
    * Returns true if HTML is allowed for this shape. This implementation always
    * returns false.
    */
-  isHtmlAllowed() {
+  override isHtmlAllowed() {
     return !this.preserveImageAspect;
   }
 
   /**
    * Disables inherited roundable support.
    */
-  isRoundable(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
+  override isRoundable(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
     return false;
   }
 
   /**
    * Generic background painting implementation.
    */
-  paintVertexShape(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
+  override paintVertexShape(
+    c: AbstractCanvas2D,
+    x: number,
+    y: number,
+    w: number,
+    h: number
+  ) {
     if (this.imageSrc) {
       const fill = this.style?.imageBackground ?? NONE;
       const stroke = this.style?.imageBorder ?? NONE;

--- a/packages/core/src/view/shape/node/LabelShape.ts
+++ b/packages/core/src/view/shape/node/LabelShape.ts
@@ -53,14 +53,14 @@ class LabelShape extends RectangleShape {
    */
   imageSize = DEFAULT_IMAGESIZE;
 
-  imageSrc: string | null = null;
+  override imageSrc: string | null = null;
 
   /**
    * Default value for image spacing
    * @type {number}
    * @default 2
    */
-  spacing = 2;
+  override spacing = 2;
 
   /**
    * Default width and height for the indicicator.
@@ -76,12 +76,12 @@ class LabelShape extends RectangleShape {
    */
   indicatorSpacing = 2;
 
-  indicatorImageSrc: string | null = null;
+  override indicatorImageSrc: string | null = null;
 
   /**
    * Initializes the shape and the <indicator>.
    */
-  init(container: SVGElement) {
+  override init(container: SVGElement) {
     super.init(container);
 
     if (this.indicatorShape) {
@@ -95,7 +95,7 @@ class LabelShape extends RectangleShape {
    * Reconfigures this shape. This will update the colors of the indicator
    * and reconfigure it if required.
    */
-  redraw() {
+  override redraw() {
     if (this.indicator) {
       this.indicator.fill = this.indicatorColor;
       this.indicator.stroke = this.indicatorStrokeColor;
@@ -110,7 +110,7 @@ class LabelShape extends RectangleShape {
    * Returns true for non-rounded, non-rotated shapes with no glass gradient and
    * no indicator shape.
    */
-  isHtmlAllowed() {
+  override isHtmlAllowed() {
     return super.isHtmlAllowed() && this.indicatorColor === NONE && !!this.indicatorShape;
   }
 
@@ -122,7 +122,13 @@ class LabelShape extends RectangleShape {
    * @param {number} w
    * @param {number} h
    */
-  paintForeground(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
+  override paintForeground(
+    c: AbstractCanvas2D,
+    x: number,
+    y: number,
+    w: number,
+    h: number
+  ) {
     this.paintImage(c, x, y, w, h);
     this.paintIndicator(c, x, y, w, h);
     super.paintForeground(c, x, y, w, h);
@@ -253,7 +259,7 @@ class LabelShape extends RectangleShape {
   /**
    * Generic background painting implementation.
    */
-  redrawHtmlShape() {
+  override redrawHtmlShape() {
     super.redrawHtmlShape();
 
     // Removes all children

--- a/packages/core/src/view/shape/node/RectangleShape.ts
+++ b/packages/core/src/view/shape/node/RectangleShape.ts
@@ -41,7 +41,7 @@ class RectangleShape extends Shape {
   /**
    * Returns true for non-rounded, non-rotated shapes with no glass gradient.
    */
-  isHtmlAllowed() {
+  override isHtmlAllowed() {
     let events = true;
 
     if (this.style && this.style.pointerEvents != null) {
@@ -59,7 +59,13 @@ class RectangleShape extends Shape {
   /**
    * Generic background painting implementation.
    */
-  paintBackground(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
+  override paintBackground(
+    c: AbstractCanvas2D,
+    x: number,
+    y: number,
+    w: number,
+    h: number
+  ) {
     let events = true;
 
     if (this.style && this.style.pointerEvents != null) {
@@ -85,14 +91,20 @@ class RectangleShape extends Shape {
   /**
    * Adds roundable support.
    */
-  isRoundable(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
+  override isRoundable(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
     return true;
   }
 
   /**
    * Generic background painting implementation.
    */
-  paintForeground(c: AbstractCanvas2D, x: number, y: number, w: number, h: number): void {
+  override paintForeground(
+    c: AbstractCanvas2D,
+    x: number,
+    y: number,
+    w: number,
+    h: number
+  ): void {
     if (this.glass && !this.outline && this.fill !== NONE) {
       this.paintGlassEffect(
         c,

--- a/packages/core/src/view/shape/node/RhombusShape.ts
+++ b/packages/core/src/view/shape/node/RhombusShape.ts
@@ -41,7 +41,7 @@ class RhombusShape extends Shape {
    * Adds roundable support.
    */
   // isRoundable(): boolean;
-  isRoundable(): boolean {
+  override isRoundable(): boolean {
     return true;
   }
 
@@ -53,7 +53,13 @@ class RhombusShape extends Shape {
    * @param {number} w
    * @param {number} h
    */
-  paintVertexShape(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
+  override paintVertexShape(
+    c: AbstractCanvas2D,
+    x: number,
+    y: number,
+    w: number,
+    h: number
+  ) {
     const hw = w / 2;
     const hh = h / 2;
 

--- a/packages/core/src/view/shape/node/SwimlaneShape.ts
+++ b/packages/core/src/view/shape/node/SwimlaneShape.ts
@@ -55,12 +55,12 @@ class SwimlaneShape extends Shape {
    */
   imageSize = 16;
 
-  imageSrc: string | null = null;
+  override imageSrc: string | null = null;
 
   /**
    * Adds roundable support.
    */
-  isRoundable(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
+  override isRoundable(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
     return true;
   }
 
@@ -74,7 +74,7 @@ class SwimlaneShape extends Shape {
   /**
    * Returns the bounding box for the gradient box for this shape.
    */
-  getLabelBounds(rect: Rectangle) {
+  override getLabelBounds(rect: Rectangle) {
     const start = this.getTitleSize();
     const bounds = new Rectangle(rect.x, rect.y, rect.width, rect.height);
     const horizontal = this.isHorizontal();
@@ -118,7 +118,13 @@ class SwimlaneShape extends Shape {
   /**
    * Returns the bounding box for the gradient box for this shape.
    */
-  getGradientBounds(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
+  override getGradientBounds(
+    c: AbstractCanvas2D,
+    x: number,
+    y: number,
+    w: number,
+    h: number
+  ) {
     let start = this.getTitleSize();
 
     if (this.isHorizontal()) {
@@ -150,7 +156,13 @@ class SwimlaneShape extends Shape {
   /**
    * Paints the swimlane vertex shape.
    */
-  paintVertexShape(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
+  override paintVertexShape(
+    c: AbstractCanvas2D,
+    x: number,
+    y: number,
+    w: number,
+    h: number
+  ) {
     let start = this.getTitleSize();
     const fill = this.style?.swimlaneFillColor ?? NONE;
     const swimlaneLine = this.style?.swimlaneLine ?? true;

--- a/packages/core/src/view/shape/node/TextShape.ts
+++ b/packages/core/src/view/shape/node/TextShape.ts
@@ -116,14 +116,14 @@ class TextShape extends Shape {
   }
 
   value: string | HTMLElement | SVGGElement;
-  bounds: Rectangle;
+  override bounds: Rectangle;
   align: AlignValue;
   valign: VAlignValue;
   color: ColorValue;
   family: string;
   size: number;
   fontStyle: number;
-  spacing: number;
+  override spacing: number;
   spacingTop: number;
   spacingRight: number;
   spacingBottom: number;
@@ -138,8 +138,8 @@ class TextShape extends Shape {
   textDirection: TextDirectionValue;
   margin: Point | null = null;
   unrotatedBoundingBox: Rectangle | null = null;
-  flipH = false;
-  flipV = false;
+  override flipH = false;
+  override flipV = false;
 
   /**
    * Specifies the spacing to be added to the top spacing. Default is 0. Use the
@@ -172,7 +172,7 @@ class TextShape extends Shape {
   /**
    * Rotation for vertical text. Default is -90 (bottom to top).
    */
-  verticalTextRotation = -90;
+  override verticalTextRotation = -90;
 
   /**
    * Specifies if the string size should be measured in <updateBoundingBox> if
@@ -202,14 +202,14 @@ class TextShape extends Shape {
   /**
    * Disables offset in IE9 for crisper image output.
    */
-  getSvgScreenOffset() {
+  override getSvgScreenOffset() {
     return 0;
   }
 
   /**
    * Returns true if the bounds are not null and all of its variables are numeric.
    */
-  checkBounds() {
+  override checkBounds() {
     return (
       !isNaN(this.scale) &&
       isFinite(this.scale) &&
@@ -225,7 +225,7 @@ class TextShape extends Shape {
   /**
    * Generic rendering code.
    */
-  paint(c: AbstractCanvas2D, update = false): void {
+  override paint(c: AbstractCanvas2D, update = false): void {
     // Scale is passed-through to canvas
     const s = this.scale;
     const x = this.bounds.x / s;
@@ -304,7 +304,7 @@ class TextShape extends Shape {
   /**
    * Renders the text using the given DOM nodes.
    */
-  redraw(): void {
+  override redraw(): void {
     if (
       this.visible &&
       this.checkBounds() &&
@@ -341,7 +341,7 @@ class TextShape extends Shape {
   /**
    * Resets all styles.
    */
-  resetStyles(): void {
+  override resetStyles(): void {
     super.resetStyles();
 
     this.color = 'black';
@@ -367,7 +367,7 @@ class TextShape extends Shape {
    *
    * @param state <CellState> of the corresponding cell.
    */
-  apply(state: CellState): void {
+  override apply(state: CellState): void {
     const old = this.spacing;
     super.apply(state);
 
@@ -441,7 +441,7 @@ class TextShape extends Shape {
   /**
    * Updates the <boundingBox> for this shape using the given node and position.
    */
-  updateBoundingBox() {
+  override updateBoundingBox() {
     let { node } = this;
     this.boundingBox = this.bounds.clone();
     const rot = this.getTextRotation();
@@ -536,14 +536,14 @@ class TextShape extends Shape {
   /**
    * Returns 0 to avoid using rotation in the canvas via updateTransform.
    */
-  getShapeRotation() {
+  override getShapeRotation() {
     return 0;
   }
 
   /**
    * Returns the rotation for the text label of the corresponding shape.
    */
-  getTextRotation() {
+  override getTextRotation() {
     return this.state && this.state.shape ? this.state.shape.getTextRotation() : 0;
   }
 
@@ -551,14 +551,20 @@ class TextShape extends Shape {
    * Inverts the bounds if {@link Shape#isBoundsInverted} returns true or if the
    * horizontal style is false.
    */
-  isPaintBoundsInverted() {
+  override isPaintBoundsInverted() {
     return !this.horizontal && !!this.state && this.state.cell.isVertex();
   }
 
   /**
    * Sets the state of the canvas for drawing the shape.
    */
-  configureCanvas(c: AbstractCanvas2D, x: number, y: number, w: number, h: number): void {
+  override configureCanvas(
+    c: AbstractCanvas2D,
+    x: number,
+    y: number,
+    w: number,
+    h: number
+  ): void {
     super.configureCanvas(c, x, y, w, h);
 
     c.setFontColor(this.color);
@@ -616,7 +622,7 @@ class TextShape extends Shape {
   /**
    * Updates the HTML node(s) to reflect the latest bounds and scale.
    */
-  redrawHtmlShape() {
+  override redrawHtmlShape() {
     const w = Math.max(0, Math.round(this.bounds.width / this.scale));
     const h = Math.max(0, Math.round(this.bounds.height / this.scale));
     const flex =

--- a/packages/core/src/view/shape/node/TriangleShape.ts
+++ b/packages/core/src/view/shape/node/TriangleShape.ts
@@ -36,14 +36,14 @@ class TriangleShape extends ActorShape {
    * Adds roundable support.
    * @returns {boolean}
    */
-  isRoundable() {
+  override isRoundable() {
     return true;
   }
 
   /**
    * Draws the path for this shape.
    */
-  redrawPath(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
+  override redrawPath(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
     const arcSize = this.getBaseArcSize();
 
     this.addPoints(

--- a/packages/core/src/view/style/edge/EdgeStyleRegistry.ts
+++ b/packages/core/src/view/style/edge/EdgeStyleRegistry.ts
@@ -33,7 +33,11 @@ class EdgeStyleRegistryImpl
   private readonly handlerMapping = new Map<EdgeStyleFunction, EdgeStyleHandlerKind>();
   private readonly orthogonalStates = new Map<EdgeStyleFunction, boolean>();
 
-  add(name: string, edgeStyle: EdgeStyleFunction, metaData?: EdgeStyleMetaData): void {
+  override add(
+    name: string,
+    edgeStyle: EdgeStyleFunction,
+    metaData?: EdgeStyleMetaData
+  ): void {
     super.add(name, edgeStyle);
     metaData?.handlerKind && this.handlerMapping.set(edgeStyle, metaData.handlerKind);
     !isNullish(metaData?.isOrthogonal) &&
@@ -48,7 +52,7 @@ class EdgeStyleRegistryImpl
     return this.handlerMapping.get(edgeStyle!) ?? 'default';
   }
 
-  clear(): void {
+  override clear(): void {
     super.clear();
     this.handlerMapping.clear();
     this.orthogonalStates.clear();

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -10,8 +10,6 @@
     "strict": true,
     "skipLibCheck": false,
     "forceConsistentCasingInFileNames": true,
-    // Do not enable for now, as we want maxGraph to support TS 3.8 and this feature requires TS 4.3+
-    "noImplicitOverride": false,
   },
   "include": ["src/**/*.ts"],
   "typedocOptions": {


### PR DESCRIPTION
Easily detect when super methods are removed in the "core" package.
Already in place in other packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Marked many internal methods and properties as explicit overrides to improve type safety and inheritance correctness; no user-facing behavior changes.
- Chores
  - Removed a redundant compiler option and an unnecessary test import to tidy build/typing configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->