### PR TITLE
fix: restore preview edge default target position on cell hover

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -243,51 +243,117 @@ export type CellStateStyle = {
    */
   endSize?: number;
   /**
-   * The horizontal offset of the connection point of an edge with its target terminal.
+   * The horizontal offset in pixels applied to the connection point of an edge with its target terminal.
+   *
+   * This offset is applied after the connection point position is determined by {@link entryX} and {@link entryY}.
+   *
+   * @see {@link entryDy} for the vertical offset.
+   * @see {@link exitDx} for the equivalent on the source terminal.
    */
   entryDx?: number;
   /**
-   * The vertical offset of the connection point of an edge with its target terminal.
+   * The vertical offset in pixels applied to the connection point of an edge with its target terminal.
+   *
+   * This offset is applied after the connection point position is determined by {@link entryX} and {@link entryY}.
+   *
+   * @see {@link entryDx} for the horizontal offset.
+   * @see {@link exitDy} for the equivalent on the source terminal.
    */
   entryDy?: number;
   /**
-   * Defines if the perimeter should be used to find the exact entry point along the perimeter
-   * of the target.
+   * Defines if the perimeter should be used to find the exact entry point along the perimeter of the target.
+   *
+   * When `false`, the target behaves as if it has no {@link perimeter}: the connection point is located at the center of the terminal.
+   *
+   * Only applies when {@link entryX} and {@link entryY} are `undefined` (i.e. no fixed connection point is set).
+   *
    * @default true
+   * @see {@link perimeter} for how the perimeter is defined on a cell.
+   * @see {@link entryX} and {@link entryY} for fixed connection point coordinates.
+   * @see {@link exitPerimeter} for the equivalent on the source terminal.
    */
   entryPerimeter?: boolean;
   /**
-   * The connection point in relative horizontal coordinates of an edge with its target terminal.
+   * The x coordinate of the connection point in relative horizontal coordinates of an edge with its target terminal.
    *
-   * Set values from 0 (left) to 1 (right). Use 0.5 for center.
+   * **Note**: Only considered if {@link entryY} is set as well.
+   *
+   * Typical values are from 0 (left) to 1 (right). Use 0.5 for center.
+   *
+   * If `undefined`, the connection point is computed based on the perimeter settings. See {@link entryPerimeter}.
+   *
+   * @see {@link entryDx} for applying a pixel offset after the connection point is determined.
+   * @see {@link exitX} for the equivalent on the source terminal.
    */
   entryX?: number;
   /**
-   * The connection point in relative vertical coordinates of an edge with its target terminal.
+   * The y coordinate of the connection point in relative vertical coordinates of an edge with its target terminal.
    *
-   * Set values from 0 (top) to 1 (bottom). Use 0.5 for center.
+   * **Note**: Only considered if {@link entryX} is set as well.
+   *
+   * Typical values are from 0 (top) to 1 (bottom). Use 0.5 for center.
+   *
+   * If `undefined`, the connection point is computed based on the perimeter settings. See {@link entryPerimeter}.
+   *
+   * @see {@link entryDy} for applying a pixel offset after the connection point is determined.
+   * @see {@link exitY} for the equivalent on the source terminal.
    */
   entryY?: number;
   /**
-   * The horizontal offset of the connection point of an edge with its source terminal.
+   * The horizontal offset in pixels applied to the connection point of an edge with its source terminal.
+   *
+   * This offset is applied after the connection point position is determined by {@link exitX} and {@link exitY}.
+   *
+   * @see {@link exitDy} for the vertical offset.
+   * @see {@link entryDx} for the equivalent on the target terminal.
    */
   exitDx?: number;
   /**
-   * The vertical offset of the connection point of an edge with its source terminal.
+   * The vertical offset in pixels applied to the connection point of an edge with its source terminal.
+   *
+   * This offset is applied after the connection point position is determined by {@link exitX} and {@link exitY}.
+   *
+   * @see {@link exitDx} for the horizontal offset.
+   * @see {@link entryDy} for the equivalent on the target terminal.
    */
   exitDy?: number;
   /**
-   * Defines if the perimeter should be used to find the exact entry point along the perimeter
-   * of the source.
+   * Defines if the perimeter should be used to find the exact exit point along the perimeter of the source.
+   *
+   * When `false`, the source behaves as if it has no {@link perimeter}: the connection point is located at the center of the terminal.
+   *
+   * Only applies when {@link exitX} and {@link exitY} are `undefined` (i.e. no fixed connection point is set).
+   *
    * @default true
+   * @see {@link perimeter} for how the perimeter is defined on a cell.
+   * @see {@link exitX} and {@link exitY} for fixed connection point coordinates.
+   * @see {@link entryPerimeter} for the equivalent on the target terminal.
    */
   exitPerimeter?: boolean;
   /**
-   * The horizontal relative coordinate connection point of an edge with its source terminal.
+   * The x coordinate of the connection point in relative horizontal coordinates of an edge with its source terminal.
+   *
+   * **Note**: Only considered if {@link exitY} is set as well.
+   *
+   * Typical values are from 0 (left) to 1 (right). Use 0.5 for center.
+   *
+   * If `undefined`, the connection point is computed based on the perimeter settings. See {@link exitPerimeter}.
+   *
+   * @see {@link exitDx} for applying a pixel offset after the connection point is determined.
+   * @see {@link entryX} for the equivalent on the target terminal.
    */
   exitX?: number;
   /**
-   * The vertical relative coordinate connection point of an edge with its source terminal.
+   * The y coordinate of the connection point in relative vertical coordinates of an edge with its source terminal.
+   *
+   * **Note**: Only considered if {@link exitX} is set as well.
+   *
+   * Typical values are from 0 (top) to 1 (bottom). Use 0.5 for center.
+   *
+   * If `undefined`, the connection point is computed based on the perimeter settings. See {@link exitPerimeter}.
+   *
+   * @see {@link exitDy} for applying a pixel offset after the connection point is determined.
+   * @see {@link entryY} for the equivalent on the target terminal.
    */
   exitY?: number;
   /**
@@ -571,6 +637,7 @@ export type CellStateStyle = {
    * Remember that enabling this switch carries a possible security risk
    *
    * **WARNING**: explicitly set the value to null or undefined means to not use any perimeter.
+   * In that case, the connection point is located at the center of the cell.
    * To use the perimeter defined in the default vertex, do not set this property.
    */
   perimeter?: PerimeterFunction | PerimeterValue | (string & Record<never, never>) | null;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -258,10 +258,14 @@ export type CellStateStyle = {
   entryPerimeter?: boolean;
   /**
    * The connection point in relative horizontal coordinates of an edge with its target terminal.
+   *
+   * Set values from 0 (left) to 1 (right). Use 0.5 for center.
    */
   entryX?: number;
   /**
    * The connection point in relative vertical coordinates of an edge with its target terminal.
+   *
+   * Set values from 0 (top) to 1 (bottom). Use 0.5 for center.
    */
   entryY?: number;
   /**

--- a/packages/core/src/view/plugin/ConnectionHandler.ts
+++ b/packages/core/src/view/plugin/ConnectionHandler.ts
@@ -1311,8 +1311,8 @@ export default class ConnectionHandler
       this.edgeState.style.entryX = constraint.point.x;
       this.edgeState.style.entryY = constraint.point.y;
     } else {
-      this.edgeState.style.entryX = 0;
-      this.edgeState.style.entryY = 0;
+      delete this.edgeState.style.entryX;
+      delete this.edgeState.style.entryY;
     }
 
     this.edgeState.absolutePoints = [null, this.currentState != null ? null : current];


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: closes #<the_issue_number_here>. If not, explain why (minor changes, etc.).
- [x] You have discussed this issue with the maintainers of `maxGraph`, and you are assigned to the issue.
- [x] The scope of the PR is sufficiently narrow to be examined in a single session. A PR covering several issues must be split into separate PRs. Do not create a large PR, otherwise it cannot be reviewed and you will be asked to split it later or the PR will be closed.
- [x] I have added tests to prove my fix is effective or my feature works. This can be done in the form of automatic tests in `packages/core/_tests_` or a new or altered Storybook story in `packages/html/stories` (an existing story may also demonstrate the change).
- [x] I have provided screenshot/videos to demonstrate the change. If no releavant, explain why.
- [x] I have added or edited necessary documentation, or no docs changes are needed.
- [x] The PR title follows the ["Conventional Commits"](https://www.conventionalcommits.org/en/v1.0.0/) guidelines.

## Overview

Restore connection handler mxgraph behavior.
Delete preview edge `entryX` and `entryY` style properties when hovering a cell without without hovering a specific target connection point instead of setting them to 0. Currently, the connection preview entry position snaps to the top left corner of cell shapes, which is not intended behavior.

### Bug description

- This pull request is intended to fix issue #841 and other issues involving misposition of the connection preview when using the connection handler.

Demonstration using the [Anchor story](https://github.com/maxGraph/maxGraph/blob/24357a7eb79a67b91a0d1c815a8e45c615188499/packages/html/stories/Anchors.stories.ts)

- Current maxgraph behavior : The connection preview snaps to the top left of the cell shape.

https://github.com/user-attachments/assets/664965eb-8a37-47a9-b2ff-9f0f17666463

- Intended mxgraph behavior : The connection preview snaps to the bottom center of the cell shape.

https://github.com/user-attachments/assets/4d2715b3-3b1c-49e6-8571-295da46b30be

### Analysis

The behavior change was introduced in commit 648e324 where the [connection handler](https://github.com/maxGraph/maxGraph/blob/24357a7eb79a67b91a0d1c815a8e45c615188499/packages/core/src/view/plugin/ConnectionHandler.ts) file was changed from

https://github.com/maxGraph/maxGraph/blob/0453da274fbbeba4b7a457daec1cd9ad6db4abe0/packages/core/src/view/connection/ConnectionHandler.ts#L1497-L1503

to

https://github.com/maxGraph/maxGraph/blob/648e324cc06254c90694347dc216ac008aa63697/packages/core/src/view/connection/ConnectionHandler.ts#L1491-L1497

Which remains to this day. Fixing the issue consists in reverting to the original code.

## Notes

- Although this pull request reverts to the initial mxgraph behavior, it provides no motivation for the initial behavior in the first place.
- I've added no tests under packages/core/\_\_tests\_\_ as the issue is related to a transient rendering artefact. Correctness can be assed using any story involving the connection handler where its `updateEdgeState` method has not been overriden.

## Keywords

closes #841 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved edge preview rendering by removing stale connection coordinate styling when preview constraints are absent, producing more accurate connection visuals.

* **Documentation**
  * Expanded and clarified connection-point docs: normalized entryX/entryY/exitX/exitY semantics (typical 0–1 range), how perimeter falls back to center, and how pixel offsets (entryDx/entryDy/exitDx/exitDy) apply after point computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->