### PR TITLE
chore: measure size of examples in v0.1.0 to v0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41528,7 +41528,7 @@
     "packages/js-example": {
       "name": "@maxgraph/js-example-webpack",
       "dependencies": {
-        "@maxgraph/core": "0.4.0"
+        "@maxgraph/core": "0.5.0"
       },
       "devDependencies": {
         "copy-webpack-plugin": "~13.0.1",
@@ -41678,9 +41678,9 @@
       }
     },
     "packages/js-example/node_modules/@maxgraph/core": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@maxgraph/core/-/core-0.4.0.tgz",
-      "integrity": "sha512-fBFS+zg4g+39yuetsxOkB5t6w0HPBmFET2jCmRuH2fIehAlfbntjsBlTvOCVc59zx07yLSdWycblFpRcRYdH/w==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@maxgraph/core/-/core-0.5.0.tgz",
+      "integrity": "sha512-6B5npGv2JBTbwvR0mt4AR5u7bNvPH1IG9QZ+FacOVy76kfs9NMxMFMTusXz0rSKYsZq9SF/T3Vs5cIb70KZi5Q==",
       "license": "Apache-2.0"
     },
     "packages/js-example/node_modules/css-loader": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41528,7 +41528,7 @@
     "packages/js-example": {
       "name": "@maxgraph/js-example-webpack",
       "dependencies": {
-        "@maxgraph/core": "0.5.0"
+        "@maxgraph/core": "0.6.0"
       },
       "devDependencies": {
         "copy-webpack-plugin": "~13.0.1",
@@ -41678,9 +41678,9 @@
       }
     },
     "packages/js-example/node_modules/@maxgraph/core": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@maxgraph/core/-/core-0.5.0.tgz",
-      "integrity": "sha512-6B5npGv2JBTbwvR0mt4AR5u7bNvPH1IG9QZ+FacOVy76kfs9NMxMFMTusXz0rSKYsZq9SF/T3Vs5cIb70KZi5Q==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@maxgraph/core/-/core-0.6.0.tgz",
+      "integrity": "sha512-DvuTgcYgtaqqLoXLKGEVqt/AXl3ggVk/0nTpnbduJgvv9VM89rcWHVHIjYcbHdsZPhKYPHbAYEW6Ay7cexsDfw==",
       "license": "Apache-2.0"
     },
     "packages/js-example/node_modules/css-loader": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41527,6 +41527,9 @@
     },
     "packages/js-example": {
       "name": "@maxgraph/js-example-webpack",
+      "dependencies": {
+        "@maxgraph/core": "0.1.0"
+      },
       "devDependencies": {
         "copy-webpack-plugin": "~13.0.1",
         "css-loader": "~7.1.2",
@@ -41674,6 +41677,12 @@
         "node": ">=10"
       }
     },
+    "packages/js-example/node_modules/@maxgraph/core": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@maxgraph/core/-/core-0.1.0.tgz",
+      "integrity": "sha512-EYg0o4j8J27+m0a4xCiDYOsjlt+XuZQ+Q1G5ocsUBIduiJPKDsLWnqNWh2MqG40js+U/DrSXY5qtO9DvQVPKIQ==",
+      "license": "Apache-2.0"
+    },
     "packages/js-example/node_modules/css-loader": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.2.tgz",
@@ -41746,6 +41755,9 @@
     "packages/ts-example": {
       "name": "@maxgraph/ts-example-vite-custom-shapes",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@maxgraph/core": "0.1.0"
+      },
       "devDependencies": {
         "vite": "~6.3.5"
       }
