### PR TITLE
refactor: prefer includes to indexOf

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -103,6 +103,7 @@ export default tsEslint.config(
       'n/file-extension-in-import': ['error', 'always'],
       'n/no-unsupported-features/node-builtins': 'off', // we don't use node in this package, and most errors are due to "navigator.xxx is still an experimental feature and is not supported until Node.js yyy"
       // apply a subset of unicorn rules for now
+      'unicorn/prefer-includes': 'error',
       'unicorn/prefer-number-properties': 'error',
       'unicorn/prefer-switch': 'error',
     },

--- a/packages/core/src/Client.ts
+++ b/packages/core/src/Client.ts
@@ -77,9 +77,9 @@ class Client {
   static IS_NS =
     typeof window !== 'undefined' &&
     navigator.userAgent != null &&
-    navigator.userAgent.indexOf('Mozilla/') >= 0 &&
-    navigator.userAgent.indexOf('MSIE') < 0 &&
-    navigator.userAgent.indexOf('Edge/') < 0;
+    navigator.userAgent.includes('Mozilla/') &&
+    !navigator.userAgent.includes('MSIE') &&
+    !navigator.userAgent.includes('Edge/');
 
   /**
    * True if the current browser is Safari.
@@ -91,7 +91,7 @@ class Client {
    * Returns true if the user agent contains Android.
    */
   static IS_ANDROID =
-    typeof window !== 'undefined' && navigator.appVersion.indexOf('Android') >= 0;
+    typeof window !== 'undefined' && navigator.appVersion.includes('Android');
 
   /**
    * Returns true if the user agent is an iPad, iPhone or iPod.
@@ -119,7 +119,7 @@ class Client {
   /**
    * True if the current browser is Firefox.
    */
-  static IS_FF = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+  static IS_FF = navigator.userAgent.toLowerCase().includes('firefox');
 
   /**
    * True if -moz-transform is available as a CSS style. This is the case
@@ -128,16 +128,16 @@ class Client {
    */
   static IS_MT =
     typeof window !== 'undefined' &&
-    ((navigator.userAgent.indexOf('Firefox/') >= 0 &&
-      navigator.userAgent.indexOf('Firefox/1.') < 0 &&
-      navigator.userAgent.indexOf('Firefox/2.') < 0) ||
-      (navigator.userAgent.indexOf('Iceweasel/') >= 0 &&
-        navigator.userAgent.indexOf('Iceweasel/1.') < 0 &&
-        navigator.userAgent.indexOf('Iceweasel/2.') < 0) ||
-      (navigator.userAgent.indexOf('SeaMonkey/') >= 0 &&
-        navigator.userAgent.indexOf('SeaMonkey/1.') < 0) ||
-      (navigator.userAgent.indexOf('Iceape/') >= 0 &&
-        navigator.userAgent.indexOf('Iceape/1.') < 0));
+    ((navigator.userAgent.includes('Firefox/') &&
+      !navigator.userAgent.includes('Firefox/1.') &&
+      !navigator.userAgent.includes('Firefox/2.')) ||
+      (navigator.userAgent.includes('Iceweasel/') &&
+        !navigator.userAgent.includes('Iceweasel/1.') &&
+        !navigator.userAgent.includes('Iceweasel/2.')) ||
+      (navigator.userAgent.includes('SeaMonkey/') &&
+        !navigator.userAgent.includes('SeaMonkey/1.')) ||
+      (navigator.userAgent.includes('Iceape/') &&
+        !navigator.userAgent.includes('Iceape/1.')));
 
   /**
    * True if the browser supports SVG.
@@ -155,7 +155,7 @@ class Client {
     (!document.createElementNS ||
       document.createElementNS(NS_SVG, 'foreignObject').toString() !==
         '[object SVGForeignObjectElement]' ||
-      navigator.userAgent.indexOf('Opera/') >= 0);
+      navigator.userAgent.includes('Opera/'));
 
   /**
    * True if the client is a Windows.
@@ -195,8 +195,8 @@ class Client {
    */
   static IS_LOCAL =
     typeof window !== 'undefined' &&
-    document.location.href.indexOf('http://') < 0 &&
-    document.location.href.indexOf('https://') < 0;
+    !document.location.href.includes('http://') &&
+    !document.location.href.includes('https://');
 }
 
 export default Client;

