### PR TITLE
docs: fix JSDoc refs pointing to CellRenderer instead of ShapeRegistry

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -440,7 +440,7 @@ export type CellStateStyle = {
   indicatorImage?: string;
   /**
    * The indicator shape used within an {@link LabelShape}.
-   * The possible values are all names of registered Shapes with {@link CellRenderer.registerShape}.
+   * The possible values are all names of registered Shapes with {@link ShapeRegistry.add}.
    * This includes {@link ShapeValue} values and custom names that have been registered.
    *
    * The `indicatorShape` property has precedence over the {@link indicatorImage} property.
@@ -681,13 +681,13 @@ export type CellStateStyle = {
    *
    * The actual implementation of the shape is determined by the {@link CellRenderer.createShape} method:
    * - first, it looks for a shape in {@link StencilShapeRegistry},
-   * - if not found, it looks for a shape in the {@link CellRenderer} registry.
+   * - if not found, it looks for a shape in the {@link ShapeRegistry}.
    *
    * If no shape is specified, the default shape is used:
    * - for edges, this is {@link CellRenderer.defaultEdgeShape}
    * - for vertices, this is {@link CellRenderer.defaultVertexShape}
    *
-   * The possible values are all names of the shapes registered with {@link CellRenderer.registerShape} and {@link StencilShapeRegistry.addStencil}.
+   * The possible values are all names of the shapes registered with {@link ShapeRegistry.add} and {@link StencilShapeRegistry.add}.
    * This includes {@link ShapeValue} values and custom names that have been registered.
    */
   shape?: StyleShapeValue;
@@ -970,7 +970,7 @@ export type StyleArrowValue = ArrowValue | (string & {});
 export type StylePortConstraint = DirectionValue | DirectionValue[];
 
 /**
- * Names used to register the shapes provided out-of-the-box by maxGraph with {@link CellRenderer.registerShape}.
+ * Names used to register the shapes provided out-of-the-box by maxGraph with {@link ShapeRegistry.add}.
  * They can be used as a value for {@link CellStateStyle.shape}.
  *
  * @category Style

--- a/packages/core/src/view/shape/Shape.ts
+++ b/packages/core/src/view/shape/Shape.ts
@@ -43,7 +43,7 @@ import { StyleDefaultsConfig } from '../../util/config.js';
  * Base class for all shapes.
  * A shape in maxGraph is a separate implementation for SVG, VML and HTML.
  * Which implementation to use is controlled by the dialect property which
- * is assigned from within the CellRenderer when the shape is created.
+ * is assigned from within the {@link CellRenderer} when the shape is created.
  * The dialect must be assigned for a shape, and it does normally depend on
  * the browser and the configuration of the graph (see maxGraph rendering hint).
  *

--- a/packages/core/src/view/shape/edge/ArrowConnectorShape.ts
+++ b/packages/core/src/view/shape/edge/ArrowConnectorShape.ts
@@ -30,7 +30,7 @@ import { ColorValue } from '../../../types.js';
  *
  * The shape is used to represent edges, not vertices.
  *
- * This shape is registered under `arrowConnector` in {@link CellRenderer} when using {@link Graph} or calling {@link registerDefaultShapes}.
+ * This shape is registered under `arrowConnector` in {@link ShapeRegistry} when using {@link Graph} or calling {@link registerDefaultShapes}.
  *
  * @category Edge Shapes
  */

--- a/packages/core/src/view/shape/edge/ArrowShape.ts
+++ b/packages/core/src/view/shape/edge/ArrowShape.ts
@@ -28,7 +28,7 @@ import { ColorValue } from '../../../types.js';
  *
  * The shape is used to represent edges, not vertices.
  *
- * This shape is registered under `arrow` in {@link CellRenderer} when using {@link Graph} or calling {@link registerDefaultShapes}.
+ * This shape is registered under `arrow` in {@link ShapeRegistry} when using {@link Graph} or calling {@link registerDefaultShapes}.
  *
  * @category Edge Shapes
  */

--- a/packages/core/src/view/shape/edge/ConnectorShape.ts
+++ b/packages/core/src/view/shape/edge/ConnectorShape.ts
@@ -31,7 +31,7 @@ import { StyleDefaultsConfig } from '../../../util/config.js';
  *
  * The shape is used to represent edges, not vertices.
  *
- * This shape is registered under `connector` in {@link CellRenderer} when using {@link Graph} or calling {@link registerDefaultShapes}.
+ * This shape is registered under `connector` in {@link ShapeRegistry} when using {@link Graph} or calling {@link registerDefaultShapes}.
  *
  * @category Edge Shapes
  */

--- a/packages/core/src/view/shape/edge/LineShape.ts
+++ b/packages/core/src/view/shape/edge/LineShape.ts
@@ -26,7 +26,7 @@ import { ColorValue } from '../../../types.js';
  *
  * The shape is used to represent edges, not vertices.
  *
- * This shape is registered under `line` in {@link CellRenderer} when using {@link Graph} or calling {@link registerDefaultShapes}.
+ * This shape is registered under `line` in {@link ShapeRegistry} when using {@link Graph} or calling {@link registerDefaultShapes}.
  *
  * @category Edge Shapes
  */

--- a/packages/core/src/view/shape/edge/PolylineShape.ts
+++ b/packages/core/src/view/shape/edge/PolylineShape.ts
@@ -26,7 +26,7 @@ import { ColorValue } from '../../../types.js';
  *
  * The shape is used to represent edges, not vertices.
  *
- * This shape is **NOT** registered in {@link CellRenderer} when using {@link Graph} or calling {@link registerDefaultShapes}.
+ * This shape is **NOT** registered in {@link ShapeRegistry} when using {@link Graph} or calling {@link registerDefaultShapes}.
  *
  * @category Edge Shapes
  */

--- a/packages/core/src/view/shape/node/ActorShape.ts
+++ b/packages/core/src/view/shape/node/ActorShape.ts
@@ -22,7 +22,7 @@ import type AbstractCanvas2D from '../../canvas/AbstractCanvas2D.js';
 /**
  * Path-based actor vertex shape built on {@link AbstractPathShape}.
  *
- * This shape is registered under `actor` in {@link CellRenderer} when using {@link Graph} or calling {@link registerDefaultShapes}.
+ * This shape is registered under `actor` in {@link ShapeRegistry} when using {@link Graph} or calling {@link registerDefaultShapes}.
  *
  * @category Vertex Shapes
  */

--- a/packages/core/src/view/shape/node/CloudShape.ts
+++ b/packages/core/src/view/shape/node/CloudShape.ts
@@ -22,7 +22,7 @@ import type AbstractCanvas2D from '../../canvas/AbstractCanvas2D.js';
 /**
  * Path-based cloud vertex shape built on {@link AbstractPathShape}.
  *
- * This shape is registered under `cloud` in {@link CellRenderer} when using {@link Graph} or calling {@link registerDefaultShapes}.
+ * This shape is registered under `cloud` in {@link ShapeRegistry} when using {@link Graph} or calling {@link registerDefaultShapes}.
  *
  * @category Vertex Shapes
  */

--- a/packages/core/src/view/shape/node/CylinderShape.ts
+++ b/packages/core/src/view/shape/node/CylinderShape.ts
@@ -24,7 +24,7 @@ import { NONE } from '../../../util/Constants.js';
 /**
  * Extends {@link Shape} to implement a cylinder shape.
  *
- * This shape is registered under `cylinder` in {@link CellRenderer} when using {@link Graph} or calling {@link registerDefaultShapes}.
+ * This shape is registered under `cylinder` in {@link ShapeRegistry} when using {@link Graph} or calling {@link registerDefaultShapes}.
  *
  * If a custom shape with one filled area and an overlay path is needed, then this shape's {@link redrawPath} should be overridden.
  *

--- a/packages/core/src/view/shape/node/DoubleEllipseShape.ts
+++ b/packages/core/src/view/shape/node/DoubleEllipseShape.ts
@@ -23,7 +23,7 @@ import AbstractCanvas2D from '../../canvas/AbstractCanvas2D.js';
 /**
  * Extends {@link Shape} to implement a double ellipse shape.
  *
- * This shape is registered under `doubleEllipse` in {@link CellRenderer} when using {@link Graph} or calling {@link registerDefaultShapes}.
+ * This shape is registered under `doubleEllipse` in {@link ShapeRegistry} when using {@link Graph} or calling {@link registerDefaultShapes}.
  *
  * If a custom shape is needed to only fill the inner ellipse, then this shape's {@link paintVertexShape} method should be overridden
  * like in the following example:

--- a/packages/core/src/view/shape/node/EllipseShape.ts
+++ b/packages/core/src/view/shape/node/EllipseShape.ts
@@ -23,7 +23,7 @@ import Rectangle from '../../geometry/Rectangle.js';
 /**
  * Extends {@link Shape} to implement an ellipse shape.
  *
- * This shape is registered under `ellipse` in {@link CellRenderer} when using {@link Graph} or calling {@link registerDefaultShapes}.
+ * This shape is registered under `ellipse` in {@link ShapeRegistry} when using {@link Graph} or calling {@link registerDefaultShapes}.
  *
  * @category Vertex Shapes
  */

--- a/packages/core/src/view/shape/node/HexagonShape.ts
+++ b/packages/core/src/view/shape/node/HexagonShape.ts
@@ -23,7 +23,7 @@ import type AbstractCanvas2D from '../../canvas/AbstractCanvas2D.js';
 /**
  * Implementation of the hexagon shape.
  *
- * This shape is registered under `hexagon` in {@link CellRenderer} when using {@link Graph} or calling {@link registerDefaultShapes}.
+ * This shape is registered under `hexagon` in {@link ShapeRegistry} when using {@link Graph} or calling {@link registerDefaultShapes}.
  *
  * @category Vertex Shapes
  */

--- a/packages/core/src/view/shape/node/ImageShape.ts
+++ b/packages/core/src/view/shape/node/ImageShape.ts
@@ -26,7 +26,7 @@ import { ColorValue } from '../../../types.js';
 /**
  * Extends {@link RectangleShape} to implement an image shape.
  *
- * This shape is registered under `image` in {@link CellRenderer} when using {@link Graph} or calling {@link registerDefaultShapes}.
+ * This shape is registered under `image` in {@link ShapeRegistry} when using {@link Graph} or calling {@link registerDefaultShapes}.
  *
  * @category Vertex Shapes
  */

--- a/packages/core/src/view/shape/node/LabelShape.ts
+++ b/packages/core/src/view/shape/node/LabelShape.ts
@@ -26,7 +26,7 @@ import { StyleDefaultsConfig } from '../../../util/config.js';
 /**
  * Extends {@link RectangleShape} to implement an image shape with a label.
  *
- * This shape is registered under `label` in {@link CellRenderer} when using {@link Graph} or calling {@link registerDefaultShapes}.
+ * This shape is registered under `label` in {@link ShapeRegistry} when using {@link Graph} or calling {@link registerDefaultShapes}.
  *
  * @category Vertex Shapes
  */

--- a/packages/core/src/view/shape/node/RectangleShape.ts
+++ b/packages/core/src/view/shape/node/RectangleShape.ts
@@ -25,7 +25,7 @@ import { ColorValue } from '../../../types.js';
 /**
  * Extends {@link Shape} to implement a rectangle shape.
  *
- * This shape is registered under `rectangle` in {@link CellRenderer} when using {@link Graph} or calling {@link registerDefaultShapes}.
+ * This shape is registered under `rectangle` in {@link ShapeRegistry} when using {@link Graph} or calling {@link registerDefaultShapes}.
  *
  * @category Vertex Shapes
  */

--- a/packages/core/src/view/shape/node/RhombusShape.ts
+++ b/packages/core/src/view/shape/node/RhombusShape.ts
@@ -24,7 +24,7 @@ import AbstractCanvas2D from '../../canvas/AbstractCanvas2D.js';
 /**
  * Extends {@link Shape} to implement a rhombus (aka diamond) shape.
  *
- * This shape is registered under `rhombus` in {@link CellRenderer} when using {@link Graph} or calling {@link registerDefaultShapes}.
+ * This shape is registered under `rhombus` in {@link ShapeRegistry} when using {@link Graph} or calling {@link registerDefaultShapes}.
  *
  * @category Vertex Shapes
  */

--- a/packages/core/src/view/shape/node/SwimlaneShape.ts
+++ b/packages/core/src/view/shape/node/SwimlaneShape.ts
@@ -25,7 +25,7 @@ import { StyleDefaultsConfig } from '../../../util/config.js';
 /**
  * Extends {@link Shape} to implement a swimlane shape.
  *
- * This shape is registered under `swimlane` in {@link CellRenderer} when using {@link Graph} or calling {@link registerDefaultShapes}.
+ * This shape is registered under `swimlane` in {@link ShapeRegistry} when using {@link Graph} or calling {@link registerDefaultShapes}.
  *
  * Use:
  * - {@link CellStateStyle.startSize} to define the size of the title region,

--- a/packages/core/src/view/shape/node/TextShape.ts
+++ b/packages/core/src/view/shape/node/TextShape.ts
@@ -53,7 +53,7 @@ import { StyleDefaultsConfig } from '../../../util/config.js';
 /**
  * Extends {@link Shape} to implement a text shape.
  *
- * This shape is **NOT** registered in {@link CellRenderer} when using {@link Graph} or calling {@link registerDefaultShapes}.
+ * This shape is **NOT** registered in {@link ShapeRegistry} when using {@link Graph} or calling {@link registerDefaultShapes}.
  *
  * To change vertical text from "bottom to top" to "top to bottom", the following code can be used:
  * ```javascript

--- a/packages/core/src/view/shape/node/TriangleShape.ts
+++ b/packages/core/src/view/shape/node/TriangleShape.ts
@@ -23,7 +23,7 @@ import type AbstractCanvas2D from '../../canvas/AbstractCanvas2D.js';
 /**
  * Implementation of the triangle shape.
  *
- * This shape is registered under `triangle` in {@link CellRenderer} when using {@link Graph} or calling {@link registerDefaultShapes}.
+ * This shape is registered under `triangle` in {@link ShapeRegistry} when using {@link Graph} or calling {@link registerDefaultShapes}.
  *
  * @category Vertex Shapes
  */

--- a/packages/core/src/view/shape/register-shapes.ts
+++ b/packages/core/src/view/shape/register-shapes.ts
@@ -36,7 +36,7 @@ import LabelShape from './node/LabelShape.js';
 let isDefaultElementsRegistered = false;
 
 /**
- * Register default builtin shapes into {@link CellRenderer}.
+ * Register default builtin shapes into {@link ShapeRegistry}.
  *
  * @category Configuration
  * @category Style


### PR DESCRIPTION
Shape registration was moved out of CellRenderer into ShapeRegistry in version 0.20.0.
Update all references across shape files and types to reflect the current API.