### PR TITLE
fix: fix memory leaks in destroy methods

### DIFF
--- a/packages/core/__tests__/editor/Editor.test.ts
+++ b/packages/core/__tests__/editor/Editor.test.ts
@@ -169,3 +169,15 @@ describe('installDblClickHandler', () => {
     container.remove();
   });
 });
+
+describe('destroy', () => {
+  test('clears eventListeners', () => {
+    const editor = new Editor(null!);
+    editor.addListener('testEvent', () => {});
+    expect(editor.eventListeners.length).toBeGreaterThan(0);
+
+    editor.destroy();
+
+    expect(editor.eventListeners).toHaveLength(0);
+  });
+});

--- a/packages/core/__tests__/gui/MaxPopupMenu.test.ts
+++ b/packages/core/__tests__/gui/MaxPopupMenu.test.ts
@@ -1,0 +1,30 @@
+/*
+Copyright 2026-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { expect, test } from '@jest/globals';
+import { MaxPopupMenu } from '../../src';
+
+describe('destroy', () => {
+  test('clears eventListeners', () => {
+    const menu = new MaxPopupMenu();
+    menu.addListener('testEvent', () => {});
+    expect(menu.eventListeners.length).toBeGreaterThan(0);
+
+    menu.destroy();
+
+    expect(menu.eventListeners).toHaveLength(0);
+  });
+});

--- a/packages/core/__tests__/gui/MaxToolbar.test.ts
+++ b/packages/core/__tests__/gui/MaxToolbar.test.ts
@@ -1,0 +1,31 @@
+/*
+Copyright 2026-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { expect, test } from '@jest/globals';
+import { MaxToolbar } from '../../src';
+
+describe('destroy', () => {
+  test('clears eventListeners', () => {
+    const container = document.createElement('div');
+    const toolbar = new MaxToolbar(container);
+    toolbar.addListener('testEvent', () => {});
+    expect(toolbar.eventListeners.length).toBeGreaterThan(0);
+
+    toolbar.destroy();
+
+    expect(toolbar.eventListeners).toHaveLength(0);
+  });
+});

--- a/packages/core/__tests__/gui/MaxWindow.test.ts
+++ b/packages/core/__tests__/gui/MaxWindow.test.ts
@@ -1,0 +1,32 @@
+/*
+Copyright 2026-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { expect, test } from '@jest/globals';
+import MaxWindow from '../../src/gui/MaxWindow';
+
+describe('destroy', () => {
+  test('clears eventListeners', () => {
+    const content = document.createElement('div');
+    document.body.appendChild(content);
+    const win = new MaxWindow('Test', content, 0, 0, 100, 100);
+    win.addListener('testEvent', () => {});
+    expect(win.eventListeners.length).toBeGreaterThan(0);
+
+    win.destroy();
+
+    expect(win.eventListeners).toHaveLength(0);
+  });
+});

--- a/packages/core/__tests__/utils.ts
+++ b/packages/core/__tests__/utils.ts
@@ -28,6 +28,9 @@ export const createGraphWithoutContainer = (): Graph => new Graph();
  */
 export const createGraphWithoutPlugins = (): Graph => new Graph(undefined, undefined, []);
 
