### PR TITLE
feat(VertexHandler): add margin and preview shape matching options

### DIFF
--- a/packages/core/src/view/event/InternalEvent.ts
+++ b/packages/core/src/view/event/InternalEvent.ts
@@ -229,12 +229,10 @@ class InternalEvent {
   }
 
   /**
-   * Redirects the mouse events from the given DOM node to the graph dispatch
-   * loop using the event and given state as event arguments. State can
-   * either be an instance of <CellState> or a function that returns an
-   * <CellState>. The down, move, up and dblClick arguments are optional
-   * functions that take the trigger event as arguments and replace the
-   * default behaviour.
+   * Redirects the mouse events from the given DOM node to the graph dispatch loop using the event and given state as event arguments.
+   * State can either be an instance of {@link CellState} or a function that returns an {@link CellState}.
+   *
+   * The down, move, up and dblClick arguments are optional functions that take the trigger event as arguments and replace the default behaviour.
    */
   static redirectMouseEvents(
     node: Listenable,

--- a/packages/core/src/view/handler/config.ts
+++ b/packages/core/src/view/handler/config.ts
@@ -237,6 +237,13 @@ export const VertexHandlerConfig = {
   cursorMovable: 'move',
 
   /**
+   * Margin to be added between the selection border and the vertex's bounding box.
+   * @default 0
+   * @since 0.22.0
+   */
+  margin: 0,
+
+  /**
    * Enable rotation handle
    * @default false
    */
@@ -250,6 +257,13 @@ export const VertexHandlerConfig = {
   selectionColor: VERTEX_SELECTION_COLOR,
 
   /**
+   * Defines the default dashed state to be used for the vertex selection border.
+   * @default {@link VERTEX_SELECTION_DASHED}
+   * @since 0.14.0
+   */
+  selectionDashed: VERTEX_SELECTION_DASHED,
+
+  /**
    * Defines the default stroke width to be used for vertex selections.
    * @default {@link VERTEX_SELECTION_STROKEWIDTH}
    * @since 0.14.0
@@ -257,11 +271,13 @@ export const VertexHandlerConfig = {
   selectionStrokeWidth: VERTEX_SELECTION_STROKEWIDTH,
 
   /**
-   * Defines the default dashed state to be used for the vertex selection border.
-   * @default {@link VERTEX_SELECTION_DASHED}
-   * @since 0.14.0
+   * Specifies if the selection border should match the shape of the vertex. If false, the border is rectangular.
+   * This mimics the behavior of {@link CellRenderer}: first check if the shape is available in the {@link StencilShapeRegistry}, otherwise use the shape of the vertex.
+   *
+   * @default false
+   * @since 0.22.0
    */
-  selectionDashed: VERTEX_SELECTION_DASHED,
+  selectionShapeMatchVertex: false,
 };
 
 const defaultVertexHandlerConfig = { ...VertexHandlerConfig };

--- a/packages/core/src/view/shape/Shape.ts
+++ b/packages/core/src/view/shape/Shape.ts
@@ -60,10 +60,11 @@ import { StyleDefaultsConfig } from '../../util/config.js';
  * or one filled region and an additional stroke the mxActor and mxCylinder
  * should be subclassed, respectively.
  * ```javascript
- * function CustomShape() { }
- *
- * CustomShape.prototype = new mxShape();
- * CustomShape.prototype.constructor = CustomShape;
+ * class CustomShape extends Shape {
+ *   constructor() {
+ *     super();
+ *   }
+ * }
  * ```
  * To register a custom shape in an existing graph instance, one must register the
  * shape under a new name in the graph’s cell renderer as follows:
@@ -203,45 +204,52 @@ class Shape {
   svgStrokeTolerance = 8;
 
   /**
-   * Specifies if pointer events should be handled. Default is true.
+   * Specifies if pointer events should be handled.
+   * @default true
    */
   pointerEvents = true;
 
   originalPointerEvents: boolean | null = null;
 
   /**
-   * Specifies if pointer events should be handled. Default is true.
+   * Specifies if pointer events should be handled.
+   * @default 'all'
    */
   svgPointerEvents = 'all';
 
   /**
-   * Specifies if pointer events outside of shape should be handled. Default
-   * is false.
+   * Specifies if pointer events outside of shape should be handled.
+   * @default false
    */
   shapePointerEvents = false;
 
   /**
-   * Specifies if pointer events outside of stencils should be handled. Default
-   * is false. Set this to true for backwards compatibility with the 1.x branch.
+   * Specifies if pointer events outside of stencils should be handled.
+   * Set this to `true` for backwards compatibility with the 1.x branch.
+   *
+   * @default false
    */
   stencilPointerEvents = false;
 
   /**
-   * Specifies if the shape should be drawn as an outline. This disables all
-   * fill colors and can be used to disable other drawing states that should
-   * not be painted for outlines. Default is false. This should be set before
-   * calling <apply>.
+   * Specifies if the shape should be drawn as an outline.
+   *
+   * This disables all fill colors and can be used to disable other drawing states that should not be painted for outlines.
+   * This should be set before calling {@link apply}.
+   *
+   * @default false
    */
   outline = false;
 
   /**
-   * Specifies if the shape is visible. Default is true.
+   * Specifies if the shape is visible.
+   * @default true
    */
   visible = true;
 
   /**
-   * Allows to use the SVG bounding box in SVG. Default is false for performance
-   * reasons.
+   * Allows to use the SVG bounding box in SVG.
+   * @default true
    */
   useSvgBoundingBox = true;
 
@@ -565,14 +573,12 @@ class Shape {
     let strokeDrawn = false;
 
     if (c && this.outline) {
-      const { stroke } = c;
+      const { fillAndStroke, stroke } = c;
 
       c.stroke = (...args) => {
         strokeDrawn = true;
         stroke.apply(c, args);
       };
-
-      const { fillAndStroke } = c;
 
       c.fillAndStroke = (...args) => {
         strokeDrawn = true;

--- a/packages/html/stories/CustomHandlesConfiguration.stories.ts
+++ b/packages/html/stories/CustomHandlesConfiguration.stories.ts
@@ -85,7 +85,10 @@ const Template = ({ label, ...args }: Record<string, string>) => {
     HandleConfig.size = 8;
     HandleConfig.strokeColor = '#0088cf';
 
+    VertexHandlerConfig.margin = 6;
     VertexHandlerConfig.selectionColor = selectionColor;
+    VertexHandlerConfig.selectionDashed = false;
+    VertexHandlerConfig.selectionShapeMatchVertex = true;
     VertexHandlerConfig.selectionStrokeWidth = 2;
   }
 
@@ -120,9 +123,37 @@ const Template = ({ label, ...args }: Record<string, string>) => {
 
   // Adds cells to the model in a single step
   graph.batchUpdate(() => {
-    const v1 = graph.insertVertex(parent, null, 'A1', 20, 20, 40, 80, { shape: 'and' });
-    const v2 = graph.insertVertex(parent, null, 'A2', 20, 220, 40, 80, { shape: 'and' });
-    const v3 = graph.insertVertex(parent, null, 'X1', 160, 110, 80, 80, { shape: 'xor' });
+    const v1 = graph.insertVertex({
+      value: 'A1\nnot rotatable',
+      x: 5,
+      y: 15,
+      width: 80,
+      height: 80,
+      style: { rotatable: false, rounded: true },
+    });
+    const v2 = graph.insertVertex({
+      value: 'A2\npre rotated',
+      x: 20,
+      y: 220,
+      width: 60,
+      height: 80,
+      style: {
+        rotation: -30,
+        rounded: true,
+      },
+    });
+    const v3 = graph.insertVertex({
+      value: 'X1 circle\nnot resizable',
+      x: 160,
+      y: 110,
+      width: 80,
+      height: 80,
+      style: {
+        perimeter: 'ellipsePerimeter',
+        resizable: false,
+        shape: 'ellipse',
+      },
+    });
     const e1 = graph.insertEdge(parent, null, 'Edge from A1 to X1', v1, v3);
     e1.geometry!.points = [new Point(90, 60), new Point(90, 130)];
     const e2 = graph.insertEdge(parent, null, 'Edge from A2 to X1', v2, v3);
@@ -132,9 +163,16 @@ const Template = ({ label, ...args }: Record<string, string>) => {
       shape: 'customShape',
       flipH: true,
     });
-    const v5 = graph.insertVertex(parent, null, 'A4', 520, 220, 40, 80, {
-      shape: 'and',
-      flipH: true,
+    const v5 = graph.insertVertex({
+      value: 'A4',
+      x: 520,
+      y: 220,
+      width: 60,
+      height: 60,
+      style: {
+        perimeter: 'ellipsePerimeter',
+        shape: 'ellipse',
+      },
     });
     const v6 = graph.insertVertex(parent, null, 'X2', 340, 110, 80, 80, {
       shape: 'xor',
@@ -147,9 +185,11 @@ const Template = ({ label, ...args }: Record<string, string>) => {
     const e4 = graph.insertEdge(parent, null, 'Edge from A4 to X2', v5, v6);
     e4.geometry!.points = [new Point(490, 260), new Point(350, 220)];
 
-    const v7 = graph.insertVertex(parent, null, 'O1', 250, 260, 80, 60, {
-      shape: 'or',
-      direction: 'south',
+    const v7 = graph.insertVertex(parent, null, 'O1\nnot movable', 250, 260, 100, 60, {
+      perimeter: 'rhombusPerimeter',
+      movable: false,
+      rounded: true,
+      shape: 'rhombus',
     });
     const e5 = graph.insertEdge(parent, null, '', v6, v7);
     e5.geometry!.points = [new Point(310, 150)];

--- a/packages/html/stories/Stencils.stories.ts
+++ b/packages/html/stories/Stencils.stories.ts
@@ -28,7 +28,6 @@ import {
   InternalEvent,
   requestUtils,
   Point,
-  type Rectangle,
   RubberBandHandler,
   Shape,
   ShapeRegistry,
@@ -78,6 +77,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
   HandleConfig.fillColor = '#99ccff';
   HandleConfig.strokeColor = '#0088cf';
   VertexHandlerConfig.selectionColor = '#00a8ff';
+  VertexHandlerConfig.selectionShapeMatchVertex = true;
 
   // Enables connections along the outline
   ConnectionHandler.prototype.outlineConnect = true;
@@ -87,32 +87,9 @@ const Template = ({ label, ...args }: Record<string, string>) => {
 
   class CustomVertexHandler extends VertexHandler {
     // Enable rotation handle
-    // use an alternate way to enable rotation handle as we already override the VertexHandler for other purposes
-    // another way to enable rotation handle is to set `VertexHandlerConfig.rotationEnabled = true`;
+    // another way to enable rotation is to set `VertexHandlerConfig.rotationEnabled = true`;
     override isRotationEnabled(): boolean {
       return true;
-    }
-
-    // Uses the shape for resize previews
-    override createSelectionShape(bounds: Rectangle) {
-      const stencil = StencilShapeRegistry.get(this.state.style.shape);
-      let shape: Shape;
-
-      if (stencil) {
-        shape = new Shape(stencil);
-        shape.apply(this.state);
-      } else {
-        // @ts-ignore known to work at runtime
-        shape = new this.state.shape.constructor();
-      }
-
-      shape.outline = true;
-      shape.bounds = bounds;
-      shape.stroke = HandleConfig.strokeColor;
-      shape.strokeWidth = this.getSelectionStrokeWidth();
-      shape.isDashed = this.isSelectionDashed();
-      shape.isShadow = false;
-      return shape;
     }
   }
   // Enables rubberband selection


### PR DESCRIPTION
Add new configuration options to VertexHandler that allow:
- Customizable selection margins via options
- Preview shapes that match the actual vertex shape including shapes defined in stencils

Changes include:
- Update getSelectionBounds to use margin from options
- Update createSelectionShape to match cell shape styling
- Add options support to VertexHandler story examples
- Improve JSDoc documentation for new options


## Screenshots

<img width="654" height="567" alt="Margin" src="https://github.com/user-attachments/assets/a20fcba6-2459-4fdc-ad0c-f469664ffca3" />



https://github.com/user-attachments/assets/1ad82e4a-1d2a-463a-b274-63bdef406e24



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Selection shapes can now match vertex shapes using stencil-based rendering.
  * Added configurable margin settings for vertex selection handlers.
  * New configuration options for selection appearance and shape matching behavior.

* **Documentation**
  * Updated documentation with improved formatting and reference links.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->