### PR TITLE
fix: restore tooltip display when PopupMenuHandler is unavailable

### DIFF
--- a/packages/core/src/view/plugins/TooltipHandler.ts
+++ b/packages/core/src/view/plugins/TooltipHandler.ts
@@ -248,8 +248,7 @@ class TooltipHandler implements GraphPlugin, MouseListenerSet {
             state &&
             node &&
             !this.graph.isEditing() &&
-            popupMenuHandler &&
-            !popupMenuHandler.isMenuShowing() &&
+            !popupMenuHandler?.isMenuShowing() &&
             !this.graph.isMouseDown
           ) {
             // Uses information from inside event cause using the event at

--- a/packages/html/stories/Wires.stories.ts
+++ b/packages/html/stories/Wires.stories.ts
@@ -730,7 +730,6 @@ const Template = ({ label, ...args }: Record<string, string>) => {
     MyCustomCellEditorHandler,
     TooltipHandler,
     SelectionCellsHandler,
-    PopupMenuHandler,
     MyCustomConnectionHandler,
     MyCustomSelectionHandler,
     PanningHandler,

--- a/packages/html/stories/Wires.stories.ts
+++ b/packages/html/stories/Wires.stories.ts
@@ -48,7 +48,6 @@ import {
   mathUtils,
   PanningHandler,
   Point,
-  PopupMenuHandler,
   Rectangle,
   RubberBandHandler,
   SelectionCellsHandler,


### PR DESCRIPTION

- Closes #961.
- See issue https://github.com/maxGraph/maxGraph/issues/961 where I have discussed the issue with @tbouffard .
- The scope of the PR is sufficiently narrow to be examined in a single session.
- I have update Storybook story in `packages/html/stories/Wires.stories.ts` by removing the unused PopupMenuHandler and verified now tooltips are correctly displayed.
- The change is semantically the same as proposed in the issue itself. See comment https://github.com/maxGraph/maxGraph/issues/961#issuecomment-3584915836.
- No changes in the documentation were needed, as this was a bug.
- The PR title follows the ["Conventional Commits"](https://www.conventionalcommits.org/en/v1.0.0/) guidelines.


## Overview

As described in issue #961 , the current version does not display any tooltip when the plugin PopupMenuHandler is not added to the list of the plugins. This is a common case when BaseGraph is used over Graph (as suggested in the documentation, BaseGraph should always be the choice for production).

The solution now handle this case correctly: when popupMenuHandler is not available (undefined) or the menu is not showing, then the tooltip will be displayed.
```typescript
!popupMenuHandler?.isMenuShowing()
```

To verify that the solution works, use the story "Wires" which has been edited in order to not include the PopupMenuHandler. Tooltips on vertices and edges should now be displayed correctly.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tooltips now appear in additional cases where they were previously suppressed, improving discoverability.

* **Chores**
  * Removed registration of an internal popup menu plugin from a demo/story, cleaning up example setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->