### PR TITLE
ci: attach examples and website assets to GitHub releases

### DIFF
--- a/.github/workflows/_reusable_build_examples.yml
+++ b/.github/workflows/_reusable_build_examples.yml
@@ -6,10 +6,15 @@ on:
         description: 'Name of the output artifact containing the built examples'
         required: true
         type: string
+      runner:
+        description: 'The runner to use for the build'
+        required: false
+        type: string
+        default: 'ubuntu-24.04'
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ inputs.runner }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/_reusable_build_examples.yml
+++ b/.github/workflows/_reusable_build_examples.yml
@@ -1,4 +1,4 @@
-name: _reusable_build_examples.yml
+name: Build examples
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/_reusable_build_examples.yml
+++ b/.github/workflows/_reusable_build_examples.yml
@@ -1,0 +1,35 @@
+name: _reusable_build_examples.yml
+on:
+  workflow_call:
+    inputs:
+      artifact-name:
+        description: 'Name of the output artifact containing the built examples'
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build Setup
+        uses: ./.github/actions/build-setup
+
+      - name: Build @maxgraph/core
+        run: npm run build -w packages/core
+
+      - name: Build all examples
+        run: ./scripts/build-all-examples.bash
+
+      - name: Upload all examples as artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ inputs['artifact-name'] }}
+          path: |
+            packages/html/dist/
+            packages/js-example*/dist/
+            packages/ts-example*/dist/

--- a/.github/workflows/_reusable_build_examples.yml
+++ b/.github/workflows/_reusable_build_examples.yml
@@ -30,6 +30,5 @@ jobs:
         with:
           name: ${{ inputs['artifact-name'] }}
           path: |
-            packages/html/dist/
             packages/js-example*/dist/
             packages/ts-example*/dist/

--- a/.github/workflows/_reusable_build_examples.yml
+++ b/.github/workflows/_reusable_build_examples.yml
@@ -25,9 +25,11 @@ jobs:
         uses: ./.github/actions/build-setup
 
       - name: Build @maxgraph/core
+        shell: bash
         run: npm run build -w packages/core
 
       - name: Build all examples
+        shell: bash
         run: ./scripts/build-all-examples.bash
 
       - name: Upload all examples as artifact

