### PR TITLE
chore(deps-gha): bump actions/setup-node from v4 to v6

### DIFF
--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -10,7 +10,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version-file: '.nvmrc'
         registry-url: ${{ inputs.registry-url }}


### PR DESCRIPTION
Update the build-setup action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environment setup for improved compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->