### PR TITLE
refactor: introduce internal log() shortcut function

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,6 +246,8 @@ packages/
 
 ## Coding Practices
 
+When developing in the core package, follow these guidelines:
+
 ### Null/Undefined Checks
 
 Use the `isNullish` function when checking for `null` or `undefined` on variables that can have falsy values (numbers, strings, booleans). This avoids bugs where `0`, `""`, or `false` are incorrectly treated as nullish.
@@ -258,6 +260,34 @@ if (isNullish(index)) { ... }
 
 // Bad - treats index = 0 as falsy
 if (!index) { ... }
+```
+
+### Logging and i18n
+
+Use the internal utility functions instead of accessing `GlobalConfig` directly:
+
+**For logging**, use the `log()` function from `internal/utils.js`:
+```typescript
+import { log } from '../internal/utils.js';
+
+// Good - uses internal log function
+log().warn('Something unexpected happened');
+log().error('An error occurred', error);
+
+// Bad - accesses GlobalConfig directly
+GlobalConfig.logger.warn('Something unexpected happened');
+```
+
+**For internationalization**, use functions from `internal/i18n-utils.js`:
+```typescript
+import { translate, isI18nEnabled } from '../internal/i18n-utils.js';
+
+// Good - uses internal i18n functions
+const message = translate('key', params, 'default');
+if (isI18nEnabled()) { ... }
+
+// Bad - accesses GlobalConfig directly
+const message = GlobalConfig.i18n.get('key', params, 'default');
 ```
 
 ## Important Patterns

--- a/packages/core/src/gui/MaxLog.ts
+++ b/packages/core/src/gui/MaxLog.ts
@@ -23,17 +23,17 @@ import { toString } from '../util/StringUtils.js';
 import MaxWindow from './MaxWindow.js';
 import { KeyboardEventListener, MouseEventListener } from '../types.js';
 import { getElapseMillisecondsMessage } from '../internal/time-utils.js';
+import { log } from '../internal/utils.js';
 import { VERSION } from '../util/Constants.js';
-import { GlobalConfig } from '../util/config.js';
 import { popup } from './guiUtils.js';
 
 const copyTextToClipboard = (text: string): void => {
   navigator.clipboard.writeText(text).then(
     function () {
-      GlobalConfig.logger.info('Async: Copying to clipboard was successful!');
+      log().info('Async: Copying to clipboard was successful!');
     },
     function (err) {
-      GlobalConfig.logger.error('Async: Could not copy text: ', err);
+      log().error('Async: Could not copy text: ', err);
     }
   );
 };

--- a/packages/core/src/internal/utils.ts
+++ b/packages/core/src/internal/utils.ts
@@ -17,6 +17,7 @@ limitations under the License.
 import { NODE_TYPE } from '../util/Constants.js';
 import { UserObject } from './types.js';
 import { GlobalConfig } from '../util/config.js';
+import { Logger } from '../types.js';
 
 /**
  * @private
@@ -45,6 +46,11 @@ export const isNullish = (v: unknown): v is null | undefined =>
   v === null || v === undefined;
 
 /**
+ * Returns the global logger.
+ */
+export const log = (): Logger => GlobalConfig.logger;
+
+/**
  * Merge a mixin into the destination.
  *
  * WARN: do not use "complex" properties type (object, array), as they will be shared between all instances of the destination class.
@@ -67,7 +73,7 @@ export const mixInto = (dest: any) => (mixin: any) => {
       });
     }
   } catch (e) {
-    GlobalConfig.logger.error('Error while mixing', e);
+    log().error('Error while mixing', e);
   }
 };
 

--- a/packages/core/src/internal/utils.ts
+++ b/packages/core/src/internal/utils.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import { NODE_TYPE } from '../util/Constants.js';
 import { UserObject } from './types.js';
 import { GlobalConfig } from '../util/config.js';
-import { Logger } from '../types.js';
+import type { Logger } from '../types.js';
 
 /**
  * @private

--- a/packages/core/src/serialization/Codec.ts
+++ b/packages/core/src/serialization/Codec.ts
@@ -120,8 +120,8 @@ const createXmlDocument = () => {
  * const oldEncode = encode;
  * encode(obj)
  * {
- *   log().show();
- *   log().debug('Codec.encode: obj=' + StringUtils.getFunctionName(obj.constructor));
+ *   GlobalConfig.logger.show();
+ *   GlobalConfig.logger.debug('Codec.encode: obj=' + StringUtils.getFunctionName(obj.constructor));
  *
  *   return oldEncode.apply(this, arguments);
  * };

--- a/packages/core/src/serialization/Codec.ts
+++ b/packages/core/src/serialization/Codec.ts
@@ -19,10 +19,9 @@ limitations under the License.
 import CellPath from '../view/cell/CellPath.js';
 import CodecRegistry from './CodecRegistry.js';
 import Cell from '../view/cell/Cell.js';
-import { GlobalConfig } from '../util/config.js';
 import { getFunctionName } from '../util/StringUtils.js';
 import { importNode, isNode } from '../util/domUtils.js';
-import { isElement } from '../internal/utils.js';
+import { isElement, log } from '../internal/utils.js';
 import type ObjectCodec from './ObjectCodec.js';
 
 const createXmlDocument = () => {
@@ -121,8 +120,8 @@ const createXmlDocument = () => {
  * const oldEncode = encode;
  * encode(obj)
  * {
- *   GlobalConfig.logger.show();
- *   GlobalConfig.logger.debug('Codec.encode: obj=' + StringUtils.getFunctionName(obj.constructor));
+ *   log().show();
+ *   log().debug('Codec.encode: obj=' + StringUtils.getFunctionName(obj.constructor));
  *
  *   return oldEncode.apply(this, arguments);
  * };
@@ -335,9 +334,7 @@ class Codec {
       } else if (isNode(obj)) {
         node = importNode(this.document, obj, true);
       } else {
-        GlobalConfig.logger.warn(
-          `Codec.encode: No codec for ${getFunctionName(obj.constructor)}`
-        );
+        log().warn(`Codec.encode: No codec for ${getFunctionName(obj.constructor)}`);
       }
     }
     return node;
@@ -365,7 +362,7 @@ class Codec {
       if (dec != null) {
         obj = dec.decode(this, node, into);
       } else {
-        GlobalConfig.logger.warn(
+        log().warn(
           `Codec.decode: No codec found for node '${node.nodeName}', so the node won't be decoded, the original XML Element is returned instead.`
         );
         obj = <Element>node.cloneNode(true);