--- a/.github/workflows/_reusable_generate_website.yml
+++ b/.github/workflows/_reusable_generate_website.yml
@@ -42,6 +42,19 @@ jobs:
         run: |
           mkdir -p artifact-output/maxGraph
           cp -r packages/website/build/* artifact-output/maxGraph/
+          cat > artifact-output/index.html << 'EOF'
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+            <meta charset="UTF-8">
+            <meta http-equiv="refresh" content="0; url=./maxGraph/index.html">
+            <title>Redirecting to maxGraph</title>
+          </head>
+          <body>
+            <p>Redirecting to <a href="./maxGraph/">maxGraph</a>...</p>
+          </body>
+          </html>
+          EOF
 
       - name: Upload website artifact for other environments
         if: ${{ inputs['artifact-name'] != 'gh-pages' }}

--- a/.github/workflows/_reusable_generate_website.yml
+++ b/.github/workflows/_reusable_generate_website.yml
@@ -41,8 +41,8 @@ jobs:
         if: ${{ inputs['artifact-name'] != 'gh-pages' }}
         uses: actions/upload-artifact@v6
         with:
-          path: packages/website/build/
           name: ${{ inputs['artifact-name'] }}
+          path: packages/website/build/
 
       - name: Check types in website
         run: npm run typecheck -w packages/website

--- a/.github/workflows/_reusable_generate_website.yml
+++ b/.github/workflows/_reusable_generate_website.yml
@@ -37,12 +37,18 @@ jobs:
         with:
           path: packages/website/build/
 
+      - name: Prepare website artifact with maxGraph subdirectory
+        if: ${{ inputs['artifact-name'] != 'gh-pages' }}
+        run: |
+          mkdir -p artifact-output/maxGraph
+          cp -r packages/website/build/* artifact-output/maxGraph/
+
       - name: Upload website artifact for other environments
         if: ${{ inputs['artifact-name'] != 'gh-pages' }}
         uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs['artifact-name'] }}
-          path: packages/website/build/
+          path: artifact-output/
 
       - name: Check types in website
         run: npm run typecheck -w packages/website

--- a/.github/workflows/_reusable_generate_website.yml
+++ b/.github/workflows/_reusable_generate_website.yml
@@ -51,7 +51,7 @@ jobs:
             <title>Redirecting to maxGraph</title>
           </head>
           <body>
-            <p>Redirecting to <a href="./maxGraph/">maxGraph</a>...</p>
+            <p>Redirecting to <a href="./maxGraph/index.html">maxGraph</a>...</p>
           </body>
           </html>
           EOF

--- a/.github/workflows/_reusable_generate_website.yml
+++ b/.github/workflows/_reusable_generate_website.yml
@@ -1,0 +1,48 @@
+name: _reusable_generate_website.yml
+on:
+    workflow_call:
+      inputs:
+        artifact-name:
+          description: 'Set to gh-pages for a special gh-pages artifact'
+          required: true
+          type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build Setup
+        uses: ./.github/actions/build-setup
+
+      - name: Build @maxgraph/core API docs
+        run: npm run docs:api -w packages/core
+
+      - name: Build Storybook demo
+        run: npm run build -w packages/core -w packages/html
+
+      - name: Copy generated resources to the website
+        run: npm run extra:copy-gen-resources -w packages/website
+
+      - name: Build website
+        run: npm run build -w packages/website
+
+      - name: Upload website artifact for GitHub Pages
+        if: ${{ inputs['artifact-name'] == 'gh-pages' }}
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: packages/website/build/
+
+      - name: Upload website artifact for other environments
+        if: ${{ inputs['artifact-name'] != 'gh-pages' }}
+        uses: actions/upload-artifact@v6
+        with:
+          path: packages/website/build/
+          name: ${{ inputs['artifact-name'] }}
+
+      - name: Check types in website
+        run: npm run typecheck -w packages/website

--- a/.github/workflows/_reusable_generate_website.yml
+++ b/.github/workflows/_reusable_generate_website.yml
@@ -1,11 +1,11 @@
 name: _reusable_generate_website.yml
 on:
-    workflow_call:
-      inputs:
-        artifact-name:
-          description: 'Set to gh-pages for a special gh-pages artifact'
-          required: true
-          type: string
+  workflow_call:
+    inputs:
+      artifact-name:
+        description: 'Set to gh-pages for a special gh-pages artifact'
+        required: true
+        type: string
 
 jobs:
   build:

--- a/.github/workflows/_reusable_generate_website.yml
+++ b/.github/workflows/_reusable_generate_website.yml
@@ -1,9 +1,9 @@
-name: _reusable_generate_website.yml
+name: Generate website
 on:
   workflow_call:
     inputs:
       artifact-name:
-        description: 'Set to gh-pages for a special gh-pages artifact'
+        description: 'Set to gh-pages for a special gh-pages artifact, otherwise the built website is zipped and uploaded as an artifact with this name'
         required: true
         type: string
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,8 @@ jobs:
 #    runs-on: ubuntu-24.04
   build_examples:
     needs: build
-    permissions: {}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_reusable_build_examples.yml
     with:
      artifact-name: examples-ubuntu-24.04-${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,13 @@ jobs:
       - name: Build Storybook mini-site
         run: npm run build -w packages/html
 
+      - name: Upload storybook mini-site as artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: storybook-${{runner.os}}-${{github.sha}}
+          path: |
+            packages/html/dist/
+
       - name: Ensure no circular dependencies in the @maxgraph/core produced JS files
         run: npm run check:circular-dependencies -w packages/core
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,8 +84,6 @@ jobs:
         run: npm run check:npm-package -w packages/core
 
 
-# TODO check if we can run on various OS https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#using-a-matrix-strategy-with-a-reusable-workflow
-#    runs-on: ubuntu-24.04
   build_examples:
     needs: build
     permissions:
@@ -95,6 +93,5 @@ jobs:
       matrix:
         runner: ['ubuntu-24.04', 'macos-14', 'windows-2022']
     with:
-     artifact-name: examples-ubuntu-24.04-${{ github.sha }}
+     artifact-name: examples-${{ matrix.runner }}-${{ github.sha }}
      runner: ${{ matrix.runner }}
-#        artifact-name: 'examples-${{runner.os}}-${{github.sha}}'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,8 @@ jobs:
 #    permissions:
 #      contents: read
   build_examples:
-      uses: ./.github/workflows/_reusable_build_examples.yml
-      with:
-       artifact-name: examples-ubuntu-24.04-${{ github.sha }}
+    permissions: {}
+    uses: ./.github/workflows/_reusable_build_examples.yml
+    with:
+     artifact-name: examples-ubuntu-24.04-${{ github.sha }}
 #        artifact-name: 'examples-${{runner.os}}-${{github.sha}}'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,14 +32,14 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
     strategy:
-      # we want to run the full build on all os: don't cancel running jobs even if one fails
+      # we want to run the full build on all runners: don't cancel running jobs even if one fails
       fail-fast: false
       matrix:
-        os: ['ubuntu-24.04', 'macos-14', 'windows-2022']
+        runner: [ 'ubuntu-24.04', 'macos-14', 'windows-2022']
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -91,6 +91,10 @@ jobs:
     permissions:
       contents: read
     uses: ./.github/workflows/_reusable_build_examples.yml
+    strategy:
+      matrix:
+        runner: ['ubuntu-24.04', 'macos-14', 'windows-2022']
     with:
      artifact-name: examples-ubuntu-24.04-${{ github.sha }}
+     runner: ${{ matrix.runner }}
 #        artifact-name: 'examples-${{runner.os}}-${{github.sha}}'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,9 +79,8 @@ jobs:
 
 # TODO check if we can run on various OS https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#using-a-matrix-strategy-with-a-reusable-workflow
 #    runs-on: ubuntu-24.04
-#    permissions:
-#      contents: read
   build_examples:
+    needs: build
     permissions: {}
     uses: ./.github/workflows/_reusable_build_examples.yml
     with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,11 +41,15 @@ jobs:
       matrix:
         os: ['ubuntu-24.04', 'macos-14', 'windows-2022']
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Build Setup
         uses: ./.github/actions/build-setup
-      - name: Build @maxgraph/core - esm
+
+      - name: Build @maxgraph/core
         run: npm run build -w packages/core
+
       - name: Check TS compilation of the tests of @maxgraph/core
         run: npm run test-check -w packages/core
       - name: Test @maxgraph/core
@@ -57,22 +61,28 @@ jobs:
           path: packages/core/coverage/lcov-report
       - name: Test TypeScript support
         run: npm test -w packages/ts-support
-      - name: Build all examples
-        run: ./scripts/build-all-examples.bash
+
+      # Already built in generate-website.yml, but here we want to ensure it can be built on all OSes
       - name: Build Storybook mini-site
         run: npm run build -w packages/html
-      - name: Upload all examples as artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: examples-${{runner.os}}-${{github.sha}}
-          path: |
-            packages/html/dist/
-            packages/js-example*/dist/
-            packages/ts-example*/dist/
+
       - name: Ensure no circular dependencies in the @maxgraph/core produced JS files
         run: npm run check:circular-dependencies -w packages/core
