### PR TITLE
refactor(Stylesheet): simplify default style creation methods

### DIFF
--- a/packages/core/src/view/style/Stylesheet.ts
+++ b/packages/core/src/view/style/Stylesheet.ts
@@ -63,32 +63,30 @@ export class Stylesheet {
   /**
    * Creates and returns the default vertex style.
    */
-  createDefaultVertexStyle() {
-    const style = {} as CellStateStyle;
-    style.shape = 'rectangle';
-    style.perimeter = 'rectanglePerimeter';
-    style.verticalAlign = 'middle';
-    style.align = 'center';
-    style.fillColor = '#C3D9FF';
-    style.strokeColor = '#6482B9';
-    style.fontColor = '#774400';
-
-    return style;
+  createDefaultVertexStyle(): CellStateStyle {
+    return {
+      shape: 'rectangle',
+      perimeter: 'rectanglePerimeter',
+      verticalAlign: 'middle',
+      align: 'center',
+      fillColor: '#C3D9FF',
+      strokeColor: '#6482B9',
+      fontColor: '#774400',
+    } as CellStateStyle;
   }
 
   /**
    * Creates and returns the default edge style.
    */
-  createDefaultEdgeStyle() {
-    const style = {} as CellStateStyle;
-    style.shape = 'connector';
-    style.endArrow = 'classic';
-    style.verticalAlign = 'middle';
-    style.align = 'center';
-    style.strokeColor = '#6482B9';
-    style.fontColor = '#446299';
-
-    return style;
+  createDefaultEdgeStyle(): CellStateStyle {
+    return {
+      shape: 'connector',
+      endArrow: 'classic',
+      verticalAlign: 'middle',
+      align: 'center',
+      strokeColor: '#6482B9',
+      fontColor: '#446299',
+    } as CellStateStyle;
   }
 
   /**


### PR DESCRIPTION
Replace imperative property assignment with object literal syntax
in createDefaultVertexStyle() and createDefaultEdgeStyle() methods.
This makes the code more concise and readable without changing behavior.

- Use direct object literal returns instead of empty object + assignments
- Add explicit return type annotations (CellStateStyle)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified default style object creation with improved type safety declarations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->