### PR TITLE
ci: publish npm package with trusted publisher

### DIFF
--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -7,8 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     permissions:
-      # required for "npm provenance"
-      id-token: write
+      id-token: write  # Required for OIDC: trusted publisher and "npm provenance"
       contents: write
     steps:
       - uses: actions/checkout@v6
@@ -16,7 +15,6 @@ jobs:
         uses: ./.github/actions/build-setup
         with:
           registry-url: 'https://registry.npmjs.org'
-      # scoped package requires "access=public"
+      # the scoped package requires "access=public"
+      # no token used, use trusted publisher setup instead (https://docs.npmjs.com/trusted-publishers)
       - run: npm publish -w packages/core --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
No longer use a token to increase security.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package publishing workflow to use a more secure authentication method, improving the reliability and security of the release process while maintaining the same publish capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->