### PR TITLE
refactor: introduce AbstractPathShape base class for shape hierarchy

### DIFF
--- a/packages/core/src/view/shape/Shape.ts
+++ b/packages/core/src/view/shape/Shape.ts
@@ -1016,8 +1016,8 @@ class Shape {
   }
 
   /**
-   * Updates the <boundingBox> for this shape using <createBoundingBox> and
-   * <augmentBoundingBox> and stores the result in <boundingBox>.
+   * Updates the {@link boundingBox} for this shape using {@link createBoundingBox} and
+   * {@link augmentBoundingBox} and stores the result in {@link boundingBox}.
    */
   updateBoundingBox() {
     // Tries to get bounding box from SVG subsystem

--- a/packages/core/src/view/shape/node/AbstractPathShape.ts
+++ b/packages/core/src/view/shape/node/AbstractPathShape.ts
@@ -1,0 +1,83 @@
+/*
+Copyright 2021-present The maxGraph project Contributors
+Copyright (c) 2006-2015, JGraph Ltd
+Copyright (c) 2006-2015, Gaudenz Alder
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import type Rectangle from '../../geometry/Rectangle.js';
+import Shape from '../Shape.js';
+import type AbstractCanvas2D from '../../canvas/AbstractCanvas2D.js';
+import type { ColorValue } from '../../../types.js';
+import { NONE } from '../../../util/Constants.js';
+
+/**
+ * Base {@link Shape} class to implement a shape with a specific .
+ *
+ * If a custom shape with one filled area is needed, then this shape's {@link redrawPath} method should be overridden like in the following example:
+ *
+ * ```typescript
+ * class SampleShape extends AbstractPathShape {
+ *   redrawPath(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
+ *     path.moveTo(0, 0);
+ *     path.lineTo(w, h);
+ *     // ...
+ *     path.close();
+ *   }
+ * }
+ * ```
+ *
+ * @category Vertex Shapes
+ */
+export abstract class AbstractPathShape extends Shape {
+  protected constructor(
+    bounds: Rectangle | null = null,
+    fill: ColorValue = NONE,
+    stroke: ColorValue = NONE,
+    strokeWidth = 1
+  ) {
+    super();
+    this.bounds = bounds;
+    this.fill = fill;
+    this.stroke = stroke;
+    this.strokeWidth = strokeWidth;
+  }
+
+  /**
+   * Redirects to redrawPath for subclasses to work.
+   */
+  override paintVertexShape(
+    c: AbstractCanvas2D,
+    x: number,
+    y: number,
+    w: number,
+    h: number
+  ) {
+    c.translate(x, y);
+    c.begin();
+    this.redrawPath(c, x, y, w, h);
+    c.fillAndStroke();
+  }
+
+  /**
+   * Draws the path for this shape.
+   */
+  abstract redrawPath(
+    c: AbstractCanvas2D,
+    x: number,
+    y: number,
+    w: number,
+    h: number
+  ): void;
+}

--- a/packages/core/src/view/shape/node/AbstractPathShape.ts
+++ b/packages/core/src/view/shape/node/AbstractPathShape.ts
@@ -41,7 +41,7 @@ import { NONE } from '../../../util/Constants.js';
  * @category Vertex Shapes
  */
 export abstract class AbstractPathShape extends Shape {
-  protected constructor(
+  constructor(
     bounds: Rectangle | null = null,
     fill: ColorValue = NONE,
     stroke: ColorValue = NONE,

--- a/packages/core/src/view/shape/node/AbstractPathShape.ts
+++ b/packages/core/src/view/shape/node/AbstractPathShape.ts
@@ -23,17 +23,17 @@ import type { ColorValue } from '../../../types.js';
 import { NONE } from '../../../util/Constants.js';
 
 /**
- * Base {@link Shape} class to implement a shape with a specific .
+ * Base {@link Shape} for vertex shapes rendered from a single path.
  *
- * If a custom shape with one filled area is needed, then this shape's {@link redrawPath} method should be overridden like in the following example:
+ * If a custom shape with one filled area is needed, override {@link redrawPath} as in the following example:
  *
  * ```typescript
  * class SampleShape extends AbstractPathShape {
  *   redrawPath(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
- *     path.moveTo(0, 0);
- *     path.lineTo(w, h);
+ *     c.moveTo(0, 0);
+ *     c.lineTo(w, h);
  *     // ...
- *     path.close();
+ *     c.close();
  *   }
  * }
  * ```

--- a/packages/core/src/view/shape/node/ActorShape.ts
+++ b/packages/core/src/view/shape/node/ActorShape.ts
@@ -16,10 +16,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type Rectangle from '../../geometry/Rectangle.js';
 import { AbstractPathShape } from './AbstractPathShape.js';
 import type AbstractCanvas2D from '../../canvas/AbstractCanvas2D.js';
-import type { ColorValue } from '../../../types.js';
 
 /**
  * Path-based actor vertex shape built on {@link AbstractPathShape}.
@@ -29,15 +27,6 @@ import type { ColorValue } from '../../../types.js';
  * @category Vertex Shapes
  */
 class ActorShape extends AbstractPathShape {
-  constructor(
-    bounds?: Rectangle | null,
-    fill?: ColorValue,
-    stroke?: ColorValue,
-    strokeWidth?: number
-  ) {
-    super(bounds, fill, stroke, strokeWidth);
-  }
-
   /**
    * Draws the path for this shape.
    */

--- a/packages/core/src/view/shape/node/ActorShape.ts
+++ b/packages/core/src/view/shape/node/ActorShape.ts
@@ -22,7 +22,7 @@ import type AbstractCanvas2D from '../../canvas/AbstractCanvas2D.js';
 import type { ColorValue } from '../../../types.js';
 
 /**
- * Extends {@link Shape} to implement an actor shape.
+ * Path-based actor vertex shape built on {@link AbstractPathShape}.
  *
  * This shape is registered under `actor` in {@link CellRenderer} when using {@link Graph} or calling {@link registerDefaultShapes}.
  *

--- a/packages/core/src/view/shape/node/ActorShape.ts
+++ b/packages/core/src/view/shape/node/ActorShape.ts
@@ -17,66 +17,31 @@ limitations under the License.
 */
 
 import type Rectangle from '../../geometry/Rectangle.js';
-import Shape from '../Shape.js';
+import { AbstractPathShape } from './AbstractPathShape.js';
 import type AbstractCanvas2D from '../../canvas/AbstractCanvas2D.js';
-import { ColorValue } from '../../../types.js';
-import { NONE } from '../../../util/Constants.js';
+import type { ColorValue } from '../../../types.js';
 
 /**
  * Extends {@link Shape} to implement an actor shape.
  *
  * This shape is registered under `actor` in {@link CellRenderer} when using {@link Graph} or calling {@link registerDefaultShapes}.
  *
- * If a custom shape with one filled area is needed, then this shape's {@link redrawPath} method should be overridden
- * like in the following example:
- *
- * ```typescript
- * class SampleShape extends ActorShape {
- *   redrawPath(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
- *     path.moveTo(0, 0);
- *     path.lineTo(w, h);
- *     // ...
- *     path.close();
- *   }
- * }
- * ```
- *
  * @category Vertex Shapes
  */
-class ActorShape extends Shape {
+class ActorShape extends AbstractPathShape {
   constructor(
-    bounds: Rectangle | null = null,
-    fill: ColorValue = NONE,
-    stroke: ColorValue = NONE,
-    strokeWidth = 1
+    bounds?: Rectangle | null,
+    fill?: ColorValue,
+    stroke?: ColorValue,
+    strokeWidth?: number
   ) {
-    super();
-    this.bounds = bounds;
-    this.fill = fill;
-    this.stroke = stroke;
-    this.strokeWidth = strokeWidth;
-  }
-
-  /**
-   * Redirects to redrawPath for subclasses to work.
-   */
-  override paintVertexShape(
-    c: AbstractCanvas2D,
-    x: number,
-    y: number,
-    w: number,
-    h: number
-  ) {
-    c.translate(x, y);
-    c.begin();
-    this.redrawPath(c, x, y, w, h);
-    c.fillAndStroke();
+    super(bounds, fill, stroke, strokeWidth);
   }
 
   /**
    * Draws the path for this shape.
    */
-  redrawPath(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
+  override redrawPath(c: AbstractCanvas2D, x: number, y: number, w: number, h: number) {
     const width = w / 3;
     c.moveTo(0, h);
     c.curveTo(0, (3 * h) / 5, 0, (2 * h) / 5, w / 2, (2 * h) / 5);

--- a/packages/core/src/view/shape/node/CloudShape.ts
+++ b/packages/core/src/view/shape/node/CloudShape.ts
@@ -20,7 +20,7 @@ import { AbstractPathShape } from './AbstractPathShape.js';
 import type AbstractCanvas2D from '../../canvas/AbstractCanvas2D.js';
 
 /**
- * Extends {@link ActorShape} to implement a cloud shape.
+ * Path-based cloud vertex shape built on {@link AbstractPathShape}.
  *
  * This shape is registered under `cloud` in {@link CellRenderer} when using {@link Graph} or calling {@link registerDefaultShapes}.
  *

--- a/packages/core/src/view/shape/node/CloudShape.ts
+++ b/packages/core/src/view/shape/node/CloudShape.ts
@@ -16,9 +16,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import ActorShape from './ActorShape.js';
-import AbstractCanvas2D from '../../canvas/AbstractCanvas2D.js';
-import Rectangle from '../../geometry/Rectangle.js';
+import { AbstractPathShape } from './AbstractPathShape.js';
+import type AbstractCanvas2D from '../../canvas/AbstractCanvas2D.js';
+import type Rectangle from '../../geometry/Rectangle.js';
+import type { ColorValue } from '../../../types.js';
 
 /**
  * Extends {@link ActorShape} to implement a cloud shape.
@@ -27,13 +28,14 @@ import Rectangle from '../../geometry/Rectangle.js';
  *
  * @category Vertex Shapes
  */
-class CloudShape extends ActorShape {
-  constructor(bounds: Rectangle, fill: string, stroke: string, strokeWidth = 1) {
-    super();
-    this.bounds = bounds;
-    this.fill = fill;
-    this.stroke = stroke;
-    this.strokeWidth = strokeWidth;
+class CloudShape extends AbstractPathShape {
+  constructor(
+    bounds?: Rectangle | null,
+    fill?: ColorValue,
+    stroke?: ColorValue,
+    strokeWidth?: number
+  ) {
+    super(bounds, fill, stroke, strokeWidth);
   }
 
   /**

--- a/packages/core/src/view/shape/node/CloudShape.ts
+++ b/packages/core/src/view/shape/node/CloudShape.ts
@@ -18,8 +18,6 @@ limitations under the License.
 
 import { AbstractPathShape } from './AbstractPathShape.js';
 import type AbstractCanvas2D from '../../canvas/AbstractCanvas2D.js';
-import type Rectangle from '../../geometry/Rectangle.js';
-import type { ColorValue } from '../../../types.js';
 
 /**
  * Extends {@link ActorShape} to implement a cloud shape.
@@ -29,15 +27,6 @@ import type { ColorValue } from '../../../types.js';
  * @category Vertex Shapes
  */
 class CloudShape extends AbstractPathShape {
-  constructor(
-    bounds?: Rectangle | null,
-    fill?: ColorValue,
-    stroke?: ColorValue,
-    strokeWidth?: number
-  ) {
-    super(bounds, fill, stroke, strokeWidth);
-  }
-
   /**
    * Draws the path for this shape.
    */

--- a/packages/core/src/view/shape/node/HexagonShape.ts
+++ b/packages/core/src/view/shape/node/HexagonShape.ts
@@ -19,8 +19,6 @@ limitations under the License.
 import { AbstractPathShape } from './AbstractPathShape.js';
 import Point from '../../geometry/Point.js';
 import type AbstractCanvas2D from '../../canvas/AbstractCanvas2D.js';
-import type Rectangle from '../../geometry/Rectangle.js';
-import type { ColorValue } from '../../../types.js';
 
 /**
  * Implementation of the hexagon shape.
@@ -30,15 +28,6 @@ import type { ColorValue } from '../../../types.js';
  * @category Vertex Shapes
  */
 class HexagonShape extends AbstractPathShape {
-  constructor(
-    bounds?: Rectangle | null,
-    fill?: ColorValue,
-    stroke?: ColorValue,
-    strokeWidth?: number
-  ) {
-    super(bounds, fill, stroke, strokeWidth);
-  }
-
   /**
    * Draws the path for this shape.
    */

--- a/packages/core/src/view/shape/node/HexagonShape.ts
+++ b/packages/core/src/view/shape/node/HexagonShape.ts
@@ -16,9 +16,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import ActorShape from './ActorShape.js';
+import { AbstractPathShape } from './AbstractPathShape.js';
 import Point from '../../geometry/Point.js';
-import AbstractCanvas2D from '../../canvas/AbstractCanvas2D.js';
+import type AbstractCanvas2D from '../../canvas/AbstractCanvas2D.js';
+import type Rectangle from '../../geometry/Rectangle.js';
+import type { ColorValue } from '../../../types.js';
 
 /**
  * Implementation of the hexagon shape.
@@ -27,9 +29,14 @@ import AbstractCanvas2D from '../../canvas/AbstractCanvas2D.js';
  *
  * @category Vertex Shapes
  */
-class HexagonShape extends ActorShape {
-  constructor() {
-    super();
+class HexagonShape extends AbstractPathShape {
+  constructor(
+    bounds?: Rectangle | null,
+    fill?: ColorValue,
+    stroke?: ColorValue,
+    strokeWidth?: number
+  ) {
+    super(bounds, fill, stroke, strokeWidth);
   }
 
   /**

--- a/packages/core/src/view/shape/node/TriangleShape.ts
+++ b/packages/core/src/view/shape/node/TriangleShape.ts
@@ -17,8 +17,10 @@ limitations under the License.
 */
 
 import Point from '../../geometry/Point.js';
-import ActorShape from './ActorShape.js';
-import AbstractCanvas2D from '../../canvas/AbstractCanvas2D.js';
+import { AbstractPathShape } from './AbstractPathShape.js';
+import type AbstractCanvas2D from '../../canvas/AbstractCanvas2D.js';
+import type Rectangle from '../../geometry/Rectangle.js';
+import type { ColorValue } from '../../../types.js';
 
 /**
  * Implementation of the triangle shape.
@@ -27,9 +29,14 @@ import AbstractCanvas2D from '../../canvas/AbstractCanvas2D.js';
  *
  * @category Vertex Shapes
  */
-class TriangleShape extends ActorShape {
-  constructor() {
-    super();
+class TriangleShape extends AbstractPathShape {
+  constructor(
+    bounds?: Rectangle | null,
+    fill?: ColorValue,
+    stroke?: ColorValue,
+    strokeWidth?: number
+  ) {
+    super(bounds, fill, stroke, strokeWidth);
   }
 
   /**

--- a/packages/core/src/view/shape/node/TriangleShape.ts
+++ b/packages/core/src/view/shape/node/TriangleShape.ts
@@ -19,8 +19,6 @@ limitations under the License.
 import Point from '../../geometry/Point.js';
 import { AbstractPathShape } from './AbstractPathShape.js';
 import type AbstractCanvas2D from '../../canvas/AbstractCanvas2D.js';
-import type Rectangle from '../../geometry/Rectangle.js';
-import type { ColorValue } from '../../../types.js';
 
 /**
  * Implementation of the triangle shape.
@@ -30,15 +28,6 @@ import type { ColorValue } from '../../../types.js';
  * @category Vertex Shapes
  */
 class TriangleShape extends AbstractPathShape {
-  constructor(
-    bounds?: Rectangle | null,
-    fill?: ColorValue,
-    stroke?: ColorValue,
-    strokeWidth?: number
-  ) {
-    super(bounds, fill, stroke, strokeWidth);
-  }
-
   /**
    * Adds roundable support.
    * @returns {boolean}


### PR DESCRIPTION
refactor: introduce AbstractPathShape base class for shape hierarchy

Replace ActorShape as the base class for CloudShape, HexagonShape, and
TriangleShape. These classes had no functional relation with ActorShape -
the inheritance was only for technical convenience.

Introduce AbstractPathShape as a dedicated abstract base class to make
the hierarchy more explicit and semantically clear. ActorShape now extends
AbstractPathShape alongside the other shapes.

Changes:
- Add new AbstractPathShape abstract class
- Refactor ActorShape to extend AbstractPathShape
- Update CloudShape, HexagonShape, and TriangleShape to extend AbstractPathShape

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized shape rendering system architecture for improved code structure and maintainability.

* **Documentation**
  * Updated shape documentation with enhanced reference annotations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->