+
       - name: Ensure no lint errors
         run: npm run lint
+
       # See https://github.com/arethetypeswrong/arethetypeswrong.github.io/tree/main/packages/cli
       - name: Check npm package
         run: npm run check:npm-package -w packages/core
+
+
+# TODO check if we can run on various OS https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#using-a-matrix-strategy-with-a-reusable-workflow
+#    runs-on: ubuntu-24.04
+#    permissions:
+#      contents: read
+  build_examples:
+      uses: ./.github/workflows/_reusable_build_examples.yml
+      with:
+       artifact-name: examples-ubuntu-24.04-${{ github.sha }}
+#        artifact-name: 'examples-${{runner.os}}-${{github.sha}}'

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -6,8 +6,28 @@ on:
       - v*
 
 jobs:
+  # TODO how to get the version (in a dedicated step?) and reuse it in both jobs?
+  compute_environment_variables:
+    runs-on: ubuntu-24.04
+    permissions: {}
+    outputs:
+      version: ${{ steps.set_version.outputs.version }}
+    steps:
+      - name: Set version
+        id: set_version
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+  generate_website:
+    needs: [compute_environment_variables]
+    uses: ./.github/workflows/_reusable_generate_website.yml
+    with:
+      artifact-name: 'maxgraph_${{ needs.compute_environment_variables.outputs.version }}_website.zip'
+
   create_release:
     runs-on: ubuntu-24.04
