### PR TITLE
feat: make default style properties globally configurable

### DIFF
--- a/packages/core/src/util/Constants.ts
+++ b/packages/core/src/util/Constants.ts
@@ -144,8 +144,8 @@ export const INVALID_CONNECT_TARGET_COLOR = '#FF0000';
 export const DROP_TARGET_COLOR = '#0000FF';
 
 /**
- * Defines the color to be used for the coloring valid connection
- * previews. Use 'none' for no color. Default is #FF0000.
+ * Defines the color to be used for the coloring valid connection previews or other valid elements.
+ * Use 'none' for no color. Default is #FF0000.
  */
 export const VALID_COLOR = '#00FF00';
 
@@ -258,19 +258,18 @@ export const OUTLINE_HANDLE_FILLCOLOR = '#00FFFF';
 export const OUTLINE_HANDLE_STROKECOLOR = '#0033FF';
 
 /**
- * Defines the default family for all fonts. Default is Arial,Helvetica.
+ * Default value of {@link StyleDefaultsConfig.fontFamily}.
  */
 export const DEFAULT_FONTFAMILY = 'Arial,Helvetica,sans-serif';
 
 /**
- * Defines the default size (in px). Default is 11.
+ * Default value of {@link StyleDefaultsConfig.fontSize}.
  */
 export const DEFAULT_FONTSIZE = 11;
 
 /**
- * Defines the default value for the <STYLE_TEXT_DIRECTION> if no value is
- * defined for it in the style. Default value is an empty string which means
- * the default system setting is used and no direction is set.
+ * Defines the default value for the {@link CellStateStyle.textDirection} if no value is defined for it in the style.
+ * Default value is an empty string which means the default system setting is used and no direction is set.
  */
 export const DEFAULT_TEXT_DIRECTION = '';
 
@@ -303,18 +302,17 @@ export const ABSOLUTE_LINE_HEIGHT = false;
 export const DEFAULT_FONTSTYLE = 0;
 
 /**
- * Defines the default start size for swimlanes. Default is 40.
+ * Default value of {@link StyleDefaultsConfig.startSize}.
  */
 export const DEFAULT_STARTSIZE = 40;
 
 /**
- * Defines the default size for all markers. Default is 6.
+ * Default value of {@link StyleDefaultsConfig.markerSize}.
  */
 export const DEFAULT_MARKERSIZE = 6;
 
 /**
- * Defines the default width and height for images used in the
- * label shape. Default is 24.
+ * Default value of {@link StyleDefaultsConfig.imageSize}.
  */
 export const DEFAULT_IMAGESIZE = 24;
 
