### PR TITLE
fix: parse HTML instead of XML in SvgCanvas2D.convertHtml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,6 +352,25 @@ Styles are defined as objects conforming to `CellStyle` type. See `packages/core
 - Tests are in `packages/core/__tests__/` mirroring `src/` structure
 - Use `@swc/jest` for fast TypeScript compilation
 - Import paths in tests should omit `.js` extension (handled by moduleNameMapper)
+- When multiple tests share the same structure and only differ by input/expected data, use `test.each` (or `it.each`) to avoid repetition and put focus on the tested use cases:
+
+```typescript
+// Good - data-driven tests with test.each
+test.each([
+  ['description of case 1', input1, expected1],
+  ['description of case 2', input2, expected2],
+])('%s', (_description, input, expected) => {
+  expect(myFunction(input)).toBe(expected);
+});
+
+// Bad - repetitive tests with identical structure
+test('case 1', () => {
+  expect(myFunction(input1)).toBe(expected1);
+});
+test('case 2', () => {
+  expect(myFunction(input2)).toBe(expected2);
+});
+```
 
 ## Commit Message Style
 

--- a/packages/core/__tests__/view/canvas/SvgCanvas2D.test.ts
+++ b/packages/core/__tests__/view/canvas/SvgCanvas2D.test.ts
@@ -37,9 +37,13 @@ describe('SvgCanvas2D.convertHtml', () => {
       '<div><div><span>deep</span></div></div>',
     ],
     ['malformed HTML gracefully', '<div><b>broken', '<div><b>broken</b></div>'],
-    ['HTML with whitespace', '   <div> spaced </div>   ', '<div> spaced </div>'],
+    [
+      'HTML with whitespace, trim only leading whitespace',
+      '   <div> spaced </div>   ',
+      '<div> spaced </div>   ',
+    ],
   ])('%s', (_description, input, expected) => {
     const canvas = createSvgCanvas2D();
-    expect(canvas.convertHtml(input).trim()).toBe(expected);
+    expect(canvas.convertHtml(input)).toBe(expected);
   });
 });

--- a/packages/core/__tests__/view/canvas/SvgCanvas2D.test.ts
+++ b/packages/core/__tests__/view/canvas/SvgCanvas2D.test.ts
@@ -1,0 +1,68 @@
+/*
+Copyright 2026-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, expect, test } from '@jest/globals';
+
+import SvgCanvas2D from '../../../src/view/canvas/SvgCanvas2D.js';
+import { NS_SVG } from '../../../src/util/Constants.js';
+
+describe('SvgCanvas2D.convertHtml', () => {
+  // Helper to create a dummy SVG root
+  function createSvgCanvas2D() {
+    return new SvgCanvas2D(document.createElementNS(NS_SVG, 'svg'), true);
+  }
+
+  test('returns plain text unchanged if not valid HTML', () => {
+    const canvas = createSvgCanvas2D();
+    const input = 'plain text';
+    expect(canvas.convertHtml(input)).toBe('plain text');
+  });
+
+  test('handles HTML with body tag', () => {
+    const canvas = createSvgCanvas2D();
+    const input = '<html><body><p>foo</p></body></html>';
+    expect(canvas.convertHtml(input)).toBe('<p>foo</p>');
+  });
+
+  test('handles HTML with attributes on body', () => {
+    const canvas = createSvgCanvas2D();
+    const input = '<html><body style="color:red"><span>bar</span></body></html>';
+    expect(canvas.convertHtml(input)).toBe('<span>bar</span>');
+  });
+
+  test('returns empty string for empty input', () => {
+    const canvas = createSvgCanvas2D();
+    expect(canvas.convertHtml('')).toBe('');
+  });
+
+  test('handles nested HTML', () => {
+    const canvas = createSvgCanvas2D();
+    const input = '<div><div><span>deep</span></div></div>';
+    expect(canvas.convertHtml(input)).toBe('<div><div><span>deep</span></div></div>');
+  });
+
+  test('handles malformed HTML gracefully', () => {
+    const canvas = createSvgCanvas2D();
+    const input = '<div><b>broken';
+    expect(canvas.convertHtml(input)).toBe('<div><b>broken</b></div>');
+  });
+
+  test('handles HTML with whitespace', () => {
+    const canvas = createSvgCanvas2D();
+    const input = '   <div> spaced </div>   ';
+    expect(canvas.convertHtml(input).trim()).toBe('<div> spaced </div>');
+  });
+});

--- a/packages/core/__tests__/view/canvas/SvgCanvas2D.test.ts
+++ b/packages/core/__tests__/view/canvas/SvgCanvas2D.test.ts
@@ -22,44 +22,24 @@ function createSvgCanvas2D() {
 }
 
 describe('SvgCanvas2D.convertHtml', () => {
-  test('returns plain text unchanged if not valid HTML', () => {
+  test.each([
+    ['plain text unchanged if not valid HTML', 'plain text', 'plain text'],
+    ['HTML with body tag', '<html><body><p>foo</p></body></html>', '<p>foo</p>'],
+    [
+      'HTML with attributes on body',
+      '<html><body style="color:red"><span>bar</span></body></html>',
+      '<span>bar</span>',
+    ],
+    ['empty string for empty input', '', ''],
+    [
+      'nested HTML',
+      '<div><div><span>deep</span></div></div>',
+      '<div><div><span>deep</span></div></div>',
+    ],
+    ['malformed HTML gracefully', '<div><b>broken', '<div><b>broken</b></div>'],
+    ['HTML with whitespace', '   <div> spaced </div>   ', '<div> spaced </div>'],
+  ])('%s', (_description, input, expected) => {
     const canvas = createSvgCanvas2D();
-    const input = 'plain text';
-    expect(canvas.convertHtml(input)).toBe('plain text');
-  });
-
-  test('handles HTML with body tag', () => {
-    const canvas = createSvgCanvas2D();
-    const input = '<html><body><p>foo</p></body></html>';
-    expect(canvas.convertHtml(input)).toBe('<p>foo</p>');
-  });
-
-  test('handles HTML with attributes on body', () => {
-    const canvas = createSvgCanvas2D();
-    const input = '<html><body style="color:red"><span>bar</span></body></html>';
-    expect(canvas.convertHtml(input)).toBe('<span>bar</span>');
-  });
-
-  test('returns empty string for empty input', () => {
-    const canvas = createSvgCanvas2D();
-    expect(canvas.convertHtml('')).toBe('');
-  });
-
-  test('handles nested HTML', () => {
-    const canvas = createSvgCanvas2D();
-    const input = '<div><div><span>deep</span></div></div>';
-    expect(canvas.convertHtml(input)).toBe('<div><div><span>deep</span></div></div>');
-  });
-
-  test('handles malformed HTML gracefully', () => {
-    const canvas = createSvgCanvas2D();
-    const input = '<div><b>broken';
-    expect(canvas.convertHtml(input)).toBe('<div><b>broken</b></div>');
-  });
-
-  test('handles HTML with whitespace', () => {
-    const canvas = createSvgCanvas2D();
-    const input = '   <div> spaced </div>   ';
-    expect(canvas.convertHtml(input).trim()).toBe('<div> spaced </div>');
+    expect(canvas.convertHtml(input).trim()).toBe(expected);
   });
 });

--- a/packages/core/__tests__/view/canvas/SvgCanvas2D.test.ts
+++ b/packages/core/__tests__/view/canvas/SvgCanvas2D.test.ts
@@ -15,16 +15,13 @@ limitations under the License.
 */
 
 import { describe, expect, test } from '@jest/globals';
+import { SvgCanvas2D, constants } from '../../../src';
 
-import SvgCanvas2D from '../../../src/view/canvas/SvgCanvas2D.js';
-import { NS_SVG } from '../../../src/util/Constants.js';
+function createSvgCanvas2D() {
+  return new SvgCanvas2D(document.createElementNS(constants.NS_SVG, 'svg'), true);
+}
 
 describe('SvgCanvas2D.convertHtml', () => {
-  // Helper to create a dummy SVG root
-  function createSvgCanvas2D() {
-    return new SvgCanvas2D(document.createElementNS(NS_SVG, 'svg'), true);
-  }
-
   test('returns plain text unchanged if not valid HTML', () => {
     const canvas = createSvgCanvas2D();
     const input = 'plain text';

--- a/packages/core/src/view/canvas/SvgCanvas2D.ts
+++ b/packages/core/src/view/canvas/SvgCanvas2D.ts
@@ -1087,9 +1087,10 @@ class SvgCanvas2D extends AbstractCanvas2D {
    * Converts the given HTML string to XHTML.
    */
   convertHtml(val: string) {
-    const doc = parseXml(val);
+    const doc = new DOMParser().parseFromString(val, 'text/html');
 
-    if (doc != null) {
+    // the jsdoc of DOMParser.parseFromString says the returned value is never null, but keep the check (it comes from mxGraph) for now until we get more feedback on this
+    if (doc) {
       val = new XMLSerializer().serializeToString(doc.body);
 
       // Extracts body content from DOM
@@ -1383,10 +1384,11 @@ class SvgCanvas2D extends AbstractCanvas2D {
   }
 
   /**
-   * Paints the given text. Possible values for format are empty string for plain
-   * text and html for HTML markup. Note that HTML markup is only supported if
-   * foreignObject is supported and <foEnabled> is true. (This means IE9 and later
-   * does currently not support HTML text as part of shapes.)
+   * Paints the given text.
+   *
+   * Possible values for format are empty string for plain text and HTML for HTML markup.
+   *
+   * Note that HTML markup is only supported if `foreignObject` is supported and {@link foEnabled} is `true`.
    */
   text(
     x: number,


### PR DESCRIPTION
The method was incorrectly using `parseXml` (XML parser) instead of `DOMParser` with `text/html`.
This bug was introduced in commit 2f4bb076 while trying to share code between methods — the code wasn't actually the same.

- Use `DOMParser.parseFromString(val, 'text/html')` for correct HTML parsing
- Add tests for `convertHtml` covering plain text, nested HTML, malformed
  HTML, empty input, and body tag extraction
- Improve JSDoc of the `text` method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for HTML-to-SVG conversion covering plain text, body-wrapped HTML, attributes on body, empty input, nested content, malformed HTML correction, and whitespace trimming.

* **Bug Fixes**
  * More robust HTML parsing when converting fragments to SVG to handle varied input formats.

* **Documentation**
  * Clarified docs on HTML support and added testing guidance with a data-driven testing example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->