### PR TITLE
refactor(typescript): fix SonarQube issues on extensible string types

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -569,7 +569,7 @@ export type CellStateStyle = {
    * **WARNING**: explicitly set the value to null or undefined means to not use any perimeter.
    * To use the perimeter defined in the default vertex, do not set this property.
    */
-  perimeter?: PerimeterFunction | PerimeterValue | (string & {}) | null;
+  perimeter?: PerimeterFunction | PerimeterValue | (string & Record<never, never>) | null;
   /**
    * This is the distance between the connection point and the perimeter in pixels.
    * - When used in a vertex style, this applies to all incoming edges to floating ports
@@ -916,7 +916,7 @@ export type SpecialStyleColorValue =
   | 'inherit'
   | 'none'
   | 'swimlane'
-  | (string & {});
+  | (string & Record<never, never>);
 
 /** @category Style */
 export type DirectionValue = 'north' | 'south' | 'east' | 'west';
@@ -961,7 +961,7 @@ export type ArrowValue =
  * {@link ArrowValue} with support for extensions.
  * @category Style
  */
-export type StyleArrowValue = ArrowValue | (string & {});
+export type StyleArrowValue = ArrowValue | (string & Record<never, never>);
 
 /**
  * @category Style
@@ -1015,7 +1015,7 @@ export type ShapeValue =
  * @category Style
  * @category Shape
  */
-export type StyleShapeValue = ShapeValue | (string & {});
+export type StyleShapeValue = ShapeValue | (string & Record<never, never>);
 
 export type CanvasState = {
   alpha: number;
@@ -1331,7 +1331,7 @@ export type EdgeStyleValue =
 export type StyleEdgeStyleValue =
   | EdgeStyleFunction
   | EdgeStyleValue
-  | (string & {})
+  | (string & Record<never, never>)
   | null;
 
 /**


### PR DESCRIPTION
Replace all occurrences of `string & {}` with `string & Record<never, never>`
to avoid SonarQube warnings while preserving the loose autocomplete behavior
for string literal union types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal type definitions for improved type precision. No user-facing changes or behavioral impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->