### PR TITLE
ci: ensure that all workflows define permissions of the GITHUB_TOKEN

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,8 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    permissions:
+        contents: read
     strategy:
       # we want to run the full build on all os: don't cancel running jobs even if one fails
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     permissions:
-        contents: read
+      contents: read
     strategy:
       # we want to run the full build on all os: don't cancel running jobs even if one fails
       fail-fast: false

--- a/.github/workflows/generate-website.yml
+++ b/.github/workflows/generate-website.yml
@@ -43,6 +43,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - name: Build Setup


### PR DESCRIPTION
This is a missing good practice in some existing workflows, highlighted by CodeQL workflow runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows with enhanced configuration settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->