### PR TITLE
fix(editor): ensure editor context in installDblClickHandler callback

### DIFF
--- a/packages/core/__tests__/editor/Editor.test.ts
+++ b/packages/core/__tests__/editor/Editor.test.ts
@@ -166,6 +166,6 @@ describe('installDblClickHandler', () => {
     expect(mockExecute).toHaveBeenCalledWith('testAction', cell);
 
     // Clean up
-    document.body.removeChild(container);
+    container.remove();
   });
 });

--- a/packages/core/__tests__/editor/Editor.test.ts
+++ b/packages/core/__tests__/editor/Editor.test.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { describe, expect, test } from '@jest/globals';
-import { Editor, Geometry } from '../../src';
+import { Editor, Geometry, EventObject, InternalEvent } from '../../src';
 import { ModelChecker } from '../serialization/utils';
 import { parseXml } from '../../src/util/xmlUtils';
 import Cell from '../../src/view/cell/Cell';
@@ -136,5 +136,36 @@ describe('cycleAttribute', () => {
     const originalStyle = { ...cell.getStyle() };
     editor.cycleAttribute(cell);
     expect(cell.getStyle()).toEqual(originalStyle);
+  });
+});
+
+describe('installDblClickHandler', () => {
+  test('double-click handler has correct editor context', () => {
+    const editor = new Editor(null!);
+    const mockExecute = jest.fn();
+    editor.execute = mockExecute;
+    editor.dblClickAction = 'testAction';
+
+    // Create a container element for the graph
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    editor.setGraphContainer(container);
+
+    // Create a test cell
+    const cell = editor.graph.insertVertex({
+      value: 'test',
+      position: [10, 10],
+      size: [100, 100],
+    });
+
+    // Fire the DOUBLE_CLICK event with proper EventObject
+    const eventObj = new EventObject(InternalEvent.DOUBLE_CLICK, { cell, event: {} });
+    editor.graph.fireEvent(eventObj);
+
+    // Verify that execute was called on the editor instance with the correct action and cell
+    expect(mockExecute).toHaveBeenCalledWith('testAction', cell);
+
+    // Clean up
+    document.body.removeChild(container);
   });
 });

--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -1532,12 +1532,13 @@ export class Editor extends EventSource {
    * @param graph
    */
   installDblClickHandler(graph: AbstractGraph): void {
+    const editor = this;
     // Installs a listener for double click events
     graph.addListener(InternalEvent.DOUBLE_CLICK, (sender: any, evt: EventObject) => {
       const cell = evt.getProperty('cell');
 
-      if (cell != null && graph.isEnabled() && this.dblClickAction != null) {
-        this.execute(this.dblClickAction, cell);
+      if (cell != null && graph.isEnabled() && editor.dblClickAction != null) {
+        editor.execute(editor.dblClickAction, cell);
         evt.consume();
       }
     });


### PR DESCRIPTION
Fix issue where the `this` reference in the double-click handler
callback was incorrectly bound to the graph instance instead of the
editor instance, breaking compatibility with mxGraph behavior.

Changes:
- Store editor reference explicitly using `const editor = this`
- Use `editor` instead of `this` in the callback to make intent clear
- Add test to verify correct editor context in double-click handler

This matches the mxGraph pattern where `mxUtils.bind(this, ...)` was
used to ensure the callback had the correct editor context.

## Notes

Closes #360

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for double-click event handling on graph cells.

* **Bug Fixes**
  * Improved double-click handler to reliably execute configured actions when cells are double-clicked.

* **Refactor**
  * Internal callback binding for the double-click handler improved to ensure consistent execution context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->