### PR TITLE
docs: fix wording in the perimeters documentation

### DIFF
--- a/packages/website/docs/usage/edge-styles.md
+++ b/packages/website/docs/usage/edge-styles.md
@@ -25,7 +25,7 @@ To check the list of registered EdgeStyles, refer to the `registerDefaultStyleEl
 :::info
 The `EdgeStyleRegistry` is a new registry introduced in version 0.20.0 to manage edge styles.
 
-Edge styles were previously managed by the `StyleRegistry`, which has then been removed.
+Edge styles were previously managed by the `StyleRegistry`, which has since been removed.
 :::
 
 ## How to Use a Specific EdgeStyle

--- a/packages/website/docs/usage/perimeters.md
+++ b/packages/website/docs/usage/perimeters.md
@@ -27,7 +27,7 @@ To check the list of registered perimeters, refer to the `registerDefaultStyleEl
 :::info
 The `PerimeterRegistry` is a new registry introduced in version 0.20.0 to manage perimeters.
 
-Perimeters were previously managed by the `StyleRegistry`, which has then been removed.
+Perimeters were previously managed by the `StyleRegistry`, which has since been removed.
 :::
 
 

--- a/packages/website/docs/usage/perimeters.md
+++ b/packages/website/docs/usage/perimeters.md
@@ -25,7 +25,7 @@ To check the list of registered perimeters, refer to the `registerDefaultStyleEl
 :::
 
 :::info
-The `PerimeterRegistry` is a new registry introduced in version 0.20.0 to manage edge styles.
+The `PerimeterRegistry` is a new registry introduced in version 0.20.0 to manage perimeters.
 
 Edge styles were previously managed by the `StyleRegistry`, which has then been removed.
 :::

--- a/packages/website/docs/usage/perimeters.md
+++ b/packages/website/docs/usage/perimeters.md
@@ -27,7 +27,7 @@ To check the list of registered perimeters, refer to the `registerDefaultStyleEl
 :::info
 The `PerimeterRegistry` is a new registry introduced in version 0.20.0 to manage perimeters.
 
-Edge styles were previously managed by the `StyleRegistry`, which has then been removed.
+Perimeters were previously managed by the `StyleRegistry`, which has then been removed.
 :::
 
 

--- a/packages/website/docs/usage/perimeters.md
+++ b/packages/website/docs/usage/perimeters.md
@@ -151,7 +151,7 @@ const CustomPerimeter: PerimeterFunction = (
 }
 ```
 
-The new perimeter can then be registered in the `PerimeterRegistry` as follows if you are intended to use it as a string in `CellStateStyle.perimeter`:
+The new perimeter can then be registered in the `PerimeterRegistry` as follows if you intend to use it as a string in `CellStateStyle.perimeter`:
 ```javascript
 PerimeterRegistry.add('customPerimeter', CustomPerimeter);
 ```


### PR DESCRIPTION
Also update the "edge styles" page for consistency.


### Notes

_This PR applies 2/2 suggestions from code quality [AI findings](https://github.com/maxGraph/maxGraph/security/quality/ai-findings)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized terminology: replaced references to "edge styles" with "perimeters" for consistency.
  * Clarified wording in informational callouts and conditional instructions (e.g., updated phrasing about prior removal and registration intent).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->