@@ -43269,6 +43281,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "packages/ts-example/node_modules/@maxgraph/core": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@maxgraph/core/-/core-0.1.0.tgz",
+      "integrity": "sha512-EYg0o4j8J27+m0a4xCiDYOsjlt+XuZQ+Q1G5ocsUBIduiJPKDsLWnqNWh2MqG40js+U/DrSXY5qtO9DvQVPKIQ==",
+      "license": "Apache-2.0"
     },
     "packages/ts-example/node_modules/esbuild": {
       "version": "0.25.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41528,7 +41528,7 @@
     "packages/js-example": {
       "name": "@maxgraph/js-example-webpack",
       "dependencies": {
-        "@maxgraph/core": "0.1.0"
+        "@maxgraph/core": "0.2.0"
       },
       "devDependencies": {
         "copy-webpack-plugin": "~13.0.1",
@@ -41678,9 +41678,9 @@
       }
     },
     "packages/js-example/node_modules/@maxgraph/core": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@maxgraph/core/-/core-0.1.0.tgz",
-      "integrity": "sha512-EYg0o4j8J27+m0a4xCiDYOsjlt+XuZQ+Q1G5ocsUBIduiJPKDsLWnqNWh2MqG40js+U/DrSXY5qtO9DvQVPKIQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@maxgraph/core/-/core-0.2.0.tgz",
+      "integrity": "sha512-Q9KbTQegv3Rjyv3Bi1Tg4q3oCp2z/Ct7mYTDQF5qf1qjqAdvEeZH5wDxHiVO8MdFCPd7c/SnrYxwQyhSpXqJmg==",
       "license": "Apache-2.0"
     },
     "packages/js-example/node_modules/css-loader": {
@@ -41756,7 +41756,7 @@
       "name": "@maxgraph/ts-example-vite-custom-shapes",
       "license": "Apache-2.0",
       "dependencies": {
-        "@maxgraph/core": "0.1.0"
+        "@maxgraph/core": "0.2.0"
       },
       "devDependencies": {
         "vite": "~6.3.5"
@@ -43283,9 +43283,9 @@
       }
     },
     "packages/ts-example/node_modules/@maxgraph/core": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@maxgraph/core/-/core-0.1.0.tgz",
-      "integrity": "sha512-EYg0o4j8J27+m0a4xCiDYOsjlt+XuZQ+Q1G5ocsUBIduiJPKDsLWnqNWh2MqG40js+U/DrSXY5qtO9DvQVPKIQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@maxgraph/core/-/core-0.2.0.tgz",
+      "integrity": "sha512-Q9KbTQegv3Rjyv3Bi1Tg4q3oCp2z/Ct7mYTDQF5qf1qjqAdvEeZH5wDxHiVO8MdFCPd7c/SnrYxwQyhSpXqJmg==",
       "license": "Apache-2.0"
     },
     "packages/ts-example/node_modules/esbuild": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41528,7 +41528,7 @@
     "packages/js-example": {
       "name": "@maxgraph/js-example-webpack",
       "dependencies": {
-        "@maxgraph/core": "0.3.0"
+        "@maxgraph/core": "0.4.0"
       },
       "devDependencies": {
         "copy-webpack-plugin": "~13.0.1",
@@ -41678,9 +41678,9 @@
       }
     },
     "packages/js-example/node_modules/@maxgraph/core": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@maxgraph/core/-/core-0.3.0.tgz",
-      "integrity": "sha512-KRoB7eSd1Md9NFWjkUyUODPnE1LBLGLQ0KGO0RCsOD5Bf1vkC01+I873yvDqYWmfYk0vk2wWlp41m0pEsg9HzA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@maxgraph/core/-/core-0.4.0.tgz",
+      "integrity": "sha512-fBFS+zg4g+39yuetsxOkB5t6w0HPBmFET2jCmRuH2fIehAlfbntjsBlTvOCVc59zx07yLSdWycblFpRcRYdH/w==",
       "license": "Apache-2.0"
     },
     "packages/js-example/node_modules/css-loader": {
@@ -41756,7 +41756,7 @@
       "name": "@maxgraph/ts-example-vite-custom-shapes",
       "license": "Apache-2.0",
       "dependencies": {
-        "@maxgraph/core": "0.3.0"
+        "@maxgraph/core": "0.4.0"
       },
       "devDependencies": {
         "vite": "~6.3.5"
@@ -43283,9 +43283,9 @@
       }
     },
     "packages/ts-example/node_modules/@maxgraph/core": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@maxgraph/core/-/core-0.3.0.tgz",