+export const hasListener = (eventListeners: { funct: Function }[], listener: Function) =>
+  eventListeners.some((l) => l.funct === listener);
+
 export const createCellWithStyle = (style: CellStateStyle): Cell => {
   const cell = new Cell();
   cell.style = style;

--- a/packages/core/__tests__/view/BaseGraph.test.ts
+++ b/packages/core/__tests__/view/BaseGraph.test.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { afterAll, beforeEach, describe, expect, test } from '@jest/globals';
+import { afterAll, beforeEach, describe, expect, jest, test } from '@jest/globals';
 import {
   AbstractGraph,
   BaseGraph,

--- a/packages/core/__tests__/view/BaseGraph.test.ts
+++ b/packages/core/__tests__/view/BaseGraph.test.ts
@@ -269,7 +269,7 @@ describe('destroy', () => {
     const onDestroyMock = jest.fn();
 
     class CustomPlugin implements GraphPlugin {
-      static pluginId = 'CustomPlugin';
+      static readonly pluginId = 'CustomPlugin';
       onDestroy = onDestroyMock;
     }
 

--- a/packages/core/__tests__/view/BaseGraph.test.ts
+++ b/packages/core/__tests__/view/BaseGraph.test.ts
@@ -284,6 +284,7 @@ describe('destroy', () => {
 
   test('nulls container reference', () => {
     const graph = new BaseGraph({});
+    expect(graph.container).not.toBeNull();
 
     graph.destroy();
 

--- a/packages/core/__tests__/view/BaseGraph.test.ts
+++ b/packages/core/__tests__/view/BaseGraph.test.ts
@@ -26,6 +26,7 @@ import {
   type EdgeStyleFunction,
   EdgeStyleRegistry,
   ElbowEdgeHandler,
+  type GraphPlugin,
   ImageBundle,
   Multiplicity,
   Point,
@@ -262,6 +263,43 @@ function expectExactInstanceOfEdgeHandler(handler: EdgeHandler): void {
   expect(handler).not.toBeInstanceOf(EdgeSegmentHandler);
   expect(handler).not.toBeInstanceOf(ElbowEdgeHandler);
 }
+
+describe('destroy', () => {
+  test('calls onDestroy on registered plugins', () => {
+    const onDestroyMock = jest.fn();
+
+    class CustomPlugin implements GraphPlugin {
+      static pluginId = 'CustomPlugin';
+      onDestroy = onDestroyMock;
+    }
+
+    const graph = new BaseGraph({
+      plugins: [CustomPlugin],
+    });
+
+    graph.destroy();
+
+    expect(onDestroyMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('nulls container reference', () => {
+    const graph = new BaseGraph({});
+
+    graph.destroy();
+
+    expect(graph.container).toBeNull();
+  });
+
+  test('clears eventListeners', () => {
+    const graph = new BaseGraph({});
+    graph.addListener('testEvent', () => {});
+    expect(graph.eventListeners.length).toBeGreaterThan(0);
+
+    graph.destroy();
+
+    expect(graph.eventListeners).toHaveLength(0);
+  });
+});
 
 // For "complex" properties, for example: arrays or object.
 describe('Expect no global state for properties coming from mixins', () => {

--- a/packages/core/__tests__/view/GraphView.test.ts
+++ b/packages/core/__tests__/view/GraphView.test.ts
@@ -116,6 +116,19 @@ describe('getEdgeStyle ', () => {
   });
 });
 
+describe('destroy', () => {
+  test('clears eventListeners', () => {
+    const graph = new BaseGraph();
+    const view = graph.getView();
+    view.addListener('testEvent', () => {});
+    expect(view.eventListeners.length).toBeGreaterThan(0);
+
+    view.destroy();
+
+    expect(view.eventListeners).toHaveLength(0);
+  });
+});
+
 describe('getPerimeterFunction', () => {
   // Prevents side effects between tests
   beforeEach(() => {

--- a/packages/core/__tests__/view/cell/CellMarker.test.ts
+++ b/packages/core/__tests__/view/cell/CellMarker.test.ts
@@ -1,0 +1,31 @@
+/*
+Copyright 2026-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { expect, test } from '@jest/globals';
+import { BaseGraph, CellMarker } from '../../../src';
+
+describe('destroy', () => {
+  test('clears eventListeners', () => {
+    const graph = new BaseGraph();
+    const marker = new CellMarker(graph);
+    marker.addListener('testEvent', () => {});
+    expect(marker.eventListeners.length).toBeGreaterThan(0);
+
+    marker.destroy();
+
+    expect(marker.eventListeners).toHaveLength(0);
+  });
+});

--- a/packages/core/__tests__/view/cell/CellTracker.test.ts
+++ b/packages/core/__tests__/view/cell/CellTracker.test.ts
@@ -1,0 +1,64 @@
+/*
+Copyright 2026-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { expect, test } from '@jest/globals';
+import { BaseGraph, CellTracker } from '../../../src';
+
+describe('destroy', () => {
+  test('sets destroyed flag', () => {
+    const graph = new BaseGraph();
+    const tracker = new CellTracker(graph, '#00FF00');
+
+    expect(tracker.destroyed).toBe(false);
+
+    tracker.destroy();
+
+    expect(tracker.destroyed).toBe(true);
+  });
+
+  test('removes mouse listener from graph', () => {
+    const graph = new BaseGraph();
+    const tracker = new CellTracker(graph, '#00FF00');
+
+    expect(graph.mouseListeners).toContain(tracker);
+
+    tracker.destroy();
+
+    expect(graph.mouseListeners).not.toContain(tracker);
+  });
+
+  test('clears eventListeners', () => {
+    const graph = new BaseGraph();
+    const tracker = new CellTracker(graph, '#00FF00');
+    tracker.addListener('testEvent', () => {});
+    expect(tracker.eventListeners.length).toBeGreaterThan(0);
+
+    tracker.destroy();
+
+    expect(tracker.eventListeners).toHaveLength(0);
+  });
+
+  test('is idempotent', () => {
+    const graph = new BaseGraph();
+    const tracker = new CellTracker(graph, '#00FF00');
+
+    tracker.destroy();
+    tracker.destroy();
+
+    expect(tracker.destroyed).toBe(true);
+    expect(graph.mouseListeners).not.toContain(tracker);
+  });
+});

--- a/packages/core/__tests__/view/event/EventSource.test.ts
+++ b/packages/core/__tests__/view/event/EventSource.test.ts
@@ -1,0 +1,31 @@
+/*
+Copyright 2026-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { expect, test } from '@jest/globals';
+import EventSource from '../../../src/view/event/EventSource';
+
+describe('destroy', () => {
+  test('clears all registered event listeners', () => {
+    const eventSource = new EventSource();
+    eventSource.addListener('event1', () => {});
+    eventSource.addListener('event2', () => {});
+    expect(eventSource.eventListeners).toHaveLength(2);
+
+    eventSource.destroy();
+
+    expect(eventSource.eventListeners).toHaveLength(0);
+  });
+});

--- a/packages/core/__tests__/view/layout/LayoutManager.test.ts
+++ b/packages/core/__tests__/view/layout/LayoutManager.test.ts
@@ -1,0 +1,31 @@
+/*
+Copyright 2026-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { expect, test } from '@jest/globals';
+import { BaseGraph, LayoutManager } from '../../../src';
+
+describe('destroy', () => {
+  test('clears eventListeners', () => {
+    const graph = new BaseGraph();
+    const manager = new LayoutManager(graph);
+    manager.addListener('testEvent', () => {});
+    expect(manager.eventListeners.length).toBeGreaterThan(0);
+
+    manager.destroy();
+
+    expect(manager.eventListeners).toHaveLength(0);
+  });
+});

--- a/packages/core/__tests__/view/layout/SwimlaneManager.test.ts
+++ b/packages/core/__tests__/view/layout/SwimlaneManager.test.ts
@@ -1,0 +1,31 @@
+/*
+Copyright 2026-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { expect, test } from '@jest/globals';
+import { BaseGraph, SwimlaneManager } from '../../../src';
+
+describe('destroy', () => {
+  test('clears eventListeners', () => {
+    const graph = new BaseGraph();
+    const manager = new SwimlaneManager(graph);
+    manager.addListener('testEvent', () => {});
+    expect(manager.eventListeners.length).toBeGreaterThan(0);
+
+    manager.destroy();
+
+    expect(manager.eventListeners).toHaveLength(0);
+  });
+});

--- a/packages/core/__tests__/view/other/AutoSaveManager.test.ts
+++ b/packages/core/__tests__/view/other/AutoSaveManager.test.ts
@@ -1,0 +1,31 @@
+/*
+Copyright 2026-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { expect, test } from '@jest/globals';
+import { AutoSaveManager, BaseGraph } from '../../../src';
+
+describe('destroy', () => {
+  test('clears eventListeners', () => {
+    const graph = new BaseGraph();
+    const manager = new AutoSaveManager(graph);
+    manager.addListener('testEvent', () => {});
+    expect(manager.eventListeners.length).toBeGreaterThan(0);
+
+    manager.destroy();
+
+    expect(manager.eventListeners).toHaveLength(0);
+  });
+});

--- a/packages/core/__tests__/view/plugin/PanningHandler.test.ts
+++ b/packages/core/__tests__/view/plugin/PanningHandler.test.ts
@@ -1,0 +1,53 @@
+/*
+Copyright 2026-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { expect, test } from '@jest/globals';
+import { BaseGraph, PanningHandler } from '../../../src';
+
+describe('onDestroy', () => {
+  test('PanningManager.destroy() is called when PanningHandler is destroyed', () => {
+    const graph = new BaseGraph({ plugins: [PanningHandler] });
+    const panningHandler = graph.getPlugin<PanningHandler>('PanningHandler')!;
+    const destroyMock = jest.fn(panningHandler.panningManager.destroy);
+    panningHandler.panningManager.destroy = destroyMock;
+
+    panningHandler.onDestroy();
+
+    expect(destroyMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('clears eventListeners', () => {
+    const graph = new BaseGraph({ plugins: [PanningHandler] });
+    const panningHandler = graph.getPlugin<PanningHandler>('PanningHandler')!;
+    panningHandler.addListener('testEvent', () => {});
+    expect(panningHandler.eventListeners.length).toBeGreaterThan(0);
+
+    panningHandler.onDestroy();
+
+    expect(panningHandler.eventListeners).toHaveLength(0);
+  });
+
+  test('PanningManager.stop() is called during destroy to clear interval timer', () => {
+    const graph = new BaseGraph({ plugins: [PanningHandler] });
+    const panningHandler = graph.getPlugin<PanningHandler>('PanningHandler')!;
+    const stopMock = jest.fn(panningHandler.panningManager.stop);
+    panningHandler.panningManager.stop = stopMock;
+
+    panningHandler.onDestroy();
+
+    expect(stopMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/__tests__/view/plugin/RubberBandHandler.test.ts
+++ b/packages/core/__tests__/view/plugin/RubberBandHandler.test.ts
@@ -1,0 +1,36 @@
+/*
+Copyright 2026-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { expect, test } from '@jest/globals';
+import { BaseGraph, RubberBandHandler } from '../../../src';
+import { hasListener } from '../../utils';
+
+describe('onDestroy', () => {
+  test('removes all graph listeners registered in constructor', () => {
+    const graph = new BaseGraph({ plugins: [RubberBandHandler] });
+    const handler = graph.getPlugin<RubberBandHandler>('RubberBandHandler')!;
+
+    expect(hasListener(graph.eventListeners, handler.forceRubberbandHandler)).toBe(true);
+    expect(hasListener(graph.eventListeners, handler.panHandler)).toBe(true);
+    expect(hasListener(graph.eventListeners, handler.gestureHandler)).toBe(true);
+
+    handler.onDestroy();
+
+    expect(hasListener(graph.eventListeners, handler.forceRubberbandHandler)).toBe(false);
+    expect(hasListener(graph.eventListeners, handler.panHandler)).toBe(false);
+    expect(hasListener(graph.eventListeners, handler.gestureHandler)).toBe(false);
+  });
+});

--- a/packages/core/__tests__/view/plugin/SelectionCellsHandler.test.ts
+++ b/packages/core/__tests__/view/plugin/SelectionCellsHandler.test.ts
@@ -1,0 +1,72 @@
+/*
+Copyright 2026-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { expect, test } from '@jest/globals';
+import { BaseGraph, SelectionCellsHandler } from '../../../src';
+import { hasListener } from '../../utils';
+
+describe('onDestroy', () => {
+  test('removes refreshHandler from selectionModel', () => {
+    const graph = new BaseGraph({ plugins: [SelectionCellsHandler] });
+    const handler = graph.getPlugin<SelectionCellsHandler>('SelectionCellsHandler')!;
+    const { refreshHandler } = handler;
+
+    expect(hasListener(graph.getSelectionModel().eventListeners, refreshHandler)).toBe(
+      true
+    );
+
+    handler.onDestroy();
+
+    expect(hasListener(graph.getSelectionModel().eventListeners, refreshHandler)).toBe(
+      false
+    );
+  });
+
+  test('clears eventListeners', () => {
+    const graph = new BaseGraph({ plugins: [SelectionCellsHandler] });
+    const handler = graph.getPlugin<SelectionCellsHandler>('SelectionCellsHandler')!;
+    handler.addListener('testEvent', () => {});
+    expect(handler.eventListeners.length).toBeGreaterThan(0);
+
+    handler.onDestroy();
+
+    expect(handler.eventListeners).toHaveLength(0);
+  });
+
+  test('removes refreshHandler from dataModel', () => {
+    const graph = new BaseGraph({ plugins: [SelectionCellsHandler] });
+    const handler = graph.getPlugin<SelectionCellsHandler>('SelectionCellsHandler')!;
+    const { refreshHandler } = handler;
+
+    expect(hasListener(graph.getDataModel().eventListeners, refreshHandler)).toBe(true);
+
+    handler.onDestroy();
+
+    expect(hasListener(graph.getDataModel().eventListeners, refreshHandler)).toBe(false);
+  });
+
+  test('removes refreshHandler from view', () => {
+    const graph = new BaseGraph({ plugins: [SelectionCellsHandler] });
+    const handler = graph.getPlugin<SelectionCellsHandler>('SelectionCellsHandler')!;
+    const { refreshHandler } = handler;
+
+    expect(hasListener(graph.getView().eventListeners, refreshHandler)).toBe(true);
+
+    handler.onDestroy();
+
+    expect(hasListener(graph.getView().eventListeners, refreshHandler)).toBe(false);
+  });
+});

--- a/packages/core/src/editor/Editor.ts
+++ b/packages/core/src/editor/Editor.ts
@@ -2585,7 +2585,7 @@ export class Editor extends EventSource {
    * normally need to be called, it is called automatically when the window
    * unloads.
    */
-  destroy(): void {
+  override destroy(): void {
     if (!this.destroyed) {
       this.destroyed = true;
 
@@ -2600,6 +2600,8 @@ export class Editor extends EventSource {
 
       this.status = null;
       this.templates = null;
+
+      super.destroy();
     }
   }
 }

--- a/packages/core/src/gui/MaxPopupMenu.ts
+++ b/packages/core/src/gui/MaxPopupMenu.ts
@@ -500,12 +500,14 @@ class MaxPopupMenu extends EventSource {
   /**
    * Destroys the handler and all its resources and DOM nodes.
    */
-  destroy(): void {
+  override destroy(): void {
     if (this.div) {
       InternalEvent.release(this.div);
 
       this.div.parentNode?.removeChild(this.div);
     }
+
+    super.destroy();
   }
 }
 

--- a/packages/core/src/gui/MaxToolbar.ts
+++ b/packages/core/src/gui/MaxToolbar.ts
@@ -477,6 +477,7 @@ class MaxToolbar extends EventSource {
 
     if (this.menu != null) {
       this.menu.destroy();
+      this.menu = null;
     }
 
     super.destroy();

--- a/packages/core/src/gui/MaxToolbar.ts
+++ b/packages/core/src/gui/MaxToolbar.ts
@@ -467,7 +467,7 @@ class MaxToolbar extends EventSource {
   /**
    * Removes the toolbar and all its associated resources.
    */
-  destroy(): void {
+  override destroy(): void {
     InternalEvent.release(this.container);
     // @ts-ignore
     this.container = null;
@@ -478,6 +478,8 @@ class MaxToolbar extends EventSource {
     if (this.menu != null) {
       this.menu.destroy();
     }
+
+    super.destroy();
   }
 }
 

--- a/packages/core/src/gui/MaxWindow.ts
+++ b/packages/core/src/gui/MaxWindow.ts
@@ -936,7 +936,7 @@ export default class MaxWindow extends EventSource {
    * Destroys the window and removes all associated resources. Fires a
    * <destroy> event prior to destroying the window.
    */
-  destroy(): void {
+  override destroy(): void {
     this.fireEvent(new EventObject(InternalEvent.DESTROY));
 
     if (this.div != null) {
@@ -953,5 +953,7 @@ export default class MaxWindow extends EventSource {
     this.content = null;
     // @ts-ignore
     this.contentWrapper = null;
+
+    super.destroy();
   }
 }

--- a/packages/core/src/view/AbstractGraph.ts
+++ b/packages/core/src/view/AbstractGraph.ts
@@ -1300,12 +1300,15 @@ export abstract class AbstractGraph extends EventSource {
 
   /**
    * Destroys the graph and all its resources.
+   * After calling this method, the Graph should not be used anymore.
+   *
+   * For example, call this method when unmounting/disposing a component using the Graph to avoid memory leaks.
    */
-  destroy() {
+  override destroy() {
     if (!this.destroyed) {
       this.destroyed = true;
 
-      Object.values(this.plugins).forEach((p) => p.onDestroy());
+      this.plugins.forEach((p) => p.onDestroy());
 
       this.view.destroy();
 
@@ -1313,6 +1316,11 @@ export abstract class AbstractGraph extends EventSource {
         this.getDataModel().removeListener(this.graphModelChangeListener);
         this.graphModelChangeListener = null;
       }
+
+      // @ts-expect-error Can be null when destroyed.
+      this.container = null;
+
+      super.destroy();
     }
   }
 }

--- a/packages/core/src/view/AbstractGraph.ts
+++ b/packages/core/src/view/AbstractGraph.ts
@@ -1304,7 +1304,7 @@ export abstract class AbstractGraph extends EventSource {
    *
    * For example, call this method when unmounting/disposing a component using the Graph to avoid memory leaks.
    */
-  override destroy() {
+  override destroy(): void {
     if (!this.destroyed) {
       this.destroyed = true;
 

--- a/packages/core/src/view/GraphView.ts
+++ b/packages/core/src/view/GraphView.ts
@@ -2360,7 +2360,7 @@ export class GraphView extends EventSource {
   /**
    * Destroys the view and all its resources.
    */
-  override destroy() {
+  override destroy(): void {
     let root: SVGElement | HTMLElement | null = null;
 
     if (this.canvas && this.canvas instanceof SVGElement) {

--- a/packages/core/src/view/GraphView.ts
+++ b/packages/core/src/view/GraphView.ts
@@ -2360,7 +2360,7 @@ export class GraphView extends EventSource {
   /**
    * Destroys the view and all its resources.
    */
-  destroy() {
+  override destroy() {
     let root: SVGElement | HTMLElement | null = null;
 
     if (this.canvas && this.canvas instanceof SVGElement) {
@@ -2395,6 +2395,8 @@ export class GraphView extends EventSource {
       this.overlayPane = null;
       // @ts-expect-error Can be null when destroyed.
       this.decoratorPane = null;
+
+      super.destroy();
     }
   }
 

--- a/packages/core/src/view/cell/CellMarker.ts
+++ b/packages/core/src/view/cell/CellMarker.ts
@@ -363,8 +363,10 @@ class CellMarker extends EventSource {
   /**
    * Destroys the handler and all its resources and DOM nodes.
    */
-  destroy() {
+  override destroy() {
     this.highlight.destroy();
+
+    super.destroy();
   }
 }
 

--- a/packages/core/src/view/cell/CellMarker.ts
+++ b/packages/core/src/view/cell/CellMarker.ts
@@ -363,7 +363,7 @@ class CellMarker extends EventSource {
   /**
    * Destroys the handler and all its resources and DOM nodes.
    */
-  override destroy() {
+  override destroy(): void {
     this.highlight.destroy();
 
     super.destroy();

--- a/packages/core/src/view/event/EventSource.ts
+++ b/packages/core/src/view/event/EventSource.ts
@@ -163,7 +163,7 @@ class EventSource {
    * Subclasses with a `destroy` method should call `super.destroy()` at the end
    * of their own cleanup to ensure no stale listeners remain.
    */
-  destroy() {
+  destroy(): void {
     this.eventListeners.length = 0;
   }
 }

--- a/packages/core/src/view/event/EventSource.ts
+++ b/packages/core/src/view/event/EventSource.ts
@@ -63,33 +63,34 @@ class EventSource {
   eventsEnabled = true;
 
   /**
-   * Optional source for events. Default is null.
+   * Optional source for events.
+   * @default null
    */
   eventSource: EventTarget | null = null;
 
   /**
-   * Returns <eventsEnabled>.
+   * Returns {@link eventsEnabled}.
    */
   isEventsEnabled() {
     return this.eventsEnabled;
   }
 
   /**
-   * Sets <eventsEnabled>.
+   * Sets {@link eventsEnabled}.
    */
   setEventsEnabled(value: boolean) {
     this.eventsEnabled = value;
   }
 
   /**
-   * Returns <eventSource>.
+   * Returns {@link eventSource}.
    */
   getEventSource() {
     return this.eventSource;
   }
 
   /**
-   * Sets <eventSource>.
+   * Sets {@link eventSource}.
    */
   setEventSource(value: EventTarget | null) {
     this.eventSource = value;
@@ -106,7 +107,7 @@ class EventSource {
   }
 
   /**
-   * Removes all occurrences of the given listener from <eventListeners>.
+   * Removes all occurrences of the given listener from {@link eventListeners}.
    */
   removeListener(funct: Function) {
     let i = 0;
@@ -134,6 +135,7 @@ class EventSource {
    * @param evt {@link EventObject} that represents the event.
    * @param sender Optional sender to be passed to the listener. Default value is the return value of {@link getEventSource}.
    */
+
   fireEvent(evt: EventObject, sender: EventTarget | null = null) {
     if (this.isEventsEnabled()) {
       if (!evt) {
@@ -153,6 +155,16 @@ class EventSource {
         }
       }
     }
+  }
+
+  /**
+   * Clears all registered event listeners.
+   *
+   * Subclasses with a `destroy` method should call `super.destroy()` at the end
+   * of their own cleanup to ensure no stale listeners remain.
+   */
+  destroy() {
+    this.eventListeners.length = 0;
   }
 }
 

--- a/packages/core/src/view/layout/LayoutManager.ts
+++ b/packages/core/src/view/layout/LayoutManager.ts
@@ -390,8 +390,10 @@ class LayoutManager extends EventSource {
   /**
    * Removes all handlers from the {@link graph} and deletes the reference to it.
    */
-  destroy() {
+  override destroy() {
     this.setGraph(null);
+
+    super.destroy();
   }
 }
 

--- a/packages/core/src/view/layout/LayoutManager.ts
+++ b/packages/core/src/view/layout/LayoutManager.ts
@@ -390,7 +390,7 @@ class LayoutManager extends EventSource {
   /**
    * Removes all handlers from the {@link graph} and deletes the reference to it.
    */
-  override destroy() {
+  override destroy(): void {
     this.setGraph(null);
 
     super.destroy();

--- a/packages/core/src/view/layout/SwimlaneManager.ts
+++ b/packages/core/src/view/layout/SwimlaneManager.ts
@@ -343,8 +343,10 @@ class SwimlaneManager extends EventSource {
   /**
    * Removes all handlers from the {@link graph} and deletes the reference to it.
    */
-  destroy() {
+  override destroy() {
     this.setGraph(null);
+
+    super.destroy();
   }
 }
 

--- a/packages/core/src/view/layout/SwimlaneManager.ts
+++ b/packages/core/src/view/layout/SwimlaneManager.ts
@@ -343,7 +343,7 @@ class SwimlaneManager extends EventSource {
   /**
    * Removes all handlers from the {@link graph} and deletes the reference to it.
    */
-  override destroy() {
+  override destroy(): void {
     this.setGraph(null);
 
     super.destroy();

--- a/packages/core/src/view/other/AutoSaveManager.ts
+++ b/packages/core/src/view/other/AutoSaveManager.ts
@@ -164,8 +164,10 @@ class AutoSaveManager extends EventSource {
   /**
    * Removes all handlers from the {@link graph} and deletes the reference to it.
    */
-  destroy(): void {
+  override destroy(): void {
     this.setGraph(null);
+
+    super.destroy();
   }
 }
 

--- a/packages/core/src/view/other/PanningManager.ts
+++ b/packages/core/src/view/other/PanningManager.ts
@@ -205,6 +205,7 @@ class PanningManager {
     };
 
     this.destroy = () => {
+      this.stop();
       graph.removeMouseListener(this.mouseListener);
       InternalEvent.removeListener(document, 'mouseup', this.mouseUpListener);
     };

--- a/packages/core/src/view/plugin/PanningHandler.ts
+++ b/packages/core/src/view/plugin/PanningHandler.ts
@@ -458,6 +458,9 @@ class PanningHandler extends EventSource implements GraphPlugin, MouseListenerSe
     this.graph.removeListener(this.forcePanningHandler);
     this.graph.removeListener(this.gestureHandler);
     InternalEvent.removeListener(document, 'mouseup', this.mouseUpListener);
+    this.panningManager.destroy();
+
+    super.destroy();
   }
 }
 

--- a/packages/core/src/view/plugin/RubberBandHandler.ts
+++ b/packages/core/src/view/plugin/RubberBandHandler.ts
@@ -392,6 +392,7 @@ class RubberBandHandler implements GraphPlugin, MouseListenerSet {
       this.graph.removeMouseListener(this);
       this.graph.removeListener(this.forceRubberbandHandler);
       this.graph.removeListener(this.panHandler);
+      this.graph.removeListener(this.gestureHandler);
       this.reset();
 
       if (this.sharedDiv) {

--- a/packages/core/src/view/plugin/SelectionCellsHandler.ts
+++ b/packages/core/src/view/plugin/SelectionCellsHandler.ts
@@ -277,9 +277,11 @@ class SelectionCellsHandler extends EventSource implements GraphPlugin, MouseLis
    */
   onDestroy() {
     this.graph.removeMouseListener(this);
-    this.graph.removeListener(this.refreshHandler);
+    this.graph.getSelectionModel().removeListener(this.refreshHandler);
     this.graph.getDataModel().removeListener(this.refreshHandler);
     this.graph.getView().removeListener(this.refreshHandler);
+
+    super.destroy();
   }
 }
 


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a Pull Request to maxGraph! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.

All contributions to this project are done under the terms of the Apache 2.0 license as stated in the LICENSE file located at the root of this repository.


Note: core contributors are not required to use this template.
-->

## PR Checklist

- [x] Addresses an existing open issue: closes #994. If not, explain why (minor changes, etc.).
- [x] You have discussed this issue with the maintainers of `maxGraph`, and you are assigned to the issue.
- [x] The scope of the PR is sufficiently narrow to be examined in a single session. A PR covering several issues must be split into separate PRs. Do not create a large PR, otherwise it cannot be reviewed and you will be asked to split it later or the PR will be closed.
- [x] I have added tests to prove my fix is effective or my feature works. This can be done in the form of automatic tests in `packages/core/_tests_` or a new or altered Storybook story in `packages/html/stories` (an existing story may also demonstrate the change).
- [x] I have provided screenshot/videos to demonstrate the change. If no releavant, explain why. No visual changes
- [x] I have added or edited necessary documentation, or no docs changes are needed. No documentation changes
- [x] The PR title follows the ["Conventional Commits"](https://www.conventionalcommits.org/en/v1.0.0/) guidelines.

<!--
The PR title must look like `<type>[optional scope]: <lower case description>`

*type* can be (see existing Pull Request for more elements):
- chore
- docs
- feat
- fix
- refactor
  ...

If defined, the _optional scope_ must be put in parentheses.

Note: The title is used as proposal for the maintainer merging the Pull Request.
-->


## Overview

<!-- Description of what and why is changed, and how the code change does that. -->
<!--
- Explain the **details** for making this change: What existing problem does the Pull Request solve? Why is this feature beneficial?
- If the Pull Request includes breaking changes, it must explicitly follow the syntax proposed by [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) (in the PR title and with a quote at this end of this overview).
- Includes keywords to reference the issue, e.g., "fixes #xxxx", "closes #xxxx", ... (where #xxxx is the issue number) and automatically closes it when the Pull Request is merged.
For more details about linking issues in Pull Requests, see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue.
- Also include a short description of the changes in this Pull Request to be used as merge commit when merging the PR.
-->

Changes:
    - Fix AbstractGraph.destroy() to iterate plugins Map correctly and set null container reference
    - Fix PanningHandler.onDestroy() to call panningManager.destroy()
    - Fix PanningManager.destroy() to call stop() to clear interval timer
    - Fix RubberBandHandler.onDestroy() to remove gestureHandler listener
    - Fix SelectionCellsHandler.onDestroy() to remove listener from selectionModel
    - Add EventSource.destroy() to clear eventListeners, call super.destroy() in children classes
    - Add destroy tests for all modified classes

## Notes

<!-- Use this paragraph to provide the reviewer with any additional information. Remove if not applicable -->

The scope of this PR is wider than what is described in #994.
I did a systematic search on destroy methods and look for missing resources releasing. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  - Added broad test coverage verifying event listeners and plugins are cleaned up during component teardown to reduce memory leaks and improve stability.

* **Refactor**
  - Standardized destruction flows across UI, graph, and plugin components to ensure base-class cleanup runs, stop active timers/processes, and explicitly remove gesture/panning and other listeners for more reliable teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->