### PR TITLE
refactor(typescript): introduce the Constructor<T> utility type

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1462,11 +1462,13 @@ export type GraphFoldingOptions = {
 };
 
 /**
+ * Represents a constructor function for a class that produces instances of type `T`.
  * @since 0.23.0
  */
 export type Constructor<T> = new (...args: any[]) => T;
 
 /**
+ * Represents a constructor function for a class that produces instances of type `Shape`.
  * @since 0.18.0
  * @category Shape
  */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1462,10 +1462,15 @@ export type GraphFoldingOptions = {
 };
 
 /**
+ * @since 0.23.0
+ */
+export type Constructor<T> = new (...args: any[]) => T;
+
+/**
  * @since 0.18.0
  * @category Shape
  */
-export type ShapeConstructor = new (...arguments_: any) => Shape;
+export type ShapeConstructor = Constructor<Shape>;
 
 /**
  * Options passed to the {@link AbstractGraph} constructor.

--- a/packages/core/src/view/handler/EdgeHandler.ts
+++ b/packages/core/src/view/handler/EdgeHandler.ts
@@ -59,6 +59,7 @@ import type {
   ColorValue,
   Listenable,
   MouseListenerSet,
+  ShapeConstructor,
 } from '../../types.js';
 import InternalMouseEvent from '../event/InternalMouseEvent.js';
 import Cell from '../cell/Cell.js';
@@ -457,7 +458,7 @@ class EdgeHandler implements MouseListenerSet {
    * Creates the shape used to draw the selection border.
    */
   createSelectionShape(points: (Point | null)[]) {
-    const c = this.state.shape!.constructor as new () => Shape;
+    const c = this.state.shape!.constructor as ShapeConstructor;
 
     const shape = new c();
     shape.outline = true;


### PR DESCRIPTION
Add a generic Constructor<T> type in types.ts to simplify and reuse constructor type declarations:
- Replace the inline constructor type in ShapeConstructor with Constructor<Shape>
- Use ShapeConstructor in EdgeHandler to replace the ad-hoc cast

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal type declarations and reuse to make the codebase safer and more maintainable. No changes to user-facing behavior or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->