--- a/packages/core/src/serialization/ObjectCodec.ts
+++ b/packages/core/src/serialization/ObjectCodec.ts
@@ -55,11 +55,11 @@ const pointNumericAttributes: Array<keyof Point> = ['_x', '_y'];
  * const node = enc.encode(obj);
  * ```
  *
- * The output of the encoding may be viewed using {@link log()} as follows.
+ * The output of the encoding may be viewed using {@link GlobalConfig.logger} as follows.
  *
  * ```javascript
- * log().show();
- * log().debug(mxUtils.getPrettyXml(node));
+ * GlobalConfig.logger.show();
+ * GlobalConfig.logger.debug(mxUtils.getPrettyXml(node));
  * ```
  *
  * Finally, the result of the encoding looks as follows.
@@ -380,7 +380,7 @@ class ObjectCodec {
    * if the value is a function.
    *
    * If no ID exists for a variable in {@link idrefs} or if an object
-   * cannot be encoded, a warning is issued using {@link log()}.
+   * cannot be encoded, a warning is issued using {@link GlobalConfig.logger}.
    *
    * Returns the resulting XML node that represents the given
    * object.
@@ -674,7 +674,7 @@ class ObjectCodec {
    * ```
    *
    * If no object exists for an ID in {@link idrefs} a warning is issued
-   * using {@link log()}.
+   * using {@link GlobalConfig.logger}.
    *
    * Returns the resulting object that represents the given XML node
    * or the object given to the method as the into parameter.

--- a/packages/core/src/serialization/ObjectCodec.ts
+++ b/packages/core/src/serialization/ObjectCodec.ts
@@ -17,14 +17,13 @@ limitations under the License.
 */
 
 import ObjectIdentity from '../util/ObjectIdentity.js';
-import { GlobalConfig } from '../util/config.js';
 import Geometry from '../view/geometry/Geometry.js';
 import Point from '../view/geometry/Point.js';
 import { isInteger, isNumeric } from '../util/mathUtils.js';
 import { getTextContent } from '../util/domUtils.js';
 import { load } from '../util/requestUtils.js';
 import type Codec from './Codec.js';
