### PR TITLE
docs: add AGENTS.md and align agent configs with current code

### DIFF
--- a/.claude/rules/architecture/coding-practices.md
+++ b/.claude/rules/architecture/coding-practices.md
@@ -40,6 +40,16 @@ Use `translate()` and `isI18nEnabled()` from `internal/i18n-utils.js`. NEVER acc
 - Use **singular** form: `handler/` not `handlers/`
 - Use **kebab-case**: `my-feature/` not `myFeature/`
 
+## Plugin ID Naming
+
+Applies to new plugins in `packages/core/src/view/plugin/` and the `BuiltinPluginId` union in `types.ts`.
+
+- Use **kebab-case** for multi-word ids: `'image-bundle'`, not `'imageBundle'` or `'ImageBundlePlugin'`.
+- Single-word ids stay lowercase: `'fit'`.
+- Do NOT suffix with `Plugin` or `Handler` — the id is not the class name. Class names use `PascalCase` and end in `Plugin`: `ImageBundlePlugin`, `FitPlugin`.
+- Prefer precise scope over generic names: `'image-bundle'` is better than `'image'` when the plugin only deals with image bundles, because it reserves the broader namespace for future plugins.
+- Legacy handler plugins (`'ConnectionHandler'`, `'PanningHandler'`, etc., defined in `BuiltinPluginId`) predate this convention and are kept for backwards compatibility; do NOT use them as a template.
+
 ## Key Lint Rules
 
 - `no-console: error` — use `log()` utility instead

--- a/.claude/rules/testing/conventions.md
+++ b/.claude/rules/testing/conventions.md
@@ -5,7 +5,7 @@ paths:
 ---
 # Testing Conventions
 
-- Tests use Jest with jsdom environment (configured in `jest.config.cjs`)
+- Tests use Jest with jsdom environment (configured in `packages/core/jest.config.cjs`)
 - Tests are in `packages/core/__tests__/` mirroring `src/` structure
 - Uses `@swc/jest` for fast TypeScript compilation
 - Import paths in tests: omit `.js` extension (handled by moduleNameMapper)

