### PR TITLE
docs: fix orthogonal projection description and add cross-links

### DIFF
--- a/packages/website/docs/usage/edge-styles.md
+++ b/packages/website/docs/usage/edge-styles.md
@@ -92,6 +92,10 @@ EdgeStyleRegistry.add('myEdgeStyle', MyStyle, edgeStyleMetadata);
 :::warning
 When registering the `EdgeStyle`, be sure to register it in the `EdgeStyleRegistry` with correct `EdgeStyleMetaData`.
 Some maxGraph features depend on the `EdgeStyleMetaData` to work correctly.
+
+In particular, the `isOrthogonal` property controls how the terminal points of edges are computed on the vertex perimeter.
+When set to `true`, the perimeter point is computed using an orthogonal projection instead of a segment intersection.
+For more details, see the [Orthogonal Projection on the Perimeter](perimeters.md#orthogonal-projection-on-the-perimeter) documentation.
 :::
 
 ### Using a Custom EdgeStyle

--- a/packages/website/docs/usage/perimeters.md
+++ b/packages/website/docs/usage/perimeters.md
@@ -86,8 +86,11 @@ By default, this is also applied when `style.orthogonal` is not explicitly set, 
 | ![perimeter computation context](assets/perimeters/perimeter-point-computation-01-context.png) | ![perimeter computation based on orthogonal projection](assets/perimeters/perimeter-point-computation-03-orthogonal_projection.png) |
 
 
-The list of `EdgeStyle` configurations considered orthogonal is defined in `Graph.isOrthogonal`.  
-This includes, for example, `SegmentConnector` and `EntityRelation`.
+An `EdgeStyle` is considered orthogonal when its `isOrthogonal` metadata property is set to `true` in the `EdgeStyleRegistry`.
+
+This is the case, for example, for `SegmentConnector` and `EntityRelation`.
+
+For more details about `EdgeStyle` metadata, see the [EdgeStyles](edge-styles.md#creating-a-custom-edgestyle) documentation.
 
 :::note  
 An example of orthogonal projection is available in the Storybook demo:


### PR DESCRIPTION
In perimeters.md, replace the reference to the internal `Graph.isOrthogonal` method with a user-facing explanation: orthogonal behavior is determined by the `isOrthogonal` metadata property of the EdgeStyle in the EdgeStyleRegistry.

In edge-styles.md, replace the placeholder in the EdgeStyleMetaData warning with details about the impact of
`isOrthogonal` on perimeter point computation.

Add cross-links between both pages on this topic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how edge terminal points are computed on vertex perimeters.
  * Explained how edge styling properties control orthogonal projection behavior.
  * Added cross-references between related documentation sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->