@@ -324,30 +322,27 @@ export const DEFAULT_IMAGESIZE = 24;
 export const ENTITY_SEGMENT = 30;
 
 /**
- * Defines the default rounding factor for the rounded vertices in percent between `0` and `1`.
- * Values should be smaller than `0.5`.
- * See {@link CellStateStyle.arcSize}.
+ * Default value of {@link StyleDefaultsConfig.roundingFactor}.
  */
 export const RECTANGLE_ROUNDING_FACTOR = 0.15;
 
 /**
- * Defines the default size in pixels of the arcs for the rounded edges and vertices.
- * See {@link CellStateStyle.arcSize}.
+ * Default value of {@link StyleDefaultsConfig.lineArcSize}.
  */
 export const LINE_ARCSIZE = 20;
 
 /**
- * Defines the spacing between the arrow shape and its terminals. Default is 0.
+ * Default value of {@link StyleDefaultsConfig.arrowSpacing}.
  */
 export const ARROW_SPACING = 0;
 
 /**
- * Defines the width of the arrow shape. Default is 30.
+ * Default value of {@link StyleDefaultsConfig.arrowWidth}.
  */
 export const ARROW_WIDTH = 30;
 
 /**
- * Defines the size of the arrowhead in the arrow shape. Default is 30.
+ * Default value of {@link StyleDefaultsConfig.arrowSize}.
  */
 export const ARROW_SIZE = 30;
 

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -17,6 +17,16 @@ limitations under the License.
 import type { I18nProvider, Logger } from '../types.js';
 import { NoOpLogger } from './logger.js';
 import {
+  ARROW_SIZE,
+  ARROW_SPACING,
+  ARROW_WIDTH,
+  DEFAULT_FONTFAMILY,
+  DEFAULT_FONTSIZE,
+  DEFAULT_IMAGESIZE,
+  DEFAULT_MARKERSIZE,
+  DEFAULT_STARTSIZE,
+  LINE_ARCSIZE,
+  RECTANGLE_ROUNDING_FACTOR,
   SHADOW_OFFSET_X,
   SHADOW_OFFSET_Y,
   SHADOW_OPACITY,
@@ -81,6 +91,63 @@ export const GlobalConfig = {
  */
 export const StyleDefaultsConfig = {
   /**
+   * Defines the size (in px) of the arrowhead in the arrow shape.
+   * @default {@link ARROW_SIZE}
+   * @since 0.22.0
+   */
+  arrowSize: ARROW_SIZE,
+  /**
+   * Defines the spacing (in px) between the arrow shape and its terminals.
+   * @default {@link ARROW_SPACING}
+   * @since 0.22.0
+   */
+  arrowSpacing: ARROW_SPACING,
+  /**
+   * Defines the width (in px) of the arrow shape.
+   * @default {@link ARROW_WIDTH}
+   * @since 0.22.0
+   */
+  arrowWidth: ARROW_WIDTH,
+  /**
+   * Defines the default family for all fonts.
+   * @default {@link DEFAULT_FONTFAMILY}
+   * @since 0.22.0
+   */
+  fontFamily: DEFAULT_FONTFAMILY,
+  /**
+   * Defines the default size (in px).
+   * @default {@link DEFAULT_FONTSIZE}
+   * @since 0.22.0
+   */
+  fontSize: DEFAULT_FONTSIZE,
+  /**
+   * Defines the default width and height (in px) for images used in the label shape.
+   * @default {@link DEFAULT_IMAGESIZE}
+   * @since 0.22.0
+   */
+  imageSize: DEFAULT_IMAGESIZE,
+  /**
+   * Defines the default size (in px) of the arcs for the rounded edges.
+   * See {@link CellStateStyle.arcSize}.
+   * @default {@link LINE_ARCSIZE}
+   * @since 0.22.0
+   */
+  lineArcSize: LINE_ARCSIZE,
+  /**
+   * Defines the default size (in px) for all markers.
+   * @default {@link DEFAULT_MARKERSIZE}
+   * @since 0.22.0
+   */
+  markerSize: DEFAULT_MARKERSIZE,
+  /**
+   * Defines the default rounding factor for the rounded vertices in percent between `0` and `1`.
+   * Values should be smaller than `0.5`.
+   * See {@link CellStateStyle.arcSize}.
+   * @default {@link RECTANGLE_ROUNDING_FACTOR}
+   * @since 0.22.0
+   */
+  roundingFactor: RECTANGLE_ROUNDING_FACTOR,
+  /**
    * Defines the color to be used to draw shadows in shapes and windows.
    * @default {@link SHADOWCOLOR}
    */
@@ -100,6 +167,12 @@ export const StyleDefaultsConfig = {
    * @default {@link SHADOW_OPACITY}
    */
   shadowOpacity: SHADOW_OPACITY,
+  /**
+   * Defines the default start size (in px) for swimlanes.
+   * @default {@link DEFAULT_STARTSIZE}
+   * @since 0.22.0
+   */
+  startSize: DEFAULT_STARTSIZE,
 };
 
 const defaultStyleDefaultsConfig = { ...StyleDefaultsConfig };

--- a/packages/core/src/util/styleUtils.ts
+++ b/packages/core/src/util/styleUtils.ts
@@ -17,12 +17,7 @@ limitations under the License.
 */
 
 import Client from '../Client.js';
-import {
-  DEFAULT_FONTFAMILY,
-  DEFAULT_FONTSIZE,
-  FONT_STYLE_MASK,
-  LINE_HEIGHT,
-} from './Constants.js';
+import { FONT_STYLE_MASK, LINE_HEIGHT } from './Constants.js';
 import Point from '../view/geometry/Point.js';
 import CellPath from '../view/cell/CellPath.js';
 import Rectangle from '../view/geometry/Rectangle.js';
@@ -36,6 +31,7 @@ import type {
   VAlignValue,
 } from '../types.js';
 import { matchBinaryMask } from '../internal/utils.js';
+import { StyleDefaultsConfig } from './config.js';
 
 /**
  * Removes the cursors from the style of the given DOM node and its descendants.
@@ -445,15 +441,15 @@ export const setOpacity = (node: HTMLElement | SVGElement, value: number) => {
  * ```
  *
  * @param text String whose size should be returned.
- * @param fontSize Integer that specifies the font size in pixels. Default is {@link DEFAULT_FONTSIZE}.
- * @param fontFamily String that specifies the name of the font family. Default is {@link DEFAULT_FONTFAMILY}.
+ * @param fontSize Integer that specifies the font size in pixels. Default is {@link StyleDefaultsConfig.fontSize}.
+ * @param fontFamily String that specifies the name of the font family. Default is {@link StyleDefaultsConfig.fontFamily}.
  * @param textWidth Optional width for text wrapping.
  * @param fontStyle Optional font style, value generally taken from {@link CellStateStyle.fontStyle}.
  */
 export const getSizeForString = (
   text: string,
-  fontSize = DEFAULT_FONTSIZE,
-  fontFamily = DEFAULT_FONTFAMILY,
+  fontSize = StyleDefaultsConfig.fontSize,
+  fontFamily = StyleDefaultsConfig.fontFamily,
   textWidth: number | null = null,
   fontStyle: number | null = null
 ) => {

--- a/packages/core/src/view/canvas/AbstractCanvas2D.ts
+++ b/packages/core/src/view/canvas/AbstractCanvas2D.ts
@@ -17,7 +17,7 @@ limitations under the License.
 */
 
 import { arcToCurves, getRotatedPoint } from '../../util/mathUtils.js';
-import { DEFAULT_FONTFAMILY, DEFAULT_FONTSIZE, NONE } from '../../util/Constants.js';
+import { NONE } from '../../util/Constants.js';
 import UrlConverter from '../../util/UrlConverter.js';
 import Point from '../geometry/Point.js';
 import { clone } from '../../util/cloneUtils.js';
@@ -172,8 +172,8 @@ abstract class AbstractCanvas2D {
       fontColor: '#000000',
       fontBackgroundColor: NONE,
       fontBorderColor: NONE,
-      fontSize: DEFAULT_FONTSIZE,
-      fontFamily: DEFAULT_FONTFAMILY,
+      fontSize: StyleDefaultsConfig.fontSize,
+      fontFamily: StyleDefaultsConfig.fontFamily,
       fontStyle: 0,
       shadow: false,
       shadowColor: StyleDefaultsConfig.shadowColor,

--- a/packages/core/src/view/canvas/SvgCanvas2D.ts
+++ b/packages/core/src/view/canvas/SvgCanvas2D.ts
@@ -22,8 +22,6 @@ import { getAlignmentAsPoint } from '../../util/styleUtils.js';
 import Client from '../../Client.js';
 import {
   ABSOLUTE_LINE_HEIGHT,
-  DEFAULT_FONTFAMILY,
-  DEFAULT_FONTSIZE,
   FONT_STYLE_MASK,
   LINE_HEIGHT,
   NONE,
@@ -46,6 +44,7 @@ import {
   TextDirectionValue,
   VAlignValue,
 } from '../../types.js';
+import { StyleDefaultsConfig } from '../../util/config.js';
 
 // Activates workaround for gradient ID resolution if base tag is used.
 const useAbsoluteIds =
@@ -387,7 +386,7 @@ class SvgCanvas2D extends AbstractCanvas2D {
     style.setAttribute('type', 'text/css');
     write(
       style,
-      `svg{font-family:${DEFAULT_FONTFAMILY};font-size:${DEFAULT_FONTSIZE};fill:none;stroke-miterlimit:10}`
+      `svg{font-family:${StyleDefaultsConfig.fontFamily};font-size:${StyleDefaultsConfig.fontSize};fill:none;stroke-miterlimit:10}`
     );
     return style;
   }
@@ -1578,7 +1577,7 @@ class SvgCanvas2D extends AbstractCanvas2D {
       node.setAttribute('text-anchor', anchor);
     }
 
-    if (!this.styleEnabled || size !== DEFAULT_FONTSIZE) {
+    if (!this.styleEnabled || size !== StyleDefaultsConfig.fontSize) {
       node.setAttribute('font-size', `${size * s.scale}px`);
     }
 
@@ -1658,7 +1657,7 @@ class SvgCanvas2D extends AbstractCanvas2D {
       node.setAttribute('fill', s.fontColor);
     }
 
-    if (!this.styleEnabled || s.fontFamily !== DEFAULT_FONTFAMILY) {
+    if (!this.styleEnabled || s.fontFamily !== StyleDefaultsConfig.fontFamily) {
       node.setAttribute('font-family', s.fontFamily);
     }
 

--- a/packages/core/src/view/canvas/XmlCanvas2D.ts
+++ b/packages/core/src/view/canvas/XmlCanvas2D.ts
@@ -17,7 +17,7 @@ limitations under the License.
 */
 
 import AbstractCanvas2D from './AbstractCanvas2D.js';
-import { DEFAULT_FONTFAMILY, DEFAULT_FONTSIZE, NONE } from '../../util/Constants.js';
+import { NONE } from '../../util/Constants.js';
 import { getOuterHtml, isNode } from '../../util/domUtils.js';
 import { DirectionValue, TextDirectionValue } from '../../types.js';
 import { StyleDefaultsConfig } from '../../util/config.js';
@@ -60,11 +60,11 @@ class XmlCanvas2D extends AbstractCanvas2D {
 
     // Writes font defaults
     elem = this.createElement('fontfamily');
-    elem.setAttribute('family', DEFAULT_FONTFAMILY);
+    elem.setAttribute('family', StyleDefaultsConfig.fontFamily);
     this.root.appendChild(elem);
 
     elem = this.createElement('fontsize');
-    elem.setAttribute('size', String(DEFAULT_FONTSIZE));
+    elem.setAttribute('size', String(StyleDefaultsConfig.fontSize));
     this.root.appendChild(elem);
 
     // Writes shadow defaults
@@ -526,7 +526,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
 
   /**
    * Sets the current font size.
-   * @default {@link mxConstants.DEFAULT_FONTSIZE}
+   * @default {@link StyleDefaultsConfig.fontSize}
    *
    * @param value Numeric representation of the font size.
    */
@@ -547,7 +547,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
 
   /**
    * Sets the current font family.
-   * @default {@link mxConstants.DEFAULT_FONTFAMILY}
+   * @default {@link StyleDefaultsConfig.fontFamily}
    *
    * @param value String representation of the font family. This handles the same
    * values as the CSS font-family property.

--- a/packages/core/src/view/cell/CellRenderer.ts
+++ b/packages/core/src/view/cell/CellRenderer.ts
@@ -20,13 +20,7 @@ import RectangleShape from '../shape/node/RectangleShape.js';
 import ConnectorShape from '../shape/edge/ConnectorShape.js';
 import ImageShape from '../shape/node/ImageShape.js';
 import TextShape from '../shape/node/TextShape.js';
-import {
-  DEFAULT_FONTFAMILY,
-  DEFAULT_FONTSIZE,
-  DEFAULT_FONTSTYLE,
-  DEFAULT_TEXT_DIRECTION,
-  NONE,
-} from '../../util/Constants.js';
+import { DEFAULT_FONTSTYLE, DEFAULT_TEXT_DIRECTION, NONE } from '../../util/Constants.js';
 import { getRotatedPoint, mod, toRadians } from '../../util/mathUtils.js';
 import { convertPoint } from '../../util/styleUtils.js';
 import { equalEntries, equalPoints } from '../../util/arrayUtils.js';
@@ -46,6 +40,7 @@ import { getClientX, getClientY, getSource } from '../../util/EventUtils.js';
 import { isNode } from '../../util/domUtils.js';
 import type { CellStateStyle, ShapeConstructor } from '../../types.js';
 import type SelectionCellsHandler from '../plugins/SelectionCellsHandler.js';
+import { StyleDefaultsConfig } from '../../util/config.js';
 
 const placeholderStyleValues = ['inherit', 'swimlane', 'indicated'];
 const placeholderStyleProperties: (keyof CellStateStyle)[] = [
@@ -898,8 +893,8 @@ class CellRenderer {
 
     return (
       check('fontStyle', 'fontStyle', DEFAULT_FONTSTYLE) ||
-      check('family', 'fontFamily', DEFAULT_FONTFAMILY) ||
-      check('size', 'fontSize', DEFAULT_FONTSIZE) ||
+      check('family', 'fontFamily', StyleDefaultsConfig.fontFamily) ||
+      check('size', 'fontSize', StyleDefaultsConfig.fontSize) ||
       check('color', 'fontColor', 'black') ||
       check('align', 'align', '') ||
       check('valign', 'verticalAlign', '') ||

--- a/packages/core/src/view/handler/VertexHandler.ts
+++ b/packages/core/src/view/handler/VertexHandler.ts
@@ -1531,7 +1531,7 @@ class VertexHandler implements MouseListenerSet {
    *        && (index == 3 || index == 4)
    *        && s.text != null && s.style.whiteSpace == 'wrap') {
    *     const label = this.graph.getLabel(s.cell);
-   *     const fontSize = s.style.fontSize ?? constants.DEFAULT_FONTSIZE;
+   *     const fontSize = s.style.fontSize ?? StyleDefaultsConfig.fontSize;
    *     const ww = result.width / s.view.scale - s.text.spacingRight - s.text.spacingLeft
    *
    *     result.height = styleUtils.getSizeForString(label, fontSize, s.style.fontFamily, ww).height;

--- a/packages/core/src/view/mixins/CellsMixin.ts
+++ b/packages/core/src/view/mixins/CellsMixin.ts
@@ -28,7 +28,7 @@ import {
   setCellStyleFlags,
   setCellStyles,
 } from '../../util/styleUtils.js';
-import { DEFAULT_FONTSIZE, DEFAULT_IMAGESIZE } from '../../util/Constants.js';
+import { StyleDefaultsConfig } from '../../util/config.js';
 import Geometry from '../geometry/Geometry.js';
 import EventObject from '../event/EventObject.js';
 import InternalEvent from '../event/InternalEvent.js';
@@ -976,7 +976,7 @@ export const CellsMixin: PartialType = {
     const { style } = state;
 
     if (!cell.isEdge()) {
-      const fontSize = style.fontSize || DEFAULT_FONTSIZE;
+      const fontSize = style.fontSize || StyleDefaultsConfig.fontSize;
       let dx = 0;
       let dy = 0;
 
@@ -984,11 +984,11 @@ export const CellsMixin: PartialType = {
       if (state.getImageSrc() || style.image) {
         if (style.shape === 'label') {
           if (style.verticalAlign === 'middle') {
-            dx += style.imageWidth || DEFAULT_IMAGESIZE;
+            dx += style.imageWidth || StyleDefaultsConfig.imageSize;
           }
 
           if (style.align !== 'center') {
-            dy += style.imageHeight || DEFAULT_IMAGESIZE;
+            dy += style.imageHeight || StyleDefaultsConfig.imageSize;
           }
         }
       }

--- a/packages/core/src/view/mixins/SwimlaneMixin.ts
+++ b/packages/core/src/view/mixins/SwimlaneMixin.ts
@@ -17,10 +17,10 @@ limitations under the License.
 import Rectangle from '../geometry/Rectangle.js';
 import { convertPoint } from '../../util/styleUtils.js';
 import { mod } from '../../util/mathUtils.js';
-import { DEFAULT_STARTSIZE } from '../../util/Constants.js';
 import { getClientX, getClientY } from '../../util/EventUtils.js';
 import type { AbstractGraph } from '../AbstractGraph.js';
 import type { DirectionValue } from '../../types.js';
+import { StyleDefaultsConfig } from '../../util/config.js';
 
 type PartialGraph = Pick<
   AbstractGraph,
@@ -128,7 +128,7 @@ export const SwimlaneMixin: PartialType = {
   getStartSize(swimlane, ignoreState = false) {
     const result = new Rectangle();
     const style = this.getCurrentCellStyle(swimlane, ignoreState);
-    const size = style.startSize ?? DEFAULT_STARTSIZE;
+    const size = style.startSize ?? StyleDefaultsConfig.startSize;
 
     if (style.horizontal ?? true) {
       result.height = size;
@@ -182,7 +182,7 @@ export const SwimlaneMixin: PartialType = {
 
     if (this.isSwimlane(swimlane, ignoreState)) {
       const style = this.getCurrentCellStyle(swimlane, ignoreState);
-      const size = style.startSize ?? DEFAULT_STARTSIZE;
+      const size = style.startSize ?? StyleDefaultsConfig.startSize;
       const dir = this.getSwimlaneDirection(style);
 
       switch (dir) {

--- a/packages/core/src/view/plugins/CellEditorHandler.ts
+++ b/packages/core/src/view/plugins/CellEditorHandler.ts
@@ -22,8 +22,6 @@ import InternalEvent from '../event/InternalEvent.js';
 import Client from '../../Client.js';
 import {
   ABSOLUTE_LINE_HEIGHT,
-  DEFAULT_FONTFAMILY,
-  DEFAULT_FONTSIZE,
   DEFAULT_TEXT_DIRECTION,
   FONT_STYLE_MASK,
   LINE_HEIGHT,
@@ -53,6 +51,7 @@ import { matchBinaryMask } from '../../internal/utils.js';
 import type { AbstractGraph } from '../AbstractGraph.js';
 import type { AlignValue, GraphPlugin } from '../../types.js';
 import type TooltipHandler from './TooltipHandler.js';
+import { StyleDefaultsConfig } from '../../util/config.js';
 
 /**
  * In-place editor for the graph.
@@ -697,8 +696,8 @@ class CellEditorHandler implements GraphPlugin {
       // Configures the style of the in-place editor
       // Notice that the logic here is duplicated with styleUtils.getSizeForString
       const stateStyle = state.style;
-      const size = stateStyle.fontSize ?? DEFAULT_FONTSIZE;
-      const family = stateStyle.fontFamily ?? DEFAULT_FONTFAMILY;
+      const size = stateStyle.fontSize ?? StyleDefaultsConfig.fontSize;
+      const family = stateStyle.fontFamily ?? StyleDefaultsConfig.fontFamily;
       const color = stateStyle.fontColor ?? 'black';
       const align = stateStyle.align ?? 'left';
       const fontStyle = stateStyle.fontStyle ?? 0;

--- a/packages/core/src/view/plugins/ConnectionHandler.ts
+++ b/packages/core/src/view/plugins/ConnectionHandler.ts
@@ -24,7 +24,6 @@ import InternalEvent from '../event/InternalEvent.js';
 import {
   DEFAULT_HOTSPOT,
   DEFAULT_INVALID_COLOR,
-  DEFAULT_VALID_COLOR,
   HIGHLIGHT_STROKEWIDTH,
   INVALID_COLOR,
   NONE,
@@ -995,7 +994,7 @@ export default class ConnectionHandler
               this.marker.highlight.shape.stroke = 'transparent';
               this.currentState = null;
             } else {
-              this.marker.highlight.shape.stroke = DEFAULT_VALID_COLOR;
+              this.marker.highlight.shape.stroke = VALID_COLOR;
             }
 
             this.marker.highlight.shape.strokeWidth = HIGHLIGHT_STROKEWIDTH / s / s;
@@ -2025,7 +2024,7 @@ export class ConnectionHandlerCellMarker extends CellMarker {
   constructor(
     graph: AbstractGraph,
     connectionHandler: ConnectionHandler,
-    validColor: ColorValue = DEFAULT_VALID_COLOR,
+    validColor: ColorValue = VALID_COLOR,
     invalidColor: ColorValue = DEFAULT_INVALID_COLOR,
     hotspot: number = DEFAULT_HOTSPOT
   ) {

--- a/packages/core/src/view/shape/Shape.ts
+++ b/packages/core/src/view/shape/Shape.ts
@@ -19,12 +19,7 @@ limitations under the License.
 import Rectangle from '../geometry/Rectangle.js';
 import { isNullish } from '../../internal/utils.js';
 import { getBoundingBox, getDirectedBounds, mod } from '../../util/mathUtils.js';
-import {
-  LINE_ARCSIZE,
-  NONE,
-  NS_SVG,
-  RECTANGLE_ROUNDING_FACTOR,
-} from '../../util/Constants.js';
+import { NONE, NS_SVG } from '../../util/Constants.js';
 import Point from '../geometry/Point.js';
 import type AbstractCanvas2D from '../canvas/AbstractCanvas2D.js';
 import SvgCanvas2D from '../canvas/SvgCanvas2D.js';
@@ -761,7 +756,7 @@ class Shape {
    * @since 0.21.0
    */
   protected getBaseArcSize(): number {
-    return (this.style?.arcSize ?? LINE_ARCSIZE) / 2;
+    return (this.style?.arcSize ?? StyleDefaultsConfig.lineArcSize) / 2;
   }
 
   /**
@@ -771,7 +766,8 @@ class Shape {
     if (this.style?.absoluteArcSize) {
       return Math.min(this.getBaseArcSize(), Math.min(h, w) / 2);
     }
-    const roundingFactor = (this.style?.arcSize ?? RECTANGLE_ROUNDING_FACTOR * 100) / 100;
+    const roundingFactor =
+      (this.style?.arcSize ?? StyleDefaultsConfig.roundingFactor * 100) / 100;
     return Math.min(w, h) * roundingFactor;
   }
 

--- a/packages/core/src/view/shape/edge/ConnectorShape.ts
+++ b/packages/core/src/view/shape/edge/ConnectorShape.ts
@@ -16,13 +16,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { DEFAULT_MARKERSIZE, NONE } from '../../../util/Constants.js';
+import { NONE } from '../../../util/Constants.js';
 import PolylineShape from './PolylineShape.js';
 import { EdgeMarkerRegistry } from '../../style/marker/EdgeMarkerRegistry.js';
 import Point from '../../geometry/Point.js';
 import AbstractCanvas2D from '../../canvas/AbstractCanvas2D.js';
 import Rectangle from '../../geometry/Rectangle.js';
 import { ArrowValue, ColorValue } from '../../../types.js';
+import { StyleDefaultsConfig } from '../../../util/config.js';
 
 /**
  * Extends {@link PolylineShape} to implement a connector shape including a polyline (a line with multiple points)
@@ -115,7 +116,8 @@ class ConnectorShape extends PolylineShape {
       const unitY = dy / dist;
 
       const size =
-        (source ? this.style.startSize : this.style.endSize) ?? DEFAULT_MARKERSIZE;
+        (source ? this.style.startSize : this.style.endSize) ??
+        StyleDefaultsConfig.markerSize;
 
       // Allow for stroke width in the end point used and the
       // orthogonal vectors describing the direction of the marker
@@ -150,11 +152,11 @@ class ConnectorShape extends PolylineShape {
     let size = 0;
 
     if (this.style.startArrow !== NONE) {
-      size = (this.style.startSize ?? DEFAULT_MARKERSIZE) + 1;
+      size = (this.style.startSize ?? StyleDefaultsConfig.markerSize) + 1;
     }
 
     if (this.style.endArrow !== NONE) {
-      size = Math.max(size, this.style.endSize ?? DEFAULT_MARKERSIZE) + 1;
+      size = Math.max(size, this.style.endSize ?? StyleDefaultsConfig.markerSize) + 1;
     }
 
     bbox.grow(size * this.scale);

--- a/packages/core/src/view/shape/node/LabelShape.ts
+++ b/packages/core/src/view/shape/node/LabelShape.ts
@@ -17,10 +17,11 @@ limitations under the License.
 */
 
 import Rectangle from '../../geometry/Rectangle.js';
-import { DEFAULT_IMAGESIZE, NONE } from '../../../util/Constants.js';
+import { NONE } from '../../../util/Constants.js';
 import RectangleShape from './RectangleShape.js';
 import { ColorValue } from '../../../types.js';
 import AbstractCanvas2D from '../../canvas/AbstractCanvas2D.js';
+import { StyleDefaultsConfig } from '../../../util/config.js';
 
 /**
  * Extends {@link RectangleShape} to implement an image shape with a label.
@@ -49,9 +50,9 @@ class LabelShape extends RectangleShape {
 
   /**
    * Default width and height for the image.
-   * @default mxConstants.DEFAULT_IMAGESIZE
+   * @default {@link StyleDefaultsConfig.imageSize}
    */
-  imageSize = DEFAULT_IMAGESIZE;
+  imageSize = StyleDefaultsConfig.imageSize;
 
   override imageSrc: string | null = null;
 
@@ -168,8 +169,8 @@ class LabelShape extends RectangleShape {
   getImageBounds(x: number, y: number, w: number, h: number) {
     const align = this.style?.imageAlign ?? 'left';
     const valign = this.style?.verticalAlign ?? 'middle';
-    const width = this.style?.imageWidth ?? DEFAULT_IMAGESIZE;
-    const height = this.style?.imageHeight ?? DEFAULT_IMAGESIZE;
+    const width = this.style?.imageWidth ?? StyleDefaultsConfig.imageSize;
+    const height = this.style?.imageHeight ?? StyleDefaultsConfig.imageSize;
     const spacing = this.style?.spacing ?? this.spacing + 5;
 
     if (align === 'center') {

--- a/packages/core/src/view/shape/node/SwimlaneShape.ts
+++ b/packages/core/src/view/shape/node/SwimlaneShape.ts
@@ -17,13 +17,10 @@ limitations under the License.
 */
 import Shape from '../Shape.js';
 import Rectangle from '../../geometry/Rectangle.js';
-import {
-  DEFAULT_STARTSIZE,
-  NONE,
-  RECTANGLE_ROUNDING_FACTOR,
-} from '../../../util/Constants.js';
+import { NONE } from '../../../util/Constants.js';
 import { ColorValue } from '../../../types.js';
 import AbstractCanvas2D from '../../canvas/AbstractCanvas2D.js';
+import { StyleDefaultsConfig } from '../../../util/config.js';
 
 /**
  * Extends {@link Shape} to implement a swimlane shape.
@@ -68,7 +65,7 @@ class SwimlaneShape extends Shape {
    * Returns the bounding box for the gradient box for this shape.
    */
   getTitleSize() {
-    return Math.max(0, this.style?.startSize ?? DEFAULT_STARTSIZE);
+    return Math.max(0, this.style?.startSize ?? StyleDefaultsConfig.startSize);
   }
 
   /**
@@ -142,7 +139,8 @@ class SwimlaneShape extends Shape {
     if (this.style?.absoluteArcSize) {
       return Math.min(this.getBaseArcSize(), Math.min(h, w) / 2);
     }
-    const roundingFactor = (this.style?.arcSize ?? RECTANGLE_ROUNDING_FACTOR * 100) / 100;
+    const roundingFactor =
+      (this.style?.arcSize ?? StyleDefaultsConfig.roundingFactor * 100) / 100;
     return start * roundingFactor * 3;
   }
 

--- a/packages/core/src/view/shape/node/TextShape.ts
+++ b/packages/core/src/view/shape/node/TextShape.ts
@@ -19,8 +19,6 @@ limitations under the License.
 import Client from '../../../Client.js';
 import {
   ABSOLUTE_LINE_HEIGHT,
-  DEFAULT_FONTFAMILY,
-  DEFAULT_FONTSIZE,
   DEFAULT_FONTSTYLE,
   DEFAULT_TEXT_DIRECTION,
   FONT_STYLE_MASK,
@@ -50,6 +48,7 @@ import {
 } from '../../../types.js';
 import SvgCanvas2D from '../../canvas/SvgCanvas2D.js';
 import { matchBinaryMask } from '../../../internal/utils.js';
+import { StyleDefaultsConfig } from '../../../util/config.js';
 
 /**
  * Extends {@link Shape} to implement a text shape.
@@ -70,8 +69,8 @@ class TextShape extends Shape {
     align: AlignValue = 'center',
     valign: VAlignValue = 'middle',
     color = 'black',
-    family = DEFAULT_FONTFAMILY,
-    size = DEFAULT_FONTSIZE,
+    family = StyleDefaultsConfig.fontFamily,
+    size = StyleDefaultsConfig.fontSize,
     fontStyle = DEFAULT_FONTSTYLE,
     spacing = 2,
     spacingTop = 0,
@@ -94,8 +93,8 @@ class TextShape extends Shape {
     this.color = color ?? 'black';
     this.align = align ?? 'center';
     this.valign = valign ?? 'middle';
-    this.family = family ?? DEFAULT_FONTFAMILY;
-    this.size = size ?? DEFAULT_FONTSIZE;
+    this.family = family ?? StyleDefaultsConfig.fontFamily;
+    this.size = size ?? StyleDefaultsConfig.fontSize;
     this.fontStyle = fontStyle ?? DEFAULT_FONTSTYLE;
     this.spacing = spacing ?? 2;
     this.spacingTop = this.spacing + (spacingTop ?? 0);
@@ -347,8 +346,8 @@ class TextShape extends Shape {
     this.color = 'black';
     this.align = 'center';
     this.valign = 'middle';
-    this.family = DEFAULT_FONTFAMILY;
-    this.size = DEFAULT_FONTSIZE;
+    this.family = StyleDefaultsConfig.fontFamily;
+    this.size = StyleDefaultsConfig.fontSize;
     this.fontStyle = DEFAULT_FONTSTYLE;
     this.spacing = 2;
     this.spacingTop = 2;

--- a/packages/core/src/view/shape/stencil/StencilShape.ts
+++ b/packages/core/src/view/shape/stencil/StencilShape.ts
@@ -19,7 +19,7 @@ limitations under the License.
 import ConnectionConstraint from '../../other/ConnectionConstraint.js';
 import Rectangle from '../../geometry/Rectangle.js';
 import Shape from '../Shape.js';
-import { NONE, RECTANGLE_ROUNDING_FACTOR } from '../../../util/Constants.js';
+import { NONE } from '../../../util/Constants.js';
 import { StencilShapeRegistry } from './StencilShapeRegistry.js';
 import { getChildNodes, getTextContent } from '../../../util/domUtils.js';
 import Point from '../../geometry/Point.js';
@@ -27,6 +27,7 @@ import AbstractCanvas2D from '../../canvas/AbstractCanvas2D.js';
 import { AlignValue, ColorValue, VAlignValue } from '../../../types.js';
 import { doEval, isElement, isNullish } from '../../../internal/utils.js';
 import { translate } from '../../../internal/i18n-utils.js';
+import { StyleDefaultsConfig } from '../../../util/config.js';
 
 /**
  * Configure global settings for stencil shapes.
@@ -510,7 +511,7 @@ class StencilShape extends Shape {
           let arcsize = Number(node.getAttribute('arcsize'));
 
           if (arcsize === 0) {
-            arcsize = RECTANGLE_ROUNDING_FACTOR * 100;
+            arcsize = StyleDefaultsConfig.roundingFactor * 100;
           }
 
           const w = Number(node.getAttribute('w')) * sx;

--- a/packages/core/src/view/style/edge/Orthogonal.ts
+++ b/packages/core/src/view/style/edge/Orthogonal.ts
@@ -17,7 +17,7 @@ limitations under the License.
 */
 
 import { scaleCellState, scalePointArray } from './shared.js';
-import { DEFAULT_MARKERSIZE, DIRECTION_MASK, NONE } from '../../../util/Constants.js';
+import { DIRECTION_MASK, NONE } from '../../../util/Constants.js';
 import {
   getBoundingBox,
   getPortConstraints,
@@ -25,6 +25,7 @@ import {
 } from '../../../util/mathUtils.js';
 import type CellState from '../../cell/CellState.js';
 import { OrthogonalConnectorConfig } from '../config.js';
+import { StyleDefaultsConfig } from '../../../util/config.js';
 import type { EdgeStyleFunction } from '../../../types.js';
 import Point from '../../geometry/Point.js';
 import Rectangle from '../../geometry/Rectangle.js';
@@ -131,7 +132,8 @@ function getJettySize(state: CellState, isSource: boolean): number {
 
     if (type !== NONE) {
       const size =
-        (isSource ? state.style.startSize : state.style.endSize) ?? DEFAULT_MARKERSIZE;
+        (isSource ? state.style.startSize : state.style.endSize) ??
+        StyleDefaultsConfig.markerSize;
       value = Math.max(2, Math.ceil((size + buffer) / buffer)) * buffer;
     } else {
       value = 2 * buffer;

--- a/packages/html/stories/FixedIcons.stories.js
+++ b/packages/html/stories/FixedIcons.stories.js
@@ -19,7 +19,6 @@ import {
   Graph,
   RubberBandHandler,
   Rectangle,
-  constants,
   LabelShape,
   StyleDefaultsConfig,
 } from '@maxgraph/core';

--- a/packages/html/stories/FixedIcons.stories.js
+++ b/packages/html/stories/FixedIcons.stories.js
@@ -51,8 +51,8 @@ const Template = ({ label, ...args }) => {
 
   // Overrides the image bounds code to change the position
   LabelShape.prototype.getImageBounds = function (x, y, w, h) {
-    const iw = this.style.imageWidth ?? constants.DEFAULT_IMAGESIZE;
-    const ih = this.style.imageHeight ?? constants.DEFAULT_IMAGESIZE;
+    const iw = this.style.imageWidth ?? StyleDefaultsConfig.imageSize;
+    const ih = this.style.imageHeight ?? StyleDefaultsConfig.imageSize;
 
     // Places the icon
     const ix = (w - iw) / 2;

--- a/packages/html/stories/Labels.stories.js
+++ b/packages/html/stories/Labels.stories.js
@@ -21,6 +21,7 @@ import {
   KeyHandler,
   constants,
   Rectangle,
+  StyleDefaultsConfig,
 } from '@maxgraph/core';
 import {
   globalTypes,
@@ -89,7 +90,7 @@ const Template = ({ label, ...args }) => {
       geometry.width >= 2
     ) {
       const style = this.getCellStyle(cell);
-      const fontSize = style.fontSize || constants.DEFAULT_FONTSIZE;
+      const fontSize = style.fontSize || StyleDefaultsConfig.fontSize;
       const max = geometry.width / (fontSize * 0.625);
 
       if (max < label.length) {

--- a/packages/html/stories/Labels.stories.js
+++ b/packages/html/stories/Labels.stories.js
@@ -19,7 +19,6 @@ import {
   Graph,
   RubberBandHandler,
   KeyHandler,
-  constants,
   Rectangle,
   StyleDefaultsConfig,
 } from '@maxgraph/core';


### PR DESCRIPTION
Extend StyleDefaultsConfig to allow customization of default style values that were previously hardcoded as constants.
This enables global configuration without requiring stylesheet updates across all Graph instances.

New configurable properties:
- Font settings: fontFamily, fontSize
- Arrow settings: arrowSize, arrowSpacing, arrowWidth
- Size settings: markerSize, imageSize, startSize
- Rounding: roundingFactor, lineArcSize

All direct references to DEFAULT_* constants throughout the codebase have been replaced with StyleDefaultsConfig property access, allowing these defaults to be changed at runtime via the configuration object.


### Notes

Covers #192 

Users can now globally customize these defaults at runtime like this:

```js
import { StyleDefaultsConfig } from '@maxgraph/core';

// Change default marker size
StyleDefaultsConfig.markerSize = 10;

// Change default image size for labels
StyleDefaultsConfig.imageSize = 32;

// Change default swimlane start size
StyleDefaultsConfig.startSize = 50;

// Change default rounding factor
StyleDefaultsConfig.roundingFactor = 0.4;
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration options for default style properties: font family, font size, arrow size and spacing, marker size, image size, and rounding factors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->