-import { doEval, isElement } from '../internal/utils.js';
+import { doEval, isElement, log } from '../internal/utils.js';
 
 const geometryNumericAttributes: Array<keyof Geometry> = [
   '_x',
@@ -56,11 +55,11 @@ const pointNumericAttributes: Array<keyof Point> = ['_x', '_y'];
  * const node = enc.encode(obj);
  * ```
  *
- * The output of the encoding may be viewed using {@link GlobalConfig.logger} as follows.
+ * The output of the encoding may be viewed using {@link log()} as follows.
  *
  * ```javascript
- * GlobalConfig.logger.show();
- * GlobalConfig.logger.debug(mxUtils.getPrettyXml(node));
+ * log().show();
+ * log().debug(mxUtils.getPrettyXml(node));
  * ```
  *
  * Finally, the result of the encoding looks as follows.
@@ -381,7 +380,7 @@ class ObjectCodec {
    * if the value is a function.
    *
    * If no ID exists for a variable in {@link idrefs} or if an object
-   * cannot be encoded, a warning is issued using {@link GlobalConfig.logger}.
+   * cannot be encoded, a warning is issued using {@link log()}.
    *
    * Returns the resulting XML node that represents the given
    * object.
@@ -446,9 +445,7 @@ class ObjectCodec {
         const tmp = enc.getId(value);
 
         if (tmp == null) {
-          GlobalConfig.logger.warn(
-            `ObjectCodec.encode: No ID for ${this.getName()}.${name}=${value}`
-          );
+          log().warn(`ObjectCodec.encode: No ID for ${this.getName()}.${name}=${value}`);
           return; // exit
         }
 
@@ -527,9 +524,7 @@ class ObjectCodec {
 
       node.appendChild(child);
     } else {
-      GlobalConfig.logger.warn(
-        `ObjectCodec.encode: No node for ${this.getName()}.${name}: ${value}`
-      );
+      log().warn(`ObjectCodec.encode: No node for ${this.getName()}.${name}: ${value}`);
     }
   }
 
@@ -679,7 +674,7 @@ class ObjectCodec {
    * ```
    *
    * If no object exists for an ID in {@link idrefs} a warning is issued
-   * using {@link GlobalConfig.logger}.
+   * using {@link log()}.
    *
    * Returns the resulting object that represents the given XML node
    * or the object given to the method as the into parameter.
@@ -770,7 +765,7 @@ class ObjectCodec {
         const tmp = dec.getObject(value);
 
         if (tmp == null) {
-          GlobalConfig.logger.warn(
+          log().warn(
             `ObjectCodec.decode: No object for ${this.getName()}.${name}=${value}`
           );
           return; // exit

--- a/packages/core/src/serialization/codecs/StylesheetCodec.ts
+++ b/packages/core/src/serialization/codecs/StylesheetCodec.ts
@@ -19,10 +19,9 @@ import { getNameFromRegistries } from './utils.js';
 import { Stylesheet } from '../../view/style/Stylesheet.js';
 import type Codec from '../Codec.js';
 import { clone } from '../../util/cloneUtils.js';
-import { GlobalConfig } from '../../util/config.js';
 import { isNumeric } from '../../util/mathUtils.js';
 import { getTextContent } from '../../util/domUtils.js';
-import { doEval, isElement } from '../../internal/utils.js';
+import { doEval, isElement, log } from '../../internal/utils.js';
 
 /**
  * Codec for {@link Stylesheet}s.
@@ -147,7 +146,7 @@ export class StylesheetCodec extends ObjectCodec {
 
           if (!style) {
             if (extend) {
-              GlobalConfig.logger.warn(
+              log().warn(
                 `StylesheetCodec.decode: stylesheet ${extend} not found to extend`
               );
             }

--- a/packages/core/src/serialization/codecs/editor/EditorToolbarCodec.ts
+++ b/packages/core/src/serialization/codecs/editor/EditorToolbarCodec.ts
@@ -18,12 +18,11 @@ import ObjectCodec from '../../ObjectCodec.js';
 import { EditorToolbar } from '../../../editor/EditorToolbar.js';
 import type Codec from '../../Codec.js';
 import type Editor from '../../../editor/Editor.js';
-import { GlobalConfig } from '../../../util/config.js';
 import { convertPoint } from '../../../util/styleUtils.js';
 import { getClientX, getClientY } from '../../../util/EventUtils.js';
 import InternalEvent from '../../../view/event/InternalEvent.js';
 import { getChildNodes, getTextContent } from '../../../util/domUtils.js';
-import { doEval, isElement } from '../../../internal/utils.js';
+import { doEval, isElement, log } from '../../../internal/utils.js';
 import { translate } from '../../../internal/i18n-utils.js';
 
 type HTMLOptionElementWithCellStyle = HTMLOptionElement & { cellStyle?: string | null };
@@ -230,7 +229,7 @@ export class EditorToolbarCodec extends ObjectCodec {
 
                           return clone;
                         }
-                        GlobalConfig.logger.warn(`Template ${template} not found`);
+                        log().warn(`Template ${template} not found`);
 
                         return null;
                       };

--- a/packages/core/src/view/GraphView.ts
+++ b/packages/core/src/view/GraphView.ts
@@ -31,7 +31,6 @@ import {
   relativeCcw,
   toRadians,
 } from '../util/mathUtils.js';
-import { GlobalConfig } from '../util/config.js';
 import CellState from './cell/CellState.js';
 import UndoableEdit from './undoable_changes/UndoableEdit.js';
 import ImageShape from './shape/node/ImageShape.js';
@@ -50,7 +49,7 @@ import { EdgeStyleRegistry } from './style/edge/EdgeStyleRegistry.js';
 import { PerimeterRegistry } from './style/perimeter/PerimeterRegistry.js';
 import type TooltipHandler from './plugins/TooltipHandler.js';
 import type { EdgeStyleFunction, MouseEventListener } from '../types.js';
-import { doEval } from '../internal/utils.js';
+import { doEval, log } from '../internal/utils.js';
 import { isI18nEnabled } from '../internal/i18n-utils.js';
 
 /**
@@ -543,7 +542,7 @@ export class GraphView extends EventSource {
    * Default is {@link currentRoot} or the root of the model.
    */
   validate(cell: Cell | null = null) {
-    const t0 = GlobalConfig.logger.enter('GraphView.validate');
+    const t0 = log().enter('GraphView.validate');
 
     this.resetValidationState();
 
@@ -560,7 +559,7 @@ export class GraphView extends EventSource {
       this.resetValidationState();
     }
 
-    GlobalConfig.logger.leave('GraphView.validate', t0);
+    log().leave('GraphView.validate', t0);
   }
 
   /**

--- a/packages/core/src/view/layout/hierarchical/CoordinateAssignment.ts
+++ b/packages/core/src/view/layout/hierarchical/CoordinateAssignment.ts
@@ -18,7 +18,6 @@ limitations under the License.
 
 import HierarchicalLayoutStage from './HierarchicalLayoutStage.js';
 import type { DirectionValue } from '../../../types.js';
-import { GlobalConfig } from '../../../util/config.js';
 import WeightedCellSorter from '../util/WeightedCellSorter.js';
 import Point from '../../geometry/Point.js';
 import HierarchicalEdgeStyle from '../datatypes/HierarchicalEdgeStyle.js';
@@ -31,6 +30,7 @@ import type { AbstractGraph } from '../../AbstractGraph.js';
 import Geometry from '../../../view/geometry/Geometry.js';
 import GraphHierarchyEdge from '../datatypes/GraphHierarchyEdge.js';
 import SwimlaneLayout from '../SwimlaneLayout.js';
+import { log } from '../../../internal/utils.js';
 
 /**
  * Sets the horizontal locations of node and edge dummy nodes on each layer.
@@ -205,7 +205,7 @@ class CoordinateAssignment extends HierarchicalLayoutStage {
     const model = <GraphHierarchyModel>this.layout.getDataModel();
     const ranks = <GraphAbstractHierarchyCell[][]>model.ranks;
 
-    const logger = GlobalConfig.logger;
+    const logger = log();
     logger.show();
     logger.info('======Coord assignment debug=======');
 
@@ -727,7 +727,7 @@ class CoordinateAssignment extends HierarchicalLayoutStage {
         if (node.edges != null) {
           numEdges = node.edges.length;
         } else {
-          GlobalConfig.logger.warn('edge.edges is null');
+          log().warn('edge.edges is null');
         }
 
         node.width = (numEdges - 1) * this.parallelEdgeSpacing;
@@ -742,7 +742,7 @@ class CoordinateAssignment extends HierarchicalLayoutStage {
     }
 
     if (boundsWarning) {
-      GlobalConfig.logger.warn('At least one cell has no bounds');
+      log().warn('At least one cell has no bounds');
     }
   }
 
@@ -801,7 +801,7 @@ class CoordinateAssignment extends HierarchicalLayoutStage {
           if (node.edges != null) {
             numEdges = node.edges.length;
           } else {
-            GlobalConfig.logger.warn('edge.edges is null');
+            log().warn('edge.edges is null');
           }
 
           node.width = (numEdges - 1) * this.parallelEdgeSpacing;
@@ -823,7 +823,7 @@ class CoordinateAssignment extends HierarchicalLayoutStage {
       }
 
       if (boundsWarning) {
-        GlobalConfig.logger.warn('At least one cell has no bounds');
+        log().warn('At least one cell has no bounds');
       }
 
       this.rankY[rankValue] = y;

--- a/packages/core/src/view/other/PrintPreview.ts
+++ b/packages/core/src/view/other/PrintPreview.ts
@@ -26,7 +26,7 @@ import { addLinkToHead, write } from '../../util/domUtils.js';
 import type { AbstractGraph } from '../AbstractGraph.js';
 import type CellState from '../cell/CellState.js';
 import type Cell from '../cell/Cell.js';
-import { GlobalConfig } from '../../util/config.js';
+import { log } from '../../internal/utils.js';
 
 /**
  * Implements printing of a diagram across multiple pages.
@@ -886,7 +886,7 @@ class PrintPreview {
         return this.getLinkForCellState(state);
       });
     } catch (e: unknown) {
-      GlobalConfig.logger.error('PrintPreview unable to generate the preview', e);
+      log().error('PrintPreview unable to generate the preview', e);
     } finally {
       // Removes everything but the SVG node
       let tmp = <HTMLElement>div.firstChild;

--- a/packages/core/src/view/plugins/ConnectionHandler.ts
+++ b/packages/core/src/view/plugins/ConnectionHandler.ts
@@ -190,8 +190,8 @@ type FactoryMethod = (
  *   const sourcePortId = style.sourcePort;
  *   const targetPortId = style.targetPort;
  *
- *   log().show();
- *   log().debug(`connect edge=${edge.id} source=${source.id} target=${target.id} sourcePort=${sourcePortId} targetPort=${targetPortId}`);
+ *   GlobalConfig.logger.show();
+ *   GlobalConfig.logger.debug(`connect edge=${edge.id} source=${source.id} target=${target.id} sourcePort=${sourcePortId} targetPort=${targetPortId}`);
  * });
  * ```
  *

--- a/packages/core/src/view/plugins/ConnectionHandler.ts
+++ b/packages/core/src/view/plugins/ConnectionHandler.ts
@@ -41,7 +41,6 @@ import ConstraintHandler from '../handler/ConstraintHandler.js';
 import PolylineShape from '../shape/edge/PolylineShape.js';
 import EventSource from '../event/EventSource.js';
 import Rectangle from '../geometry/Rectangle.js';
-import { GlobalConfig } from '../../util/config.js';
 import {
   getClientX,
   getClientY,
@@ -61,6 +60,7 @@ import type {
   Listenable,
   MouseListenerSet,
 } from '../../types.js';
+import { log } from '../../internal/utils.js';
 
 type FactoryMethod = (
   source: Cell | null,
@@ -190,8 +190,8 @@ type FactoryMethod = (
  *   const sourcePortId = style.sourcePort;
  *   const targetPortId = style.targetPort;
  *
- *   GlobalConfig.logger.show();
- *   GlobalConfig.logger.debug('connect', edge, source.id, target.id, sourcePortId, targetPortId);
+ *   log().show();
+ *   log().debug('connect', edge, source.id, target.id, sourcePortId, targetPortId);
  * });
  * ```
  *
@@ -1832,11 +1832,11 @@ export default class ConnectionHandler
           );
         }
       } catch (e: any) {
-        GlobalConfig.logger.show();
+        log().show();
         const errorMessage = `Error in ConnectionHandler: ${
           e instanceof Error ? e.message + '\n' + e.stack : 'unknown cause'
         }`;
-        GlobalConfig.logger.debug(errorMessage);
+        log().debug(errorMessage);
       } finally {
         model.endUpdate();
       }

--- a/packages/core/src/view/plugins/ConnectionHandler.ts
+++ b/packages/core/src/view/plugins/ConnectionHandler.ts
@@ -191,7 +191,7 @@ type FactoryMethod = (
  *   const targetPortId = style.targetPort;
  *
  *   log().show();
- *   log().debug('connect', edge, source.id, target.id, sourcePortId, targetPortId);
+ *   log().debug(`connect edge=${edge.id} source=${source.id} target=${target.id} sourcePort=${sourcePortId} targetPort=${targetPortId}`);
  * });
  * ```
  *


### PR DESCRIPTION
Add a convenient log() function in internal/utils.ts that returns GlobalConfig.logger.
This provides a shorter, more readable alternative to accessing GlobalConfig.logger directly throughout the codebase.

Also documented the pattern in CLAUDE.md for future contributors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added coding guidelines for null/undefined checks and standardized logging recommendations.

* **Chores**
  * Migrated logging to a centralized utility for consistent log handling across the codebase. No changes to public APIs or user-facing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->