-      "integrity": "sha512-KRoB7eSd1Md9NFWjkUyUODPnE1LBLGLQ0KGO0RCsOD5Bf1vkC01+I873yvDqYWmfYk0vk2wWlp41m0pEsg9HzA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@maxgraph/core/-/core-0.4.0.tgz",
+      "integrity": "sha512-fBFS+zg4g+39yuetsxOkB5t6w0HPBmFET2jCmRuH2fIehAlfbntjsBlTvOCVc59zx07yLSdWycblFpRcRYdH/w==",
       "license": "Apache-2.0"
     },
     "packages/ts-example/node_modules/esbuild": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41528,7 +41528,7 @@
     "packages/js-example": {
       "name": "@maxgraph/js-example-webpack",
       "dependencies": {
-        "@maxgraph/core": "0.2.0"
+        "@maxgraph/core": "0.3.0"
       },
       "devDependencies": {
         "copy-webpack-plugin": "~13.0.1",
@@ -41678,9 +41678,9 @@
       }
     },
     "packages/js-example/node_modules/@maxgraph/core": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@maxgraph/core/-/core-0.2.0.tgz",
-      "integrity": "sha512-Q9KbTQegv3Rjyv3Bi1Tg4q3oCp2z/Ct7mYTDQF5qf1qjqAdvEeZH5wDxHiVO8MdFCPd7c/SnrYxwQyhSpXqJmg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@maxgraph/core/-/core-0.3.0.tgz",
+      "integrity": "sha512-KRoB7eSd1Md9NFWjkUyUODPnE1LBLGLQ0KGO0RCsOD5Bf1vkC01+I873yvDqYWmfYk0vk2wWlp41m0pEsg9HzA==",
       "license": "Apache-2.0"
     },
     "packages/js-example/node_modules/css-loader": {
@@ -41756,7 +41756,7 @@
       "name": "@maxgraph/ts-example-vite-custom-shapes",
       "license": "Apache-2.0",
       "dependencies": {
-        "@maxgraph/core": "0.2.0"
+        "@maxgraph/core": "0.3.0"
       },
       "devDependencies": {
         "vite": "~6.3.5"
@@ -43283,9 +43283,9 @@
       }
     },
     "packages/ts-example/node_modules/@maxgraph/core": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@maxgraph/core/-/core-0.2.0.tgz",
-      "integrity": "sha512-Q9KbTQegv3Rjyv3Bi1Tg4q3oCp2z/Ct7mYTDQF5qf1qjqAdvEeZH5wDxHiVO8MdFCPd7c/SnrYxwQyhSpXqJmg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@maxgraph/core/-/core-0.3.0.tgz",
+      "integrity": "sha512-KRoB7eSd1Md9NFWjkUyUODPnE1LBLGLQ0KGO0RCsOD5Bf1vkC01+I873yvDqYWmfYk0vk2wWlp41m0pEsg9HzA==",
       "license": "Apache-2.0"
     },
     "packages/ts-example/node_modules/esbuild": {

--- a/packages/js-example/package.json
+++ b/packages/js-example/package.json
@@ -7,7 +7,7 @@
     "preview": "http-server -c-1 dist"
   },
   "dependencies": {
-    "@maxgraph/core": "0.5.0"
+    "@maxgraph/core": "0.6.0"
   },
   "devDependencies": {
     "copy-webpack-plugin": "~13.0.1",

--- a/packages/js-example/package.json
+++ b/packages/js-example/package.json
@@ -7,7 +7,7 @@
     "preview": "http-server -c-1 dist"
   },
   "dependencies": {
-    "@maxgraph/core": "0.2.0"
+    "@maxgraph/core": "0.3.0"
   },
   "devDependencies": {
     "copy-webpack-plugin": "~13.0.1",

--- a/packages/js-example/package.json
+++ b/packages/js-example/package.json
@@ -7,7 +7,7 @@
     "preview": "http-server -c-1 dist"
   },
   "dependencies": {
-    "@maxgraph/core": "0.1.0"
+    "@maxgraph/core": "0.2.0"
   },
   "devDependencies": {
     "copy-webpack-plugin": "~13.0.1",

--- a/packages/js-example/package.json
+++ b/packages/js-example/package.json
@@ -7,7 +7,7 @@
     "preview": "http-server -c-1 dist"
   },
   "dependencies": {
-    "@maxgraph/core": "0.3.0"
+    "@maxgraph/core": "0.4.0"
   },
   "devDependencies": {
     "copy-webpack-plugin": "~13.0.1",

--- a/packages/js-example/package.json
+++ b/packages/js-example/package.json
@@ -6,6 +6,9 @@
     "build": "webpack --mode=production",
     "preview": "http-server -c-1 dist"
   },
