### PR TITLE
refactor: improve type guard for domUtils.isNode

### DIFF
--- a/packages/core/src/util/domUtils.ts
+++ b/packages/core/src/util/domUtils.ts
@@ -227,7 +227,7 @@ export const isNode = (
   nodeName: string | null = null,
   attributeName?: string | null,
   attributeValue?: string | null
-) => {
+): value is HTMLElement => {
   if (
     !isNullish(value) &&
     typeof value.nodeType === 'number' &&

--- a/packages/core/src/util/domUtils.ts
+++ b/packages/core/src/util/domUtils.ts
@@ -227,7 +227,7 @@ export const isNode = (
   nodeName: string | null = null,
   attributeName?: string | null,
   attributeValue?: string | null
-): value is HTMLElement => {
+): value is Element => {
   if (
     !isNullish(value) &&
     typeof value.nodeType === 'number' &&

--- a/packages/core/src/view/canvas/SvgCanvas2D.ts
+++ b/packages/core/src/view/canvas/SvgCanvas2D.ts
@@ -1113,35 +1113,33 @@ class SvgCanvas2D extends AbstractCanvas2D {
     let val = str;
 
     if (!isNode(val)) {
-      val = `<div><div>${this.convertHtml(val as string)}</div></div>`;
+      val = `<div><div>${this.convertHtml(val)}</div></div>`;
     }
 
     if (document.createElementNS) {
       const div = document.createElementNS('http://www.w3.org/1999/xhtml', 'div');
 
       if (isNode(val)) {
-        const n = val as HTMLElement;
-
         const div2 = document.createElement('div');
         const div3 = div2.cloneNode(false);
 
         // Creates a copy for export
         if (this.root!.ownerDocument !== document) {
-          div2.appendChild(n.cloneNode(true));
+          div2.appendChild(val.cloneNode(true));
         } else {
-          div2.appendChild(n);
+          div2.appendChild(val);
         }
 
         div3.appendChild(div2);
         div.appendChild(div3);
       } else {
-        div.innerHTML = val as string;
+        div.innerHTML = val;
       }
 
       return div;
     }
     if (isNode(val)) {
-      val = `<div><div>${getXml(<Element>val)}</div></div>`;
+      val = `<div><div>${getXml(val)}</div></div>`;
     }
 
     val = `<div xmlns="http://www.w3.org/1999/xhtml">${val}</div>`;

--- a/packages/core/src/view/canvas/XmlCanvas2D.ts
+++ b/packages/core/src/view/canvas/XmlCanvas2D.ts
@@ -883,7 +883,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
   ): void {
     if (this.textEnabled && str != null) {
       if (isNode(str)) {
-        str = getOuterHtml(<HTMLElement>str);
+        str = getOuterHtml(str);
       }
 
       const elem = this.createElement('text');

--- a/packages/core/src/view/canvas/XmlCanvas2D.ts
+++ b/packages/core/src/view/canvas/XmlCanvas2D.ts
@@ -891,7 +891,7 @@ class XmlCanvas2D extends AbstractCanvas2D {
       elem.setAttribute('y', String(this.format(y)));
       elem.setAttribute('w', String(this.format(w)));
       elem.setAttribute('h', String(this.format(h)));
-      elem.setAttribute('str', <string>str);
+      elem.setAttribute('str', str);
 
       if (align != null) {
         elem.setAttribute('align', align);

--- a/packages/core/src/view/mixin/LabelMixin.type.ts
+++ b/packages/core/src/view/mixin/LabelMixin.type.ts
@@ -53,18 +53,18 @@ declare module '../AbstractGraph' {
      *       }
      *     }
      *   }
-     *   return StringUtils.htmlEntities(label);
+     *   return stringUtils.htmlEntities(label);
      * }
      * ```
      *
      * A resize listener is needed in the graph to force a repaint of the label after a resize.
      *
      * ```javascript
-     * graph.addListener(mxEvent.RESIZE_CELLS, function(sender, evt) {
+     * graph.addListener(InternalEvent.RESIZE_CELLS, function(sender, evt) {
      *   const cells = evt.getProperty('cells');
      *
-     *   for (let i = 0; i < cells.length; i++) {
-     *     this.view.removeState(cells[i]);
+     *   for (const cell of cells) {
+     *     this.view.removeState(cell);
      *   }
      * });
      * ```

--- a/packages/core/src/view/plugin/TooltipHandler.ts
+++ b/packages/core/src/view/plugin/TooltipHandler.ts
@@ -297,10 +297,10 @@ class TooltipHandler implements GraphPlugin, MouseListenerSet {
       this.div!.style.top = `${y + TOOLTIP_VERTICAL_OFFSET + origin.y}px`;
 
       if (!isNode(tip)) {
-        this.div!.innerHTML = (tip as string).replace(/\n/g, '<br>');
+        this.div!.innerHTML = tip.replace(/\n/g, '<br>');
       } else {
         this.div!.innerHTML = '';
-        this.div!.appendChild(tip as HTMLElement);
+        this.div!.appendChild(tip);
       }
 
       this.div!.style.visibility = '';

--- a/packages/core/src/view/shape/node/TextShape.ts
+++ b/packages/core/src/view/shape/node/TextShape.ts
@@ -258,7 +258,6 @@ class TextShape extends Shape {
       let val = this.value as string;
 
       if (!realHtml && fmt === 'html') {
-        // @ts-ignore
         val = htmlEntities(val, false);
       }
 
@@ -269,7 +268,7 @@ class TextShape extends Shape {
       // Handles trailing newlines to make sure they are visible in rendering output
       val =
         !isNode(this.value) && this.replaceLinefeeds && fmt === 'html'
-          ? (<string>val).replace(/\n/g, '<br/>')
+          ? val.replace(/\n/g, '<br/>')
           : val;
 
       let dir: TextDirectionValue = this.textDirection;
@@ -681,10 +680,7 @@ class TextShape extends Shape {
 
         node.setAttribute('style', flex);
 
-        const html = isNode(this.value)
-          ? // @ts-ignore
-            this.value.outerHTML
-          : this.getHtmlValue();
+        const html = isNode(this.value) ? this.value.outerHTML : this.getHtmlValue();
 
         if (!node.firstChild) {
           node.innerHTML = `<div><div>${html}</div></div>`;
@@ -703,7 +699,6 @@ class TextShape extends Shape {
    */
   updateInnerHtml(elt: HTMLElement) {
     if (isNode(this.value)) {
-      // @ts-ignore
       elt.innerHTML = this.value.outerHTML;
     } else {
       let val = this.value as string;
@@ -730,7 +725,7 @@ class TextShape extends Shape {
 
     if (isNode(this.value)) {
       node.innerHTML = '';
-      node.appendChild(<HTMLElement | SVGGElement>this.value);
+      node.appendChild(this.value);
     } else {
       let val = this.value as string;
 

--- a/packages/html/stories/UserObject.stories.ts
+++ b/packages/html/stories/UserObject.stories.ts
@@ -142,7 +142,7 @@ const Template = ({ label, ...args }: Record<string, string>) => {
       const lastName = pos > 0 ? newValue.substring(pos + 1, newValue.length) : '';
 
       // Clones the value for correct undo/redo
-      const elt = cell.value.cloneNode(true);
+      const elt = cell.value.cloneNode(true) as Element;
 
       elt.setAttribute('firstName', firstName);
       elt.setAttribute('lastName', lastName);


### PR DESCRIPTION
- Change isNode to return a type predicate (value is HTMLElement)
- Remove unnecessary type assertions in code using isNode
- Simplify type narrowing in SvgCanvas2D, XmlCanvas2D, TooltipHandler, and TextShape

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved TypeScript type safety across DOM rendering and canvas code by removing unnecessary casts and ts-ignore comments and introducing precise type-guard signatures for DOM element handling.
* **Documentation**
  * Updated example snippets and event names in docs to align with current APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->