### PR TITLE
feat!: use registry metadata for edge handle visibility

### DIFF
--- a/.claude/rules/git/commit-conventions.md
+++ b/.claude/rules/git/commit-conventions.md
@@ -18,7 +18,7 @@ docs, deps-dev, deps-gha, typescript, or component names (graph, layout, seriali
 
 ## Body
 
-- Wrap at 120 characters
+- Wrap at 72 characters
 - Explain "why" not "what"
 - Use bullet points for multiple items
 

--- a/.claude/rules/git/commit-conventions.md
+++ b/.claude/rules/git/commit-conventions.md
@@ -18,7 +18,7 @@ docs, deps-dev, deps-gha, typescript, or component names (graph, layout, seriali
 
 ## Body
 
-- Wrap at 72 characters
+- Wrap at 120 characters
 - Explain "why" not "what"
 - Use bullet points for multiple items
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,24 @@ For more details on the contents of a release, see [the GitHub release page] (ht
 
 _**Note:** Yet to be released breaking changes appear here._
 
+**Breaking Changes**:
+- `EdgeHandler.isHandleVisible()` now uses `EdgeStyleRegistry.allowsIntermediateHandles()` instead of checking against the `EdgeStyle.EntityRelation` function reference.
+  If you register custom edge styles that should hide intermediate bend handles, you must now set `allowIntermediateHandles: false` in the `EdgeStyleMetaData` when calling `EdgeStyleRegistry.add()`.
+  In particular, if you register `EdgeStyle.EntityRelation` yourself (e.g. when using `BaseGraph`), you must include `{ allowIntermediateHandles: false }` in the metadata to preserve the previous behavior.
+- `EdgeStyleRegistryInterface` has a new `allowsIntermediateHandles` method. If you implement this interface directly, you must add this method.
+
 ## 0.23.0
 
 Release date: `2026-03-30`
 
 For more details, see the [0.23.0 Changelog](https://github.com/maxGraph/maxGraph/releases/tag/v0.23.0) on the GitHub release page.
 
+This new version improves modularity, fixes important memory leaks, and adds utilities for better configuration management.
+
 **Breaking Changes**:
 - The `getTooltip` and `getTooltipForCell` methods have been moved from `AbstractGraph` to the `TooltipHandler` plugin.
   If you were overriding these methods in a `AbstractGraph` subclass, you should now extend `TooltipHandler` instead.
 - `xmlUtils.getViewXml` moved to `xmlViewUtils.getViewXml`. The impact should be limited as this function was not widely used (only in the Editor class in the maxGraph code).
-
-This new version improves modularity, fixes important memory leaks, and adds utilities for better configuration management.
 
 ## 0.22.0
 

--- a/packages/core/__tests__/view/handler/EdgeHandler.test.ts
+++ b/packages/core/__tests__/view/handler/EdgeHandler.test.ts
@@ -1,0 +1,126 @@
+/*
+Copyright 2026-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { afterEach, beforeAll, describe, expect, test } from '@jest/globals';
+import {
+  BaseGraph,
+  Cell,
+  CellState,
+  type CellStateStyle,
+  EdgeHandler,
+  EdgeStyle,
+  type EdgeStyleFunction,
+  EdgeStyleRegistry,
+  Geometry,
+  Point,
+  Rectangle,
+  RectangleShape,
+  registerDefaultEdgeStyles,
+  unregisterAllEdgeStyles,
+} from '../../../src';
+
+const createEdgeHandlerForStyle = (
+  edgeStyle: EdgeStyleFunction | undefined,
+  pointCount: number,
+  { skipDefaultRegistration = false } = {}
+): EdgeHandler => {
+  const graph = new BaseGraph();
+  if (!skipDefaultRegistration) {
+    registerDefaultEdgeStyles();
+  }
+
+  const cell = new Cell();
+  cell.setEdge(true);
+  cell.setVertex(false);
+  cell.setGeometry(new Geometry());
+
+  const style: CellStateStyle = edgeStyle ? { edgeStyle } : {};
+  const cellState = new CellState(graph.view, cell, style);
+  cellState.absolutePoints = Array.from(
+    { length: pointCount },
+    (_, i) => new Point(i * 10, 0)
+  );
+  cellState.shape = new RectangleShape(new Rectangle(), 'green', 'blue');
+
+  return new EdgeHandler(cellState);
+};
+
+const createEdgeHandlerWithoutGeometry = (): EdgeHandler => {
+  const graph = new BaseGraph();
+  const cell = new Cell();
+  cell.setEdge(true);
+  cell.setVertex(false);
+  // no geometry set
+
+  const cellState = new CellState(graph.view, cell, {
+    edgeStyle: EdgeStyle.EntityRelation,
+  });
+  cellState.absolutePoints = [new Point(0, 0), new Point(10, 0)];
+  cellState.shape = new RectangleShape(new Rectangle(), 'green', 'blue');
+
+  return new EdgeHandler(cellState);
+};
+
+describe('isHandleVisible', () => {
+  beforeAll(() => {
+    unregisterAllEdgeStyles();
+  });
+  afterEach(() => {
+    unregisterAllEdgeStyles();
+  });
+
+  describe('EntityRelation edge style', () => {
+    test('first handle is visible', () => {
+      const handler = createEdgeHandlerForStyle(EdgeStyle.EntityRelation, 5);
+      expect(handler.isHandleVisible(0)).toBe(true);
+    });
+
+    test('last handle is visible', () => {
+      const handler = createEdgeHandlerForStyle(EdgeStyle.EntityRelation, 5);
+      expect(handler.isHandleVisible(4)).toBe(true);
+    });
+
+    test('intermediate handle is not visible', () => {
+      const handler = createEdgeHandlerForStyle(EdgeStyle.EntityRelation, 5);
+      expect(handler.isHandleVisible(2)).toBe(false);
+    });
+  });
+
+  test('other edge style - intermediate handle is visible', () => {
+    const handler = createEdgeHandlerForStyle(EdgeStyle.OrthConnector, 5);
+    expect(handler.isHandleVisible(2)).toBe(true);
+  });
+
+  test('no geometry - all handles are visible', () => {
+    const handler = createEdgeHandlerWithoutGeometry();
+    expect(handler.isHandleVisible(0)).toBe(true);
+    expect(handler.isHandleVisible(1)).toBe(true);
+  });
+
+  test('no edge style - intermediate handle is visible', () => {
+    const handler = createEdgeHandlerForStyle(undefined, 5);
+    expect(handler.isHandleVisible(2)).toBe(true);
+  });
+
+  test('EntityRelation registered without allowIntermediateHandles metadata - intermediate handle is visible', () => {
+    EdgeStyleRegistry.add('entityRelationEdgeStyle', EdgeStyle.EntityRelation, {});
+
+    const handler = createEdgeHandlerForStyle(EdgeStyle.EntityRelation, 5, {
+      skipDefaultRegistration: true,
+    });
+    expect(handler.isHandleVisible(2)).toBe(true);
+  });
+});

--- a/packages/core/__tests__/view/style/EdgeStyleRegistry.test.ts
+++ b/packages/core/__tests__/view/style/EdgeStyleRegistry.test.ts
@@ -40,17 +40,20 @@ describe('registry', () => {
     EdgeStyleRegistry.add('custom', customEdgeStyle, {
       isOrthogonal: true,
       handlerKind: 'customHandler',
+      allowIntermediateHandles: false,
     });
 
     expect(EdgeStyleRegistry.get('custom')).toBe(customEdgeStyle);
     expect(EdgeStyleRegistry.getHandlerKind(customEdgeStyle)).toEqual('customHandler');
     expect(EdgeStyleRegistry.isOrthogonal(customEdgeStyle)).toBeTruthy();
+    expect(EdgeStyleRegistry.allowsIntermediateHandles(customEdgeStyle)).toBeFalsy();
   });
 
   test.each([null, undefined])('retrieve with nullish: %s', (value) => {
     expect(EdgeStyleRegistry.get(value)).toBeNull();
     expect(EdgeStyleRegistry.getHandlerKind(value)).toEqual('default');
     expect(EdgeStyleRegistry.isOrthogonal(value)).toBeFalsy();
+    expect(EdgeStyleRegistry.allowsIntermediateHandles(value)).toBeTruthy();
   });
 
   test('verify registration - no meta data', () => {
@@ -59,12 +62,14 @@ describe('registry', () => {
     expect(EdgeStyleRegistry.get('custom')).toBe(customEdgeStyle);
     expect(EdgeStyleRegistry.getHandlerKind(customEdgeStyle)).toEqual('default');
     expect(EdgeStyleRegistry.isOrthogonal(customEdgeStyle)).toBeFalsy();
+    expect(EdgeStyleRegistry.allowsIntermediateHandles(customEdgeStyle)).toBeTruthy();
   });
 
   test('clear', () => {
     EdgeStyleRegistry.add('custom', customEdgeStyle, {
       isOrthogonal: false,
       handlerKind: 'customHandler',
+      allowIntermediateHandles: false,
     });
     expect(EdgeStyleRegistry.get('custom')).toBeDefined();
 
@@ -74,6 +79,7 @@ describe('registry', () => {
     // the edge style function is no longer registered, so returns default values
     expect(EdgeStyleRegistry.getHandlerKind(customEdgeStyle)).toEqual('default');
     expect(EdgeStyleRegistry.isOrthogonal(customEdgeStyle)).toBeFalsy();
+    expect(EdgeStyleRegistry.allowsIntermediateHandles(customEdgeStyle)).toBeTruthy();
   });
 
   describe('getName', () => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1569,6 +1569,14 @@ export type EdgeStyleMetaData = {
    * Defines if the edge style is considered as orthogonal or not.
    * @default false */
   isOrthogonal?: boolean;
+  /**
+   * Defines if intermediate bend handles are visible when this edge style is used.
+   *
+   * When set to `false`, only the first and last handles are visible. This is useful for edge styles that do not support intermediate control points.
+   * @default true
+   * @since 0.24.0
+   */
+  allowIntermediateHandles?: boolean;
 };
 
 /**
@@ -1594,6 +1602,14 @@ export interface EdgeStyleRegistryInterface extends Registry<EdgeStyleFunction> 
    * If the `edgeStyle` is not registered or the `handlerKind` was not set during registration, this method returns  `'default'`.
    */
   getHandlerKind(edgeStyle?: EdgeStyleFunction | null): EdgeStyleHandlerKind;
+
+  /**
+   * Retrieves whether the specified `edgeStyle` allows intermediate bend handles.
+   *
+   * If the `edgeStyle` is not registered or the `allowIntermediateHandles` was not set during registration, this method returns `true`.
+   * @since 0.24.0
+   */
+  allowsIntermediateHandles(edgeStyle?: EdgeStyleFunction | null): boolean;
 }
 
 /**

--- a/packages/core/src/view/handler/EdgeHandler.ts
+++ b/packages/core/src/view/handler/EdgeHandler.ts
@@ -43,7 +43,7 @@ import InternalEvent from '../event/InternalEvent.js';
 import ConstraintHandler from './ConstraintHandler.js';
 import Rectangle from '../geometry/Rectangle.js';
 import Client from '../../Client.js';
-import { EdgeStyle } from '../style/builtin-style-elements.js';
+import { EdgeStyleRegistry } from '../style/edge/EdgeStyleRegistry.js';
 import {
   getClientX,
   getClientY,
@@ -610,7 +610,7 @@ class EdgeHandler implements MouseListenerSet {
       : null;
 
     return (
-      edgeStyle !== EdgeStyle.EntityRelation ||
+      EdgeStyleRegistry.allowsIntermediateHandles(edgeStyle) ||
       index === 0 ||
       index === this.abspoints.length - 1
     );

--- a/packages/core/src/view/style/edge/EdgeStyleRegistry.ts
+++ b/packages/core/src/view/style/edge/EdgeStyleRegistry.ts
@@ -32,6 +32,7 @@ class EdgeStyleRegistryImpl
 {
   private readonly handlerMapping = new Map<EdgeStyleFunction, EdgeStyleHandlerKind>();
   private readonly orthogonalStates = new Map<EdgeStyleFunction, boolean>();
+  private readonly intermediateHandlesStates = new Map<EdgeStyleFunction, boolean>();
 
   override add(
     name: string,
@@ -42,6 +43,8 @@ class EdgeStyleRegistryImpl
     metaData?.handlerKind && this.handlerMapping.set(edgeStyle, metaData.handlerKind);
     !isNullish(metaData?.isOrthogonal) &&
       this.orthogonalStates.set(edgeStyle, metaData.isOrthogonal);
+    !isNullish(metaData?.allowIntermediateHandles) &&
+      this.intermediateHandlesStates.set(edgeStyle, metaData.allowIntermediateHandles);
   }
 
   isOrthogonal(edgeStyle?: EdgeStyleFunction | null): boolean {
@@ -52,10 +55,15 @@ class EdgeStyleRegistryImpl
     return this.handlerMapping.get(edgeStyle!) ?? 'default';
   }
 
+  allowsIntermediateHandles(edgeStyle?: EdgeStyleFunction | null): boolean {
+    return this.intermediateHandlesStates.get(edgeStyle!) ?? true;
+  }
+
   override clear(): void {
     super.clear();
     this.handlerMapping.clear();
     this.orthogonalStates.clear();
+    this.intermediateHandlesStates.clear();
   }
 }
 

--- a/packages/core/src/view/style/edge/EntityRelation.ts
+++ b/packages/core/src/view/style/edge/EntityRelation.ts
@@ -37,7 +37,8 @@ import { EntityRelationConnectorConfig } from '../config.js';
  *
  * This EdgeStyle is registered under `entityRelationEdgeStyle` in {@link EdgeStyleRegistry} when using {@link Graph} or calling {@link registerDefaultEdgeStyles}.
  *
- * **IMPORTANT**: When registering it manually  in {@link EdgeStyleRegistry}, the following metadata must be used:
+ * **IMPORTANT**: When registering it manually in {@link EdgeStyleRegistry}, the following metadata must be used:
+ * - allowIntermediateHandles: false
  * - handlerKind: 'default' or unset
  * - isOrthogonal: true
  *

--- a/packages/core/src/view/style/register.ts
+++ b/packages/core/src/view/style/register.ts
@@ -42,7 +42,11 @@ export const registerDefaultEdgeStyles = (): void => {
     const edgeStylesToRegister: [EdgeStyleValue, EdgeStyleFunction, EdgeStyleMetaData][] =
       [
         ['elbowEdgeStyle', EdgeStyle.ElbowConnector, { handlerKind: 'elbow' }],
-        ['entityRelationEdgeStyle', EdgeStyle.EntityRelation, {}],
+        [
+          'entityRelationEdgeStyle',
+          EdgeStyle.EntityRelation,
+          { allowIntermediateHandles: false },
+        ],
         ['loopEdgeStyle', EdgeStyle.Loop, { handlerKind: 'elbow', isOrthogonal: false }],
         ['manhattanEdgeStyle', EdgeStyle.ManhattanConnector, { handlerKind: 'segment' }],
         ['orthogonalEdgeStyle', EdgeStyle.OrthConnector, { handlerKind: 'segment' }],
@@ -53,7 +57,7 @@ export const registerDefaultEdgeStyles = (): void => {
     for (const [name, edgeStyle, metadata] of edgeStylesToRegister) {
       EdgeStyleRegistry.add(name, edgeStyle, {
         ...metadata,
-        // most edge styles registered here are orthogonal, so set to true by default to avoid to duplicate the configuration code
+        // most edge styles registered here are orthogonal, so set to true by default to avoid duplicating the configuration code
         isOrthogonal: metadata.isOrthogonal ?? true,
       });
     }

--- a/packages/ts-example-selected-features/vite.config.js
+++ b/packages/ts-example-selected-features/vite.config.js
@@ -27,7 +27,7 @@ export default defineConfig(({ mode }) => {
           },
         },
       },
-      chunkSizeWarningLimit: 368, // @maxgraph/core
+      chunkSizeWarningLimit: 367, // @maxgraph/core
     },
   };
 });

--- a/packages/ts-example-without-defaults/vite.config.js
+++ b/packages/ts-example-without-defaults/vite.config.js
@@ -27,7 +27,7 @@ export default defineConfig(({ mode }) => {
           },
         },
       },
-      chunkSizeWarningLimit: 307, // @maxgraph/core
+      chunkSizeWarningLimit: 305, // @maxgraph/core
     },
   };
 });

--- a/packages/website/docs/usage/edge-styles.md
+++ b/packages/website/docs/usage/edge-styles.md
@@ -93,9 +93,12 @@ EdgeStyleRegistry.add('myEdgeStyle', MyStyle, edgeStyleMetadata);
 When registering the `EdgeStyle`, be sure to register it in the `EdgeStyleRegistry` with correct `EdgeStyleMetaData`.
 Some maxGraph features depend on the `EdgeStyleMetaData` to work correctly.
 
-In particular, the `isOrthogonal` property controls how the terminal points of edges are computed on the vertex perimeter.
+In particular:
+- The `isOrthogonal` property controls how the terminal points of edges are computed on the vertex perimeter.
 When set to `true`, the perimeter point is computed using an orthogonal projection instead of a segment intersection.
 For more details, see the [Orthogonal Projection on the Perimeter](perimeters.md#orthogonal-projection-on-the-perimeter) documentation.
+- The `allowIntermediateHandles` property (available since 0.24.0) controls whether intermediate bend handles are visible when editing the edge. When set to `false`, only the first and last handles are shown. This is useful for edge styles like `EntityRelation` that do not support intermediate control points. Defaults to `true`.
+If you register `EdgeStyle.EntityRelation` yourself (e.g. when using `BaseGraph`), you must include `allowIntermediateHandles: false` in the metadata to preserve the expected behavior.
 :::
 
 ### Using a Custom EdgeStyle


### PR DESCRIPTION

## Overview

The hard-coded reference to EdgeStyle.EntityRelation in EdgeHandler.isHandleVisible()
created a direct dependency on the EntityRelation function, preventing tree-shaking
when EntityRelation is not used in the application. It also meant only EntityRelation
could influence handle visibility — no other edge style (including custom ones) could
control whether intermediate bend handles are shown.

Replace this with an allowIntermediateHandles metadata property on EdgeStyleRegistry,
following the existing pattern of isOrthogonal and handlerKind.

Benefits:
- Generic: any edge style can now control intermediate handle visibility via metadata
- Configurable and extensible: custom edge styles can set allowIntermediateHandles: false
- Tree-shakeable: EdgeHandler no longer imports EdgeStyle directly

BREAKING CHANGE:
- EdgeStyleRegistryInterface has a new allowsIntermediateHandles() method
- Custom registrations of EntityRelation (e.g. when using BaseGraph) must now include
  { allowIntermediateHandles: false } in the metadata to preserve the previous behavior

## Notes

Closes #978

I did a search to check if EdgeStyle is referenced elsewhere in the code.
With the exception of the function that stores the default value “EdgeStyle” and the loop described in section #758, there are no other references.

### Impact on the bundle size

When `EntityRelation` is not used by the application, the decrease is **~2kB**.

| Example | 9f8381b9 | now |
| --- | --- | --- |
| js-example | 467.65 kB | 467.94 kB |
| js-example-selected-features | 388.78 kB | 386.69 kB |
| js-example-without-defaults | 323.37 kB | 321.28 kB |
| ts-example | 433.53 kB | 433.85 kB |
| ts-example-selected-features | 367.64 kB | 366.59 kB |
| ts-example-without-defaults | 306.64 kB | 304.04 kB |

Note that the size increases in _js-example_ and _ts-example_ because EntityRelation is registered (in the list of default EdgeStyles loaded in this case), so the change made in this PR has no effect; this PR actually includes new code designed to manage the visibility of identifiers. It is this new code that is causing the increase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Edge handle visibility now follows registry-based configuration instead of prior hardcoded logic.

* **New Features**
  * Added a metadata option to control intermediate bend-handle visibility when registering edge styles.
  * Entity-relation edge styles now hide intermediate bend handles by default.

* **Documentation**
  * Updated docs to explain the new handle-visibility option and migration guidance.

* **Tests**
  * Added tests covering handle-visibility scenarios and registry behavior.

* **Chores**
  * Updated commit message body wrapping guidance to 120 characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->