+  "dependencies": {
+    "@maxgraph/core": "0.1.0"
+  },
   "devDependencies": {
     "copy-webpack-plugin": "~13.0.1",
     "css-loader": "~7.1.2",

--- a/packages/js-example/package.json
+++ b/packages/js-example/package.json
@@ -7,7 +7,7 @@
     "preview": "http-server -c-1 dist"
   },
   "dependencies": {
-    "@maxgraph/core": "0.4.0"
+    "@maxgraph/core": "0.5.0"
   },
   "devDependencies": {
     "copy-webpack-plugin": "~13.0.1",

--- a/packages/js-example/src/index.js
+++ b/packages/js-example/src/index.js
@@ -14,16 +14,42 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import '@maxgraph/core/css/common.css'; // required by RubberBandHandler
+// not available in v0.1.0
+// import '@maxgraph/core/css/common.css'; // required by RubberBandHandler
 import './style.css';
 import {
-  constants,
-  getDefaultPlugins,
+  // constants,
+  Client,
+  Codec,
+  // getDefaultPlugins,
   Graph,
   InternalEvent,
-  ModelXmlSerializer,
+  // ModelExportOptions,
+  // ModelXmlSerializer,
+  // registerModelCodecs,
   RubberBandHandler,
+  xmlUtils,
 } from '@maxgraph/core';
+
+// not available in v0.1.0,
+export class ModelXmlSerializer {
+  constructor(dataModel) {
+    this.dataModel = dataModel;
+  }
+
+  import(input) {
+    const doc =
+      typeof input === 'string' ? xmlUtils.parseXml(input) : input.ownerDocument;
+    new Codec(doc).decode(doc.documentElement, this.dataModel);
+  }
+
+  export(options) {
+    const encodedNode = new Codec().encode(this.dataModel);
+    return (options?.pretty ?? true)
+      ? xmlUtils.getPrettyXml(encodedNode)
+      : xmlUtils.getXml(encodedNode);
+  }
+}
 
 const xmlWithVerticesAndEdges = `<GraphDataModel>
     <root>
@@ -59,10 +85,12 @@ const initializeGraph = (container) => {
   // Disables the built-in context menu
   InternalEvent.disableContextMenu(container);
 
-  const graph = new Graph(container, undefined, [
-    ...getDefaultPlugins(),
-    RubberBandHandler, // Enables rubber band selection
-  ]);
+  // const graph = new Graph(container, undefined, [
+  //   ...getDefaultPlugins(),
+  //   RubberBandHandler, // Enables rubber band selection
+  // ]);
+  const graph = new Graph(container);
+  new RubberBandHandler(graph); // Enables rubber band selection
   graph.setPanning(true); // Use mouse right button for panning
 
   const modelXmlSerializer = new ModelXmlSerializer(graph.model);
@@ -73,7 +101,7 @@ const initializeGraph = (container) => {
 
 // display the maxGraph version in the footer
 const footer = document.querySelector('footer');
-footer.innerText = `Built with maxGraph ${constants.VERSION}`;
+footer.innerText = `Built with maxGraph ${Client.VERSION}`;
 
 // Creates the graph inside the given container
 const container = document.querySelector('#graph-container');

--- a/packages/ts-example/package.json
+++ b/packages/ts-example/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@maxgraph/core": "0.1.0"
+    "@maxgraph/core": "0.2.0"
   },
   "devDependencies": {
     "vite": "~6.3.5"

--- a/packages/ts-example/package.json
+++ b/packages/ts-example/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@maxgraph/core": "0.2.0"
+    "@maxgraph/core": "0.3.0"
   },
   "devDependencies": {
     "vite": "~6.3.5"

--- a/packages/ts-example/package.json
+++ b/packages/ts-example/package.json
@@ -8,6 +8,9 @@
     "build": "tsc --version && tsc && vite build --base ./",
     "preview": "vite preview"
   },
+  "dependencies": {
+    "@maxgraph/core": "0.1.0"
+  },
   "devDependencies": {
     "vite": "~6.3.5"
   }

--- a/packages/ts-example/package.json
+++ b/packages/ts-example/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@maxgraph/core": "0.3.0"
+    "@maxgraph/core": "0.4.0"
   },
   "devDependencies": {
     "vite": "~6.3.5"

--- a/packages/ts-example/src/custom-shapes.ts
+++ b/packages/ts-example/src/custom-shapes.ts
@@ -15,11 +15,18 @@ limitations under the License.
 */
 
 import type { AbstractCanvas2D, ColorValue, Rectangle } from '@maxgraph/core';
-import { EllipseShape, RectangleShape, ShapeRegistry } from '@maxgraph/core';
+import { CellRenderer, EllipseShape, RectangleShape } from '@maxgraph/core';
 
 export const registerCustomShapes = (): void => {
-  ShapeRegistry.add('customRectangle', CustomRectangleShape);
-  ShapeRegistry.add('customEllipse', CustomEllipseShape);
+  // ShapeRegistry.add('customRectangle', CustomRectangleShape);
+  // ShapeRegistry.add('customEllipse', CustomEllipseShape);
+
+  // console.info('Registering custom shapes...');
+  // @ts-ignore TODO fix CellRenderer. Calls to this function are also marked as 'ts-ignore' in CellRenderer
+  CellRenderer.registerShape('customRectangle', CustomRectangleShape);
+  // @ts-ignore
+  CellRenderer.registerShape('customEllipse', CustomEllipseShape);
+  // console.info('Custom shapes registered');
 };
 
 class CustomRectangleShape extends RectangleShape {

--- a/packages/ts-example/src/main.ts
+++ b/packages/ts-example/src/main.ts
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import '@maxgraph/core/css/common.css'; // required by RubberBandHandler
+// not available in v0.1.0
+// import '@maxgraph/core/css/common.css'; // required by RubberBandHandler
 import './style.css';
 import {
-  constants,
-  type FitPlugin,
-  getDefaultPlugins,
+  Client,
+  // type FitPlugin,
+  // getDefaultPlugins,
   Graph,
   InternalEvent,
   Perimeter,
@@ -31,10 +32,12 @@ const initializeGraph = (container: HTMLElement) => {
   // Disables the built-in context menu
   InternalEvent.disableContextMenu(container);
 
-  const graph = new Graph(container, undefined, [
-    ...getDefaultPlugins(),
-    RubberBandHandler, // Enables rubber band selection
-  ]);
+  // const graph = new Graph(container, undefined, [
+  //   ...getDefaultPlugins(),
+  //   RubberBandHandler, // Enables rubber band selection
+  // ]);
+  const graph = new Graph(container);
+  new RubberBandHandler(graph); // Enables rubber band selection
   graph.setPanning(true); // Use mouse right button for panning
 
   // shapes and styles
@@ -103,7 +106,7 @@ const initializeGraph = (container: HTMLElement) => {
 
 // display the maxGraph version in the footer
 const footer = document.querySelector('footer')!;
-footer.innerText = `Built with maxGraph ${constants.VERSION}`;
+footer.innerText = `Built with maxGraph ${Client.VERSION}`;
 
 // Creates the graph inside the given container
 const graph = initializeGraph(document.querySelector('#graph-container')!);
@@ -113,5 +116,7 @@ document.getElementById('reset-zoom')!.addEventListener('click', () => {
   graph.zoomActual();
 });
 document.getElementById('fit-center')!.addEventListener('click', () => {
-  graph.getPlugin<FitPlugin>('fit')?.fitCenter({ margin: 20 });
+  console.warn('Fit center is not available in v0.1.0');
+  // Do not exist in v0.1.0
+  //graph.getPlugin<FitPlugin>('fit')?.fitCenter({ margin: 20 });
 });


### PR DESCRIPTION
The examples were added in later versions. Adapt the examples to get their size for comparison with later versions.
The js-example does not work because in these versions, Codecs had a lot of issues.

The meseasure for version 0.5.0 and 0.6.0 is only required for js-example. Real values are already available for ts-example which was introduced in 0.5.0.

Values are in `kB`.

version | js-example | ts-example
---- | ---- | ----
0.1.0 | 676.79 | 561.89
0.2.0 | 676.71 | 561.84
0.3.0 | 676.79 | 561.43
0.4.0 | 682.21 | 568.18
0.5.0 | 682.5 | - 
0.6.0 | 681.45| -

### Notes

For investigation only, this PR is not intended to be merged.