### PR TITLE
refactor: simplify Editor installDblClickHandler

### DIFF
--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -1532,13 +1532,12 @@ export class Editor extends EventSource {
    * @param graph
    */
   installDblClickHandler(graph: AbstractGraph): void {
-    const editor = this;
     // Installs a listener for double click events
-    graph.addListener(InternalEvent.DOUBLE_CLICK, (sender: any, evt: EventObject) => {
+    graph.addListener(InternalEvent.DOUBLE_CLICK, (_sender: any, evt: EventObject) => {
       const cell = evt.getProperty('cell');
 
-      if (cell != null && graph.isEnabled() && editor.dblClickAction != null) {
-        editor.execute(editor.dblClickAction, cell);
+      if (cell && graph.isEnabled() && this.dblClickAction) {
+        this.execute(this.dblClickAction, cell);
         evt.consume();
       }
     });


### PR DESCRIPTION
Remove usage of variable holding this.

The callback passed to graph.addListener is an arrow function.
Arrow functions do not have their own this binding; they inherit this from the enclosing scope, which in this case is the Editor instance.

These rollbacks 1f31f7f7.

## Notes

Covers #360
Rollback #934



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal code structure in the editor's double-click handler for improved maintainability. No functional changes to end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->