### PR TITLE
fix: enforce type-safe value in setCellStyles

### DIFF
--- a/packages/core/__tests__/view/mixin/EdgeMixin.test.ts
+++ b/packages/core/__tests__/view/mixin/EdgeMixin.test.ts
@@ -36,8 +36,8 @@ describe('insertEdge', () => {
     expect(cell.style).toStrictEqual({
       ...style,
       // added during insertion
-      sourcePort: null,
-      targetPort: null,
+      sourcePort: undefined,
+      targetPort: undefined,
     });
 
     const geometry = new Geometry();
@@ -77,8 +77,8 @@ describe('insertEdge', () => {
     expect(cell.style).toStrictEqual({
       ...style,
       // added during insertion
-      sourcePort: null,
-      targetPort: null,
+      sourcePort: undefined,
+      targetPort: undefined,
     });
 
     const geometry = new Geometry();

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -258,10 +258,14 @@ export type CellStateStyle = {
   entryPerimeter?: boolean;
   /**
    * The connection point in relative horizontal coordinates of an edge with its target terminal.
+   *
+   * Set values from 0 (left) to 1 (right). Use 0.5 for center.
    */
   entryX?: number;
   /**
    * The connection point in relative vertical coordinates of an edge with its target terminal.
+   *
+   * Set values from 0 (top) to 1 (bottom). Use 0.5 for center.
    */
   entryY?: number;
   /**

--- a/packages/core/src/util/styleUtils.ts
+++ b/packages/core/src/util/styleUtils.ts
@@ -30,7 +30,7 @@ import type {
   NumericCellStateStyleKeys,
   VAlignValue,
 } from '../types.js';
-import { matchBinaryMask } from '../internal/utils.js';
+import { isNullish, matchBinaryMask } from '../internal/utils.js';
 import { StyleDefaultsConfig } from './config.js';
 
 /**
@@ -313,19 +313,19 @@ export const convertPoint = (container: HTMLElement, x: number, y: number) => {
 };
 
 /**
- * Assigns the value for the given key in the styles of the given cells, or removes the key from the styles if the value is `null`.
+ * Assigns the value for the given key in the styles of the given cells, or removes the key from the styles if the value is `nullish`.
  *
  * @param model {@link GraphDataModel} to execute the transaction in.
  * @param cells Array of {@link Cell}s to be updated.
  * @param key Key of the style to be changed.
  * @param value New value for the given key.
  */
-export const setCellStyles = (
+export const setCellStyles = <K extends keyof CellStateStyle>(
   model: GraphDataModel,
   cells: Cell[],
-  key: keyof CellStateStyle,
-  value: any
-) => {
+  key: K,
+  value: CellStateStyle[K] | undefined | null
+): void => {
   if (cells.length > 0) {
     model.batchUpdate(() => {
       for (let i = 0; i < cells.length; i += 1) {
@@ -334,7 +334,7 @@ export const setCellStyles = (
         if (cell) {
           // Currently, the style object must be cloned, otherwise model.setStyle does not trigger the change event and the cell state in the view is not updated
           const style = cell.getClonedStyle();
-          style[key] = value;
+          style[key] = isNullish(value) ? undefined : value;
 
           model.setStyle(cell, style);
         }

--- a/packages/core/src/view/layout/GraphLayout.ts
+++ b/packages/core/src/view/layout/GraphLayout.ts
@@ -241,14 +241,14 @@ class GraphLayout {
    * Disables or enables the edge style of the given edge.
    */
   setEdgeStyleEnabled(edge: Cell, value: any): void {
-    this.graph.setCellStyles('noEdgeStyle', value ? '0' : '1', [edge]);
+    this.graph.setCellStyles('noEdgeStyle', !value, [edge]);
   }
 
   /**
    * Disables or enables orthogonal end segments of the given edge.
    */
   setOrthogonalEdge(edge: Cell, value: any): void {
-    this.graph.setCellStyles('orthogonal', value ? '1' : '0', [edge]);
+    this.graph.setCellStyles('orthogonal', !!value, [edge]);
   }
 
   /**

--- a/packages/core/src/view/mixin/CellsMixin.type.ts
+++ b/packages/core/src/view/mixin/CellsMixin.type.ts
@@ -206,9 +206,9 @@ declare module '../AbstractGraph' {
      * @param value String representing the new value for the key.
      * @param cells Optional array of {@link Cell} to change the style for. Default is the selection cells.
      */
-    setCellStyles: (
-      key: keyof CellStateStyle,
-      value: CellStateStyle[keyof CellStateStyle],
+    setCellStyles: <K extends keyof CellStateStyle>(
+      key: K,
+      value: CellStateStyle[K] | null,
       cells?: Cell[]
     ) => void;
 

--- a/packages/core/src/view/mixin/ConnectionsMixin.ts
+++ b/packages/core/src/view/mixin/ConnectionsMixin.ts
@@ -201,7 +201,9 @@ export const ConnectionsMixin: PartialType = {
 
           // Only writes 0 since 1 is default
           if (!constraint.perimeter) {
-            this.setCellStyles(source ? 'exitPerimeter' : 'entryPerimeter', '0', [edge]);
+            this.setCellStyles(source ? 'exitPerimeter' : 'entryPerimeter', false, [
+              edge,
+            ]);
           } else {
             this.setCellStyles(source ? 'exitPerimeter' : 'entryPerimeter', null, [edge]);
           }


### PR DESCRIPTION
**This is a WIP**


**description for enforce type-safe value in setCellStyles**
Previously, any value type could be passed for any style key without compile-time error, allowing bugs like passing a string for a boolean property.
Using a generic constraint ensures the value type matches the key's declared type in CellStateStyle, catching mismatches at compile
time.


### Tasks

Increase the scope of this PR:
- [ ] add tests to the code which is going to be updated
- [ ] improve the explanation in https://github.com/maxGraph/maxGraph/pull/1026/changes#r2986999100. Add direct link to the source code, link to commit are unpracticable as there are too many files involved and this is hard to display in the GH web UI
- [x]  (see #1160) Fix the default value to true in https://github.com/maxGraph/maxGraph/blob/24357a7eb79a67b91a0d1c815a8e45c615188499/packages/core/src/view/mixin/ConnectionsMixin.ts#L170-L175
- [ ] refactor the code of https://github.com/maxGraph/maxGraph/blob/24357a7eb79a67b91a0d1c815a8e45c615188499/packages/core/src/view/mixin/ConnectionsMixin.ts#L202-L206 to have a single call to this.setCellStyles

Other tasks
- [ ] improve  the PR description. Not really a breaking change as wrong values leads to bug
>  This is a breaking change for any consumer calling setCellStyles with a value that does not match the type of the specified key. These calls were already semantically incorrect — the stricter type now surfaces the error at compile time.

### Notes

Covers #840
Should be merged after #1026