--- a/.claude/rules/testing/conventions.md
+++ b/.claude/rules/testing/conventions.md
@@ -24,4 +24,4 @@ test.each([
 ## Troubleshooting
 
 - Build core package first: `npm run build -w packages/core`
-- Module resolution issues: check `moduleNameMapper` in `jest.config.cjs`
+- Module resolution issues: check `moduleNameMapper` in `packages/core/jest.config.cjs`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,68 @@
+# AGENTS.md
+
+## maxGraph AI Agent Guide
+
+This document provides essential knowledge for AI coding agents to be productive in the maxGraph codebase. It summarizes architecture, workflows, and project-specific conventions. For deeper details, see `CLAUDE.md`, `README.md`, and referenced files.
+
+---
+
+### 1. Architecture Overview
+- **Core Library**: TypeScript, modular, tree-shakable. Main logic in `packages/core/src/`.
+- **Graph Hierarchy**: Three main classes:
+  - `AbstractGraph`: Abstract base, mixin-based, no built-ins.
+  - `BaseGraph`: Minimal, production-optimized, explicit config (recommended for production).
+  - `Graph`: Full-featured, all defaults/plugins registered (for prototyping).
+- **Key Patterns**:
+  - **Mixins**: `packages/core/src/view/mixin/` (`.ts` + `.type.ts` per mixin)
+  - **Plugins**: `packages/core/src/view/plugin/`, loaded by `Graph` via `getDefaultPlugins()`. New plugins follow the `*Plugin.ts` naming; some legacy files still use `*Handler.ts` and will be renamed later.
+  - **Registries**: Edge styles, markers, perimeters in `packages/core/src/view/style/`; shape registry in `packages/core/src/view/shape/`
+  - **Serialization**: XML (mxGraph-compatible) in `packages/core/src/serialization/`
+  - **Batch Updates**: Always wrap multiple model changes in `batchUpdate()`
+
+### 2. Developer Workflows
+- **Node.js**: Always use version in `.nvmrc` (`nvm use`)
+- **Install**: `npm install` (uses npm workspaces)
+- **Build Core**: `npm run build -w packages/core` (ESM + CJS)
+- **Watch Core**: `npm run dev -w packages/core`
+- **Run Storybook**: `npm run dev -w packages/html`
+- **Test**: `npm test -w packages/core` (coverage: add `-- --coverage`)
+- **Lint**: `npm run lint` (auto-fix: `npm run lint:fix`)
+- **CI Validation**: Run all before PR:
+  - `npm run build -w packages/core`
+  - `npm run test-check -w packages/core`
+  - `npm test -w packages/core -- --coverage`
+  - `npm test -w packages/ts-support`
+  - `./scripts/build-all-examples.bash`
+  - `npm run build -w packages/html`
+  - `npm run check:circular-dependencies -w packages/core`
+  - `npm run lint`
+  - `npm run check:npm-package -w packages/core`
+
+### 3. Project-Specific Conventions
+- **TypeScript**: Strict types, no implicit any. Use object references, not strings, for API calls.
+- **Mixins/Plugins**: Add new features via mixins or plugins, not by modifying core classes directly.
+- **Registries**: Register only required shapes/styles for tree-shaking (see `ts-example-selected-features`).
+- **Testing**: Use Jest. Test patterns in `.claude/rules/testing/conventions.md`.
+- **Commits/PRs**: Follow `.claude/rules/git/commit-conventions.md` for commit messages. PRs should run full CI.
+- **Documentation**: Update `README.md` and `CLAUDE.md` for major changes. Use concise, accurate docs.
+
+### 4. Examples & Integration
+- **Examples**: See `packages/ts-example*` and `packages/js-example*` for integration patterns:
+  - With/without defaults, feature selection, headless Node.js, XML import/export.
+- **Storybook**: `packages/html/stories/` for feature demos (JS/TS, migrating to TS).
+- **Website**: Built with Docusaurus (`packages/website`). External resources must be copied to `generated/` before build.
+
+### 5. References
+- **CellStyle interface**: `packages/core/src/types.ts`
+- **Graph vs BaseGraph**: `packages/ts-example-selected-features/`
+- **Build output**: `packages/core/lib/esm/`, `packages/core/lib/cjs/`
+- **Release process**: See `packages/website/docs/development/release.md`
+
+---
+
+**For more, see:**
+- `CLAUDE.md` (architecture, CI, conventions)
+- Project root `README.md` (features, commands, migration)
+- `packages/core/README.md` (core usage)
+- Example READMEs for integration patterns
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,9 +43,9 @@ Three-tier Graph class hierarchy:
 - **Graph** — full-featured with all defaults registered (good for prototyping, not production)
 
 Key patterns:
-- **Mixins** in `packages/core/src/view/mixins/` — each has `.ts` + `.type.ts` files
-- **Plugins** in `packages/core/src/view/plugins/` — loaded by `Graph` via `getDefaultPlugins()`
-- **Registries** for shapes, edge styles, perimeters in `packages/core/src/view/style/`
+- **Mixins** in `packages/core/src/view/mixin/` — each has `.ts` + `.type.ts` files
+- **Plugins** in `packages/core/src/view/plugin/` — loaded by `Graph` via `getDefaultPlugins()`. New plugins follow the `*Plugin.ts` naming; some legacy files still use `*Handler.ts` and will be renamed later
+- **Registries** for edge styles, markers, perimeters in `packages/core/src/view/style/`; shape registry in `packages/core/src/view/shape/`
 - **XML serialization** in `packages/core/src/serialization/` (mxGraph-compatible)
 - Always wrap multiple model changes in `batchUpdate()`
 


### PR DESCRIPTION
Introduce AGENTS.md as a quick-reference guide for AI coding agents, covering
architecture, workflows and conventions. Initial draft was generated by gh
copilot, then corrected to match the actual repository layout.

During the review, aligned CLAUDE.md and .claude/rules/testing/conventions.md
with the code as well, to keep agent-facing docs factually accurate:

- Fix plural path references: packages/core/src/view/mixin/ and
  packages/core/src/view/plugin/ (the actual directories are singular, not
  the plural form originally written).
- Document the plugin naming convention: new plugins follow the *Plugin.ts
  pattern; some legacy files still use *Handler.ts and will be renamed later.
- Split the registries description: shape registry lives in view/shape/, not
  view/style/. Registries under view/style/ cover edge styles, markers and
  perimeters only.
- Point the testing conventions to the real jest config location at
  packages/core/jest.config.cjs; there is no root-level jest.config.cjs.
  Also fix the same stale path in the troubleshooting section of that file.
- Drop the "(if present)" hedge in AGENTS.md's testing entry, since the
  referenced conventions file does exist.

Also codify a plugin id naming convention in the architecture coding-practices
rule so future plugin migrations follow a consistent pattern (no existing rule
covered pluginId casing):

- Kebab-case for multi-word ids (`image-bundle`), consistent with the existing
  kebab-case source folder rule.
- Single-word ids stay lowercase (`fit`).
- No `Plugin`/`Handler` suffix in the id string — class names carry the suffix,
  ids identify.
- Prefer precise scope (`image-bundle` over `image`) to reserve the broader
  namespace for future plugins.
- Legacy handler ids in `BuiltinPluginId` (`ConnectionHandler`, `PanningHandler`,
  ...) are grandfathered and must not be used as a template for new plugins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated testing configuration path references for clarity in testing conventions.
  * Added AGENTS guide documenting project structure, architecture patterns, and CI/workflow checks.
  * Clarified module directory organization and registry locations in architectural documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->