### PR TITLE
feat(config): add reset functions for global configurations

### DIFF
--- a/packages/core/__tests__/util/config.test.ts
+++ b/packages/core/__tests__/util/config.test.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { describe, expect, test } from '@jest/globals';
+import { expect, test } from '@jest/globals';
 import {
   ConsoleLogger,
   GlobalConfig,

--- a/packages/core/__tests__/util/config.test.ts
+++ b/packages/core/__tests__/util/config.test.ts
@@ -14,12 +14,40 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { expect, test } from '@jest/globals';
-import { resetStyleDefaultsConfig, StyleDefaultsConfig } from '../../src';
+import { describe, expect, test } from '@jest/globals';
+import {
+  ConsoleLogger,
+  GlobalConfig,
+  resetGlobalConfig,
+  resetStyleDefaultsConfig,
+  StyleDefaultsConfig,
+  TranslationsAsI18n,
+} from '../../src';
+
+test('resetGlobalConfig', () => {
+  // Keep track of original default values
+  const originalConfig = { ...GlobalConfig };
+  const originalLogger = GlobalConfig.logger;
+  const originalI18n = GlobalConfig.i18n;
+
+  // Change some values
+  GlobalConfig.logger = new ConsoleLogger();
+  GlobalConfig.i18n = new TranslationsAsI18n();
+
+  expect(GlobalConfig.logger).not.toBe(originalLogger);
+  expect(GlobalConfig.i18n).not.toBe(originalI18n);
+
+  resetGlobalConfig();
+
+  // Ensure that the values are correctly reset
+  expect(GlobalConfig.logger).toBe(originalLogger);
+  expect(GlobalConfig.i18n).toBe(originalI18n);
+  expect(GlobalConfig).toStrictEqual(originalConfig);
+});
 
 test('resetStyleDefaultsConfig', () => {
   // Keep track of original default values
-  const originalStyleDefaultsConfig = { ...StyleDefaultsConfig };
+  const originalConfig = { ...StyleDefaultsConfig };
 
   // Change some values
   StyleDefaultsConfig.shadowColor = 'pink';
@@ -30,5 +58,5 @@ test('resetStyleDefaultsConfig', () => {
   // Ensure that the values are correctly reset
   expect(StyleDefaultsConfig.shadowColor).toBe('gray');
   expect(StyleDefaultsConfig.shadowOffsetX).toBe(2);
-  expect(StyleDefaultsConfig).toStrictEqual(originalStyleDefaultsConfig);
+  expect(StyleDefaultsConfig).toStrictEqual(originalConfig);
 });

--- a/packages/core/__tests__/view/shape/stencil/StencilShape.test.ts
+++ b/packages/core/__tests__/view/shape/stencil/StencilShape.test.ts
@@ -1,0 +1,33 @@
+/*
+Copyright 2025-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { expect, test } from '@jest/globals';
+import { resetStencilShapeConfig, StencilShapeConfig } from '../../../../src';
+
+test('resetStencilShapeConfig', () => {
+  // Keep track of original default values
+  const originalConfig = { ...StencilShapeConfig };
+
+  // Change some values
+  StencilShapeConfig.allowEval = true;
+  StencilShapeConfig.defaultLocalized = true;
+
+  resetStencilShapeConfig();
+
+  // Ensure that the values are correctly reset
+  expect(StencilShapeConfig.allowEval).toBeFalsy();
+  expect(StencilShapeConfig).toStrictEqual(originalConfig);
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -122,6 +122,7 @@ export * from './view/shape/register-shapes.js';
 
 export { unregisterAllStencilShapes } from './view/shape/stencil/register.js';
 export {
+  resetStencilShapeConfig,
   default as StencilShape,
   StencilShapeConfig,
 } from './view/shape/stencil/StencilShape.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -121,11 +121,7 @@ export * from './view/shape/ShapeRegistry.js';
 export * from './view/shape/register-shapes.js';
 
 export { unregisterAllStencilShapes } from './view/shape/stencil/register.js';
-export {
-  resetStencilShapeConfig,
-  default as StencilShape,
-  StencilShapeConfig,
-} from './view/shape/stencil/StencilShape.js';
+export * from './view/shape/stencil/StencilShape.js';
 export * from './view/shape/stencil/StencilShapeRegistry.js';
 
 export { default as Guide } from './view/other/Guide.js';

--- a/packages/core/src/util/config.ts
+++ b/packages/core/src/util/config.ts
@@ -82,6 +82,18 @@ export const GlobalConfig = {
   logger: new NoOpLogger() as Logger,
 };
 
+const defaultGlobalConfig = { ...GlobalConfig };
+/**
+ * Resets {@link GlobalConfig} to default values, restoring the original {@link NoOpI18n} and {@link NoOpLogger} instances.
+ *
+ * @experimental Subject to change or removal. maxGraph's global configuration may be modified in the future without prior notice.
+ * @since 0.23.0
+ * @category Configuration
+ */
+export const resetGlobalConfig = (): void => {
+  shallowCopy(defaultGlobalConfig, GlobalConfig);
+};
+
 /**
  * Configure style defaults for maxGraph.
  *

--- a/packages/core/src/view/shape/Shape.ts
+++ b/packages/core/src/view/shape/Shape.ts
@@ -26,7 +26,7 @@ import SvgCanvas2D from '../canvas/SvgCanvas2D.js';
 import InternalEvent from '../event/InternalEvent.js';
 import Client from '../../Client.js';
 import type CellState from '../cell/CellState.js';
-import type StencilShape from './stencil/StencilShape.js';
+import type { StencilShape } from './stencil/StencilShape.js';
 import type CellOverlay from '../cell/CellOverlay.js';
 import type ImageBox from '../image/ImageBox.js';
 import type {

--- a/packages/core/src/view/shape/stencil/StencilShape.ts
+++ b/packages/core/src/view/shape/stencil/StencilShape.ts
@@ -79,7 +79,7 @@ const toBoolean = (value: string | null) => value !== '0';
  *
  * @category Shape
  */
-class StencilShape extends Shape {
+export class StencilShape extends Shape {
   constructor(desc: Element) {
     super();
     this.desc = desc;
@@ -745,5 +745,3 @@ class StencilShape extends Shape {
     }
   }
 }
-
-export default StencilShape;

--- a/packages/core/src/view/shape/stencil/StencilShape.ts
+++ b/packages/core/src/view/shape/stencil/StencilShape.ts
@@ -28,6 +28,7 @@ import { AlignValue, ColorValue, VAlignValue } from '../../../types.js';
 import { doEval, isElement, isNullish } from '../../../internal/utils.js';
 import { translate } from '../../../internal/i18n-utils.js';
 import { StyleDefaultsConfig } from '../../../util/config.js';
+import { shallowCopy } from '../../../internal/clone-utils.js';
 
 /**
  * Configure global settings for stencil shapes.
@@ -52,6 +53,18 @@ export const StencilShapeConfig = {
    * @default false
    */
   defaultLocalized: false,
+};
+
+const defaultStencilShapeConfig = { ...StencilShapeConfig };
+/**
+ * Resets {@link StencilShapeConfig} to default values.
+ *
+ * @experimental Subject to change or removal. maxGraph's global configuration may be modified in the future without prior notice.
+ * @since 0.23.0
+ * @category Configuration
+ */
+export const resetStencilShapeConfig = (): void => {
+  shallowCopy(defaultStencilShapeConfig, StencilShapeConfig);
 };
 
 // To manage the following attribute described in stencils.xsd

--- a/packages/core/src/view/shape/stencil/StencilShapeRegistry.ts
+++ b/packages/core/src/view/shape/stencil/StencilShapeRegistry.ts
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type StencilShape from './StencilShape.js';
+import type { StencilShape } from './StencilShape.js';
 import { BaseRegistry } from '../../../internal/BaseRegistry.js';
 import type { Registry } from '../../../types.js';
 

--- a/packages/html/.storybook/preview.ts
+++ b/packages/html/.storybook/preview.ts
@@ -22,9 +22,11 @@ import {
   ObjectCodec,
   resetEdgeHandlerConfig,
   resetEntityRelationConnectorConfig,
+  resetGlobalConfig,
   resetHandleConfig,
   resetManhattanConnectorConfig,
   resetOrthogonalConnectorConfig,
+  resetStencilShapeConfig,
   resetStyleDefaultsConfig,
   resetTranslationsConfig,
   resetVertexHandlerConfig,
@@ -59,6 +61,7 @@ const originalAllowEvalConfig = {
 
 const resetMaxGraphConfigs = (): void => {
   // Global configuration
+  resetGlobalConfig();
   GlobalConfig.i18n = i18nProvider;
   GlobalConfig.logger = defaultLogger;
 
@@ -83,6 +86,7 @@ const resetMaxGraphConfigs = (): void => {
 
   // The following registries are filled by stories only
   unregisterAllStencilShapes();
+  resetStencilShapeConfig();
 };
 
 // This function is a workaround to destroy mxGraph elements that are not released by the previous story.

--- a/packages/website/docs/usage/global-configuration.md
+++ b/packages/website/docs/usage/global-configuration.md
@@ -28,7 +28,9 @@ The following objects can be used to configure `maxGraph` globally:
 Some functions are provided to reset the global configuration to the default values. For example:
 
   - `resetEdgeHandlerConfig` (since 0.14.0)
+  - `resetGlobalConfig` (since 0.23.0)
   - `resetHandleConfig` (since 0.14.0)
+  - `resetStencilShapeConfig` (since 0.23.0)
   - `resetStyleDefaultsConfig` (since 0.14.0)
   - `resetTranslationsConfig` (since 0.16.0)
   - `resetVertexHandlerConfig` (since 0.14.0)
@@ -42,7 +44,7 @@ Notice that the new global configuration elements introduced as version _0.11.0_
 :::
 
 :::info
-For former mxGraph users, the global configuration objects allow to set the default values previously defined in `mxConstants` and used everywhere in the code.
+For former mxGraph users, the global configuration objects allow you to set the default values previously defined in `mxConstants` and used everywhere in the code.
 Not all values are currently configurable yet, but the list is growing. 
 
 See also discussions in [issue #192](https://github.com/maxGraph/maxGraph/issues/192).
@@ -58,7 +60,7 @@ See also discussions in [issue #192](https://github.com/maxGraph/maxGraph/issues
 - `ShapeRegistry`: shapes (since 0.20.0, previously managed by `CellRenderer`)
 - `StencilShapeRegistry`: stencil shapes
 
-When instantiating a `Graph` object, the registries are filled with `maxGraph` default style configurations. There is no default stencil shapes registered by default.
+When instantiating a `Graph` object, the registries are filled with `maxGraph` default style configurations. There are no default stencil shapes registered by default.
 
 To manually register default style configurations, you can use the following functions:
 
@@ -83,7 +85,7 @@ unregisterAllStencilShapes();
 
 ## Codecs and Serialization
 
-`CodecRegistry` is used for serialization and deserialization of objects in XML object.
+`CodecRegistry` is used for serialization and deserialization of objects in XML objects.
 By default, no codec is registered. Some functions are provided to register codecs for specific objects.
 
 For more details about the codecs, see the Codec [documentation page](./codecs.md).


### PR DESCRIPTION
  Add functions to reset configuration objects to their default values:
  - `resetGlobalConfig()`: restores GlobalConfig to defaults, including the original NoOpLogger and NoOpI18n instances
  - `resetStencilShapeConfig()`: restores StencilShapeConfig to defaults

  Other changes:
  - Change StencilShape from default export to named export for better star re-export support
  - Use reset functions in Storybook preview to ensure consistent state between stories
  - Add tests for the new reset functions
  - Update documentation with new reset functions

  These reset functions are useful for testing scenarios and Storybook stories where configuration state needs to be restored between runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to reset global configuration and stencil-shape configuration back to defaults; widened public API surface for stencil shapes.

* **Bug Fixes / Tests**
  * Expanded tests to validate full configuration restoration after resets.

* **Documentation**
  * Updated global-configuration docs to include reset capabilities and minor clarity/grammar improvements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->