+#    needs: [compute_environment_variables, generate_website]
     permissions:
       contents: write # create the GH release
     steps:

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -21,6 +21,7 @@ jobs:
 
   generate_website:
     needs: [compute_environment_variables]
+    permissions: {}
     uses: ./.github/workflows/_reusable_generate_website.yml
     with:
       artifact-name: 'maxgraph_${{ needs.compute_environment_variables.outputs.version }}_website.zip'

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -28,7 +28,8 @@ jobs:
 
   generate_website:
     needs: compute_environment_variables
-    permissions: {}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_reusable_generate_website.yml
     with:
       artifact-name: 'maxgraph_${{ needs.compute_environment_variables.outputs.version }}_website.zip'

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -6,7 +6,6 @@ on:
       - v*
 
 jobs:
-  # TODO how to get the version (in a dedicated step?) and reuse it in both jobs?
   compute_environment_variables:
     runs-on: ubuntu-24.04
     permissions: {}
@@ -19,8 +18,16 @@ jobs:
           VERSION=${GITHUB_REF_NAME#v}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+  build_examples:
+    needs: compute_environment_variables
+    permissions:
+      contents: read
+    uses: ./.github/workflows/_reusable_build_examples.yml
+    with:
+      artifact-name: maxgraph_${{ needs.compute_environment_variables.outputs.version }}_examples.zip
+
   generate_website:
-    needs: [compute_environment_variables]
+    needs: compute_environment_variables
     permissions: {}
     uses: ./.github/workflows/_reusable_generate_website.yml
     with:
@@ -28,7 +35,7 @@ jobs:
 
   create_release:
     runs-on: ubuntu-24.04
-#    needs: [compute_environment_variables, generate_website]
+    needs: [build_examples, generate_website]
     permissions:
       contents: write # create the GH release
     steps:

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -63,7 +63,7 @@ jobs:
           echo "MILESTONE_NUMBER=${MILESTONE_NUMBER:-x}" >> $GITHUB_ENV
 
       - name: Download examples artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: maxgraph_${{ env.VERSION }}_examples.zip
           path: artifacts/examples

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -33,6 +33,7 @@ jobs:
     with:
       artifact-name: 'maxgraph_${{ needs.compute_environment_variables.outputs.version }}_website.zip'
 
+
   create_release:
     runs-on: ubuntu-24.04
     needs: [build_examples, generate_website]
@@ -43,6 +44,7 @@ jobs:
         run: |
           echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
           echo "RELEASE_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+
       - name: Get milestone number
         env:
           GH_TOKEN: ${{ github.token }}
@@ -59,9 +61,31 @@ jobs:
           echo "Found milestone: ${MILESTONE_NUMBER}"
           echo "MILESTONE_NUMBER=${MILESTONE_NUMBER:-x}" >> $GITHUB_ENV
 
+      - name: Download examples artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: maxgraph_${{ env.VERSION }}_examples.zip
+          path: artifacts/examples
+
+      - name: Download website artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: maxgraph_${{ env.VERSION }}_website.zip
+          path: artifacts/website
+
+      - name: Create zip files for release
+        run: |
+          cd artifacts/examples
+          zip -r ../../maxgraph_${{ env.VERSION }}_examples.zip .
+          cd ../website
+          zip -r ../../maxgraph_${{ env.VERSION }}_website.zip .
+
       - name: Create release
         uses: ncipollo/release-action@v1
         with:
+          artifacts: |
+            maxgraph_${{ env.VERSION }}_examples.zip
+            maxgraph_${{ env.VERSION }}_website.zip
           body: |
             _Version ${{ env.VERSION }} released on ${{ env.RELEASE_DATE }}._
             

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -24,7 +24,7 @@ jobs:
       contents: read
     uses: ./.github/workflows/_reusable_build_examples.yml
     with:
-      artifact-name: maxgraph_${{ needs.compute_environment_variables.outputs.version }}_examples.zip
+      artifact-name: 'maxgraph_${{ needs.compute_environment_variables.outputs.version }}_examples.zip'
 
   generate_website:
     needs: compute_environment_variables

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -36,13 +36,13 @@ jobs:
 
   create_release:
     runs-on: ubuntu-24.04
-    needs: [build_examples, generate_website]
+    needs: [compute_environment_variables, build_examples, generate_website]
     permissions:
       contents: write # create the GH release
     steps:
       - name: Set env
         run: |
-          echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+          echo "VERSION=${{ needs.compute_environment_variables.outputs.version }}" >> $GITHUB_ENV
           echo "RELEASE_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
       - name: Get milestone number

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -63,13 +63,13 @@ jobs:
           echo "MILESTONE_NUMBER=${MILESTONE_NUMBER:-x}" >> $GITHUB_ENV
 
       - name: Download examples artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: maxgraph_${{ env.VERSION }}_examples.zip
           path: artifacts/examples
 
       - name: Download website artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: maxgraph_${{ env.VERSION }}_website.zip
           path: artifacts/website

--- a/.github/workflows/generate-website.yml
+++ b/.github/workflows/generate-website.yml
@@ -46,8 +46,7 @@ jobs:
       contents: read
     uses: ./.github/workflows/_reusable_generate_website.yml
     with:
-# TODO on PR, use a name to easily deploy it locally
-      artifact-name: 'gh-pages'
+      artifact-name: ${{ github.event_name == 'pull_request' && format('website-pr-{0}', github.event.pull_request.number) || 'gh-pages' }}
 
   deploy:
     needs: build

--- a/.github/workflows/generate-website.yml
+++ b/.github/workflows/generate-website.yml
@@ -42,7 +42,8 @@ concurrency:
 
 jobs:
   build:
-    permissions: {}
+    permissions:
+      contents: read
     uses: ./.github/workflows/_reusable_generate_website.yml
     with:
       artifact-name: 'gh-pages'

--- a/.github/workflows/generate-website.yml
+++ b/.github/workflows/generate-website.yml
@@ -42,9 +42,7 @@ concurrency:
 
 jobs:
   build:
-#    TODO we should be able to remove permissions
-#    permissions:
-#      contents: read
+    permissions: {}
     uses: ./.github/workflows/_reusable_generate_website.yml
     with:
       artifact-name: 'gh-pages'

--- a/.github/workflows/generate-website.yml
+++ b/.github/workflows/generate-website.yml
@@ -42,27 +42,11 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
     permissions:
       contents: read
-    steps:
-      - uses: actions/checkout@v6
-      - name: Build Setup
-        uses: ./.github/actions/build-setup
-      - name: Build @maxgraph/core API docs
-        run: npm run docs:api -w packages/core
-      - name: Build Storybook demo
-        run: npm run build -w packages/core -w packages/html
-      - name: Copy generated resources to the website
-        run: npm run extra:copy-gen-resources -w packages/website
-      - name: Build website
-        run: npm run build -w packages/website
-      - name: Upload website artifact
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: packages/website/build/
-      - name: Check types in website
-        run: npm run typecheck -w packages/website
+    uses: ./.github/workflows/_reusable_generate_website.yml
+    with:
+      artifact-name: 'gh-pages'
 
   deploy:
     needs: build

--- a/.github/workflows/generate-website.yml
+++ b/.github/workflows/generate-website.yml
@@ -46,6 +46,7 @@ jobs:
       contents: read
     uses: ./.github/workflows/_reusable_generate_website.yml
     with:
+# TODO on PR, use a name to easily deploy it locally
       artifact-name: 'gh-pages'
 
   deploy:

--- a/.github/workflows/generate-website.yml
+++ b/.github/workflows/generate-website.yml
@@ -46,7 +46,7 @@ jobs:
       contents: read
     uses: ./.github/workflows/_reusable_generate_website.yml
     with:
-      artifact-name: ${{ github.event_name == 'pull_request' && format('website-pr-{0}', github.event.pull_request.number) || 'gh-pages' }}
+      artifact-name: ${{ github.event_name == 'pull_request' && format('website-pr-{0}-{1}', github.event.pull_request.number, github.sha) || 'gh-pages' }}
 
   deploy:
     needs: build

--- a/.github/workflows/generate-website.yml
+++ b/.github/workflows/generate-website.yml
@@ -42,8 +42,9 @@ concurrency:
 
 jobs:
   build:
-    permissions:
-      contents: read
+#    TODO we should be able to remove permissions
+#    permissions:
+#      contents: read
     uses: ./.github/workflows/_reusable_generate_website.yml
     with:
       artifact-name: 'gh-pages'

--- a/packages/website/docs/development/release.md
+++ b/packages/website/docs/development/release.md
@@ -93,14 +93,7 @@ The list of the major changes has been [automatically generated](https://docs.gi
   - If the list is incorrect (for example, an item is not in the correct category), update the label(s) or the associated
 Pull Request and regenerate the list.
 
-Attach the examples and the website to the release (in the "assets" location):
-  - Retrieve the artifacts built by GitHub Actions on the commit of the tag
-  - examples:
-    - location: https://github.com/maxGraph/maxGraph/actions/workflows/create-github-release.yml
-    - get the file: `maxgraph_<version>_examples.zip`
-  - website:
-    - location: https://github.com/maxGraph/maxGraph/actions/workflows/create-github-release.yml
-    - get the file: `maxgraph_<version>_website.zip`
+The examples and website zip files are automatically attached to the release as assets by the GitHub workflow.
 
 Before you publish the release, make sure that a discussion will be created in the `Announces` category when the release
 is published.

--- a/packages/website/docs/development/release.md
+++ b/packages/website/docs/development/release.md
@@ -99,8 +99,8 @@ Attach the examples and the website to the release (in the "assets" location):
     - location: https://github.com/maxGraph/maxGraph/actions/workflows/build.yml
     - rename the file to: `maxgraph_<version>_examples.zip`
   - website:
-    - location: https://github.com/maxGraph/maxGraph/actions/workflows/generate-website.yml. The artifact is not available in the summary of the job. Open the log to get the URL of the artifact.
-    - rename the file to: `maxgraph_<version>_website.zip`
+    - location: https://github.com/maxGraph/maxGraph/actions/workflows/create-github-release.yml
+    - get the file: `maxgraph_<version>_website.zip`
 
 Before you publish the release, make sure that a discussion will be created in the `Announces` category when the release
 is published.

--- a/packages/website/docs/development/release.md
+++ b/packages/website/docs/development/release.md
@@ -96,8 +96,8 @@ Pull Request and regenerate the list.
 Attach the examples and the website to the release (in the "assets" location):
   - Retrieve the artifacts built by GitHub Actions on the commit of the tag
   - examples:
-    - location: https://github.com/maxGraph/maxGraph/actions/workflows/build.yml
-    - rename the file to: `maxgraph_<version>_examples.zip`
+    - location: https://github.com/maxGraph/maxGraph/actions/workflows/create-github-release.yml
+    - get the file: `maxgraph_<version>_examples.zip`
   - website:
     - location: https://github.com/maxGraph/maxGraph/actions/workflows/create-github-release.yml
     - get the file: `maxgraph_<version>_website.zip`

--- a/packages/website/docs/development/release.md
+++ b/packages/website/docs/development/release.md
@@ -93,7 +93,7 @@ The list of the major changes has been [automatically generated](https://docs.gi
   - If the list is incorrect (for example, an item is not in the correct category), update the label(s) or the associated
 Pull Request and regenerate the list.
 
-The examples and website zip files are automatically attached to the release as assets by the GitHub workflow.
+The GitHub workflow automatically attaches the examples and website zip files to the release as assets.
 
 Before you publish the release, make sure that a discussion will be created in the `Announces` category when the release
 is published.

--- a/packages/website/docs/intro.md
+++ b/packages/website/docs/intro.md
@@ -25,8 +25,8 @@ The documentation hosted at https://maxgraph.github.io/maxGraph includes the lat
 To visualize the documentation for a specific version (and the corresponding demo):
 - First, download the archive of the website attached to the [related release](https://github.com/maxGraph/maxGraph/releases). Documentation archives are available as of version `0.10.3`.
 - Decompress the archive (it may include archives, in this case decompress them)
-- For versions prior 0.23.0, rename the root folder to maxGraph (the case matters!)
-- From the parent of the root folder, start a webserver with a command like `npx http-server -c-1`
+- For versions prior to 0.23.0, decompress the enclosing tar file and ensure all website contents are placed in a folder named `maxGraph` (case-sensitive).
+- From the parent directory of the decompressed `maxGraph` folder, start a web server with a command like `npx http-server -c-1`
 - The website will be available at `http://localhost:8080/maxGraph/` (or something similar) 
 
 :::

--- a/packages/website/docs/intro.md
+++ b/packages/website/docs/intro.md
@@ -25,7 +25,7 @@ The documentation hosted at https://maxgraph.github.io/maxGraph includes the lat
 To visualize the documentation for a specific version (and the corresponding demo):
 - First, download the archive of the website attached to the [related release](https://github.com/maxGraph/maxGraph/releases). Documentation archives are available as of version `0.10.3`.
 - Decompress the archive (it may include archives, in this case decompress them)
-- Rename the root folder to maxGraph (the case matters!)
+- For versions prior 0.23.0, rename the root folder to maxGraph (the case matters!)
 - From the parent of the root folder, start a webserver with a command like `npx http-server -c-1`
 - The website will be available at `http://localhost:8080/maxGraph/` (or something similar) 
 


### PR DESCRIPTION
                                                                                                                                                                            
  - Create reusable workflows for building examples and generating website                                                                                                     
  - Download and attach artifacts as zip files to the draft release                                                                                                            
  - Update release documentation to reflect the automation                                                                                                                     
                                                                                                                                                                               
This eliminates manual steps for attaching release assets. 


### Notes

Closes #859
Covers #889

## Remaining Tasks

- [x] in the gh release workflow, build the examples
- [x] gh release wf: attach the assets to the release
- [x] test the gh release wf with these PR: https://github.com/process-analytics/github-actions-playground/pull/439 and https://github.com/process-analytics/github-actions-playground/pull/440#issuecomment-3790980298
- [x] update documentation: how to handle the website archive to use it (may differ from previous versions)
- [x] update the PR description
- [x] add links to issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reusable CI workflows to build examples, Storybook/site assets, and the website; artifacts produced per-runner and selectable by artifact name.

* **Release**
  * Release pipeline now derives the version, runs dedicated build jobs (including examples and website), and attaches versioned zip artifacts to GitHub releases.

* **Documentation**
  * Updated release and website docs with automatic artifact attachment, version-aware setup, and post-release review guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->