### PR TITLE
docs(HiearchicalLayout): fix copy pasted JSDoc for cache attributes

### DIFF
--- a/packages/core/src/view/layout/HierarchicalLayout.ts
+++ b/packages/core/src/view/layout/HierarchicalLayout.ts
@@ -144,17 +144,17 @@ class HierarchicalLayout extends GraphLayout {
   model: GraphHierarchyModel | null = null;
 
   /**
-   * A cache of edges whose source terminal is the key
+   * Maps each vertex to its computed list of incident edges considered by the layout.
    */
   edgesCache: Map<Cell, Cell[]> = new Map();
 
   /**
-   * A cache of edges whose source terminal is the key
+   * Maps each edge to its resolved visible source terminal vertex.
    */
   edgeSourceTermCache: Map<Cell, Cell> = new Map();
 
   /**
-   * A cache of edges whose source terminal is the key
+   * Maps each edge to its resolved visible target terminal vertex.
    */
   edgesTargetTermCache: Map<Cell, Cell> = new Map();
 
@@ -318,7 +318,6 @@ class HierarchicalLayout extends GraphLayout {
       return cachedEdges;
     }
 
-    const { model } = this.graph;
     let edges: Cell[] = [];
     const isCollapsed = cell.isCollapsed();
     const childCount = cell.getChildCount();

--- a/packages/core/src/view/layout/HierarchicalLayout.ts
+++ b/packages/core/src/view/layout/HierarchicalLayout.ts
@@ -144,17 +144,17 @@ class HierarchicalLayout extends GraphLayout {
   model: GraphHierarchyModel | null = null;
 
   /**
-   * Maps each vertex to its computed list of incident edges considered by the layout.
+   * Maps each cell to its computed list of incident edges considered by the layout.
    */
   edgesCache: Map<Cell, Cell[]> = new Map();
 
   /**
-   * Maps each edge to its resolved visible source terminal vertex.
+   * Maps each edge to its resolved visible source terminal cell.
    */
   edgeSourceTermCache: Map<Cell, Cell> = new Map();
 
   /**
-   * Maps each edge to its resolved visible target terminal vertex.
+   * Maps each edge to its resolved visible target terminal cell.
    */
   edgesTargetTermCache: Map<Cell, Cell> = new Map();
 


### PR DESCRIPTION

## Overview

Hello ! First of all thank you for the work on this library, it is very cool to use !
I was going throught the code and I think I spot a wrong copy/paste for the docstrings of `edgesCache`, `edgeSourceTermCache` and `edgesTargetTermCache`. I also removed a variable declaration that wasn't used

Very small changes so I didn't raise an issue, I hope it is ok 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed an unused local code declaration to streamline internal layout logic.
* **Documentation**
  * Clarified internal documentation describing how layout-related caches map edges and terminals for more accurate maintenance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->