--- a/packages/core/src/gui/MaxLog.ts
+++ b/packages/core/src/gui/MaxLog.ts
@@ -334,7 +334,7 @@ class MaxLog {
       MaxLog.textarea.value = MaxLog.textarea.value + string;
 
       // Workaround for no update in Presto 2.5.22 (Opera 10.5)
-      if (navigator.userAgent && navigator.userAgent.includes('Presto/2.5')) {
+      if (navigator.userAgent?.includes('Presto/2.5')) {
         MaxLog.textarea.style.visibility = 'hidden';
         MaxLog.textarea.style.visibility = 'visible';
       }

--- a/packages/core/src/gui/MaxLog.ts
+++ b/packages/core/src/gui/MaxLog.ts
@@ -334,7 +334,7 @@ class MaxLog {
       MaxLog.textarea.value = MaxLog.textarea.value + string;
 
       // Workaround for no update in Presto 2.5.22 (Opera 10.5)
-      if (navigator.userAgent != null && navigator.userAgent.indexOf('Presto/2.5') >= 0) {
+      if (navigator.userAgent && navigator.userAgent.includes('Presto/2.5')) {
         MaxLog.textarea.style.visibility = 'hidden';
         MaxLog.textarea.style.visibility = 'visible';
       }

--- a/packages/core/src/gui/MaxWindow.ts
+++ b/packages/core/src/gui/MaxWindow.ts
@@ -387,7 +387,7 @@ export default class MaxWindow extends EventSource {
    */
   setScrollable(scrollable: boolean): void {
     // Workaround for hang in Presto 2.5.22 (Opera 10.5)
-    if (navigator.userAgent == null || navigator.userAgent.indexOf('Presto/2.5') < 0) {
+    if (!navigator.userAgent || !navigator.userAgent.includes('Presto/2.5')) {
       if (scrollable) {
         this.contentWrapper.style.overflow = 'auto';
       } else {

--- a/packages/core/src/gui/MaxWindow.ts
+++ b/packages/core/src/gui/MaxWindow.ts
@@ -387,7 +387,7 @@ export default class MaxWindow extends EventSource {
    */
   setScrollable(scrollable: boolean): void {
     // Workaround for hang in Presto 2.5.22 (Opera 10.5)
-    if (!navigator.userAgent || !navigator.userAgent.includes('Presto/2.5')) {
+    if (!navigator.userAgent?.includes('Presto/2.5')) {
       if (scrollable) {
         this.contentWrapper.style.overflow = 'auto';
       } else {

--- a/packages/core/src/i18n/Translations.ts
+++ b/packages/core/src/i18n/Translations.ts
@@ -116,7 +116,7 @@ export default class Translations {
   static isLanguageSupported = (lan: string): boolean => {
     const languages = TranslationsConfig.getLanguages();
     if (languages) {
-      return languages.indexOf(lan) >= 0;
+      return languages.includes(lan);
     }
     return true;
   };

--- a/packages/core/src/serialization/ObjectCodec.ts
+++ b/packages/core/src/serialization/ObjectCodec.ts
@@ -333,7 +333,7 @@ class ObjectCodec {
    * Write is true if the field is being encoded, else it is being decoded.
    */
   isExcluded(obj: any, attr: string, value: any, write?: boolean): boolean {
-    return attr == ObjectIdentity.FIELD_NAME || this.exclude.indexOf(attr) >= 0;
+    return attr == ObjectIdentity.FIELD_NAME || this.exclude.includes(attr);
   }
 
   /**

--- a/packages/core/src/util/cloneUtils.ts
+++ b/packages/core/src/util/cloneUtils.ts
@@ -43,7 +43,7 @@ export const clone = function _clone(
     for (const i in obj) {
       if (
         i != ObjectIdentity.FIELD_NAME &&
-        (transients == null || transients.indexOf(i) < 0)
+        (transients == null || !transients.includes(i))
       ) {
         if (!shallow && typeof obj[i] === 'object') {
           clone[i] = _clone(obj[i]);

--- a/packages/core/src/util/domUtils.ts
+++ b/packages/core/src/util/domUtils.ts
@@ -68,7 +68,7 @@ export const extractTextWithWhitespace = (elems: Element[]): string => {
           doExtract(<Element[]>Array.from(elem.childNodes));
         }
 
-        if (i < elts.length - 1 && blocks.indexOf(elts[i + 1].nodeName) >= 0) {
+        if (i < elts.length - 1 && blocks.includes(elts[i + 1].nodeName)) {
           ret.push('\n');
         }
       }

--- a/packages/core/src/util/domUtils.ts
+++ b/packages/core/src/util/domUtils.ts
@@ -17,28 +17,29 @@ limitations under the License.
 import { NODE_TYPE } from './Constants.js';
 import { isNullish } from '../internal/utils.js';
 
+// Known block elements for handling linefeed (list is not complete)
+const blocks = new Set([
+  'BLOCKQUOTE',
+  'DIV',
+  'H1',
+  'H2',
+  'H3',
+  'H4',
+  'H5',
+  'H6',
+  'OL',
+  'P',
+  'PRE',
+  'TABLE',
+  'UL',
+]);
+
 /**
  * Returns the text content of the specified node.
  *
  * @param elems DOM nodes to return the text for.
  */
 export const extractTextWithWhitespace = (elems: Element[]): string => {
-  // Known block elements for handling linefeeds (list is not complete)
-  const blocks = [
-    'BLOCKQUOTE',
-    'DIV',
-    'H1',
-    'H2',
-    'H3',
-    'H4',
-    'H5',
-    'H6',
-    'OL',
-    'P',
-    'PRE',
-    'TABLE',
-    'UL',
-  ];
   const ret: string[] = [];
 
   function doExtract(elts: Element[]) {
@@ -68,7 +69,7 @@ export const extractTextWithWhitespace = (elems: Element[]): string => {
           doExtract(<Element[]>Array.from(elem.childNodes));
         }
 
-        if (i < elts.length - 1 && blocks.includes(elts[i + 1].nodeName)) {
+        if (i < elts.length - 1 && blocks.has(elts[i + 1].nodeName)) {
           ret.push('\n');
         }
       }
@@ -146,7 +147,7 @@ export const write = (parent: Element, text: string) => {
   const doc = parent.ownerDocument;
   const node = doc.createTextNode(text);
 
-  if (parent != null) {
+  if (parent) {
     parent.appendChild(node);
   }
 
@@ -164,7 +165,7 @@ export const writeln = (parent: Element, text: string) => {
   const doc = parent.ownerDocument;
   const node = doc.createTextNode(text);
 
-  if (parent != null) {
+  if (parent) {
     parent.appendChild(node);
     parent.appendChild(document.createElement('br'));
   }

--- a/packages/core/src/util/mathUtils.ts
+++ b/packages/core/src/util/mathUtils.ts
@@ -254,7 +254,7 @@ export const getPortConstraints = (
     }
   }
 
-  if (directions.indexOf('north') >= 0) {
+  if (directions.includes('north')) {
     switch (quad) {
       case 0:
         returnValue |= DIRECTION_MASK.NORTH;
@@ -270,7 +270,7 @@ export const getPortConstraints = (
         break;
     }
   }
-  if (directions.indexOf('west') >= 0) {
+  if (directions.includes('west')) {
     switch (quad) {
       case 0:
         returnValue |= DIRECTION_MASK.WEST;
@@ -286,7 +286,7 @@ export const getPortConstraints = (
         break;
     }
   }
-  if (directions.indexOf('south') >= 0) {
+  if (directions.includes('south')) {
     switch (quad) {
       case 0:
         returnValue |= DIRECTION_MASK.SOUTH;
@@ -302,7 +302,7 @@ export const getPortConstraints = (
         break;
     }
   }
-  if (directions.indexOf('east') >= 0) {
+  if (directions.includes('east')) {
     switch (quad) {
       case 0:
         returnValue |= DIRECTION_MASK.EAST;
@@ -674,7 +674,7 @@ export const isNumeric = (n: any): n is number | string => {
   return (
     !Number.isNaN(Number.parseFloat(n)) &&
     Number.isFinite(+n) &&
-    (typeof n !== 'string' || n.toLowerCase().indexOf('0x') < 0)
+    (typeof n !== 'string' || !n.toLowerCase().includes('0x'))
   );
 };
 

--- a/packages/core/src/view/GraphSelectionModel.ts
+++ b/packages/core/src/view/GraphSelectionModel.ts
@@ -111,7 +111,7 @@ class GraphSelectionModel extends EventSource {
    * Returns true if the given {@link Cell} is selected.
    */
   isSelected(cell: Cell) {
-    return this.cells.indexOf(cell) >= 0;
+    return this.cells.includes(cell);
   }
 
   /**

--- a/packages/core/src/view/cell/Cell.ts
+++ b/packages/core/src/view/cell/Cell.ts
@@ -515,7 +515,7 @@ export class Cell implements IdentityObject {
     if (
       this.edges.length === 0 ||
       edge.getTerminal(!isOutgoing) !== this ||
-      this.edges.indexOf(edge) < 0
+      !this.edges.includes(edge)
     ) {
       this.edges.push(edge);
     }

--- a/packages/core/src/view/layout/hierarchical/GraphHierarchyModel.ts
+++ b/packages/core/src/view/layout/hierarchical/GraphHierarchyModel.ts
@@ -104,7 +104,7 @@ class GraphHierarchyModel {
               internalTargetCell.connectsAsTarget = [];
             }
 
-            if (internalTargetCell.connectsAsTarget.indexOf(internalEdge) < 0) {
+            if (!internalTargetCell.connectsAsTarget.includes(internalEdge)) {
               internalTargetCell.connectsAsTarget.push(internalEdge);
             }
           }
@@ -238,7 +238,7 @@ class GraphHierarchyModel {
 
             internalEdge.source = internalVertices[i];
 
-            if (internalVertices[i].connectsAsSource.indexOf(internalEdge) < 0) {
+            if (!internalVertices[i].connectsAsSource.includes(internalEdge)) {
               internalVertices[i].connectsAsSource.push(internalEdge);
             }
           }

--- a/packages/core/src/view/layout/hierarchical/SwimlaneModel.ts
+++ b/packages/core/src/view/layout/hierarchical/SwimlaneModel.ts
@@ -104,7 +104,7 @@ class SwimlaneModel {
               internalTargetCell.connectsAsTarget = [];
             }
 
-            if (internalTargetCell.connectsAsTarget.indexOf(internalEdge) < 0) {
+            if (!internalTargetCell.connectsAsTarget.includes(internalEdge)) {
               internalTargetCell.connectsAsTarget.push(internalEdge);
             }
           }
@@ -252,7 +252,7 @@ class SwimlaneModel {
 
             internalEdge.source = internalVertices[i];
 
-            if (internalVertices[i].connectsAsSource.indexOf(internalEdge) < 0) {
+            if (!internalVertices[i].connectsAsSource.includes(internalEdge)) {
               internalVertices[i].connectsAsSource.push(internalEdge);
             }
           }

--- a/packages/core/src/view/mixins/CellsMixin.ts
+++ b/packages/core/src/view/mixins/CellsMixin.ts
@@ -2054,7 +2054,7 @@ export const CellsMixin: PartialType = {
                     geo.height
                   );
 
-                  if (cells.indexOf(parent) >= 0) {
+                  if (cells.includes(parent)) {
                     bbox.x += tmp.x;
                     bbox.y += tmp.y;
                   }
@@ -2063,7 +2063,7 @@ export const CellsMixin: PartialType = {
             } else {
               bbox = Rectangle.fromRectangle(geo);
 
-              if (parent && parent.isVertex() && cells.indexOf(parent) >= 0) {
+              if (parent && parent.isVertex() && cells.includes(parent)) {
                 tmp = this.getBoundingBoxFromGeometry([parent], false);
 
                 if (tmp) {

--- a/packages/core/src/view/mixins/SwimlaneMixin.ts
+++ b/packages/core/src/view/mixins/SwimlaneMixin.ts
@@ -266,7 +266,7 @@ export const SwimlaneMixin: PartialType = {
     // Checks if parent is dropped into child if not cloning
     let parentCell = cell;
     if (!clone) {
-      while (parentCell && cells.indexOf(parentCell) < 0) {
+      while (parentCell && !cells.includes(parentCell)) {
         parentCell = parentCell.getParent();
       }
     }

--- a/packages/core/src/view/shape/Shape.ts
+++ b/packages/core/src/view/shape/Shape.ts
@@ -845,7 +845,7 @@ class Shape {
         let dx = pt.x - tmp.x;
         let dy = pt.y - tmp.y;
 
-        if (rounded && (dx !== 0 || dy !== 0) && exclude.indexOf(i - 1) < 0) {
+        if (rounded && (dx !== 0 || dy !== 0) && !exclude.includes(i - 1)) {
           // Draws a line from the last point to the current
           // point with a spacing of size off the current point
           // into direction of the last point

--- a/packages/core/src/view/style/edge/Manhattan.ts
+++ b/packages/core/src/view/style/edge/Manhattan.ts
@@ -111,7 +111,7 @@ export const ManhattanConnector: EdgeStyleFunction = (
   }
 
   function toPointFromString(pointString: string) {
-    const xy = pointString.split(pointString.indexOf('@') === -1 ? ' ' : '@');
+    const xy = pointString.split(!pointString.includes('@') ? ' ' : '@');
     return new Point(Number.parseInt(xy[0], 10), Number.parseInt(xy[1], 10));
   }
 
@@ -477,7 +477,7 @@ export const ManhattanConnector: EdgeStyleFunction = (
             : getDirectionAngle(startCenter, currentPoint, opt.directions.length);
 
         // if get the endpoint
-        if (endPointsKeys.indexOf(currentKey) >= 0) {
+        if (endPointsKeys.includes(currentKey)) {
           // stop route to enter the end point in opposite direction.
           const directionChangedAngle = getDirectionChange(
             currentDirectionAngle,


### PR DESCRIPTION
From typescript-eslint
Prior to ES2015, Array#indexOf and String#indexOf comparisons against -1 were the standard ways to check whether a
value exists in an array or string, respectively.
Alternatives that are easier to read and write now exist: ES2015 added String#includes and ES2016 added Array#includes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized many internal membership and string checks to use contemporary includes-based operations, improving readability, null-safety, and consistency without changing user-visible behavior.

* **Chores**
  * ESLint configuration updated to enforce includes-style checks to maintain consistent coding standards across the core codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->