### PR TITLE
refactor: make ImageBundlePlugin.imageBundles private

### DIFF
--- a/packages/core/__tests__/view/plugin/ImageBundlePlugin.test.ts
+++ b/packages/core/__tests__/view/plugin/ImageBundlePlugin.test.ts
@@ -26,6 +26,11 @@ const createGraphWithPlugin = (): {
   return { graph, plugin };
 };
 
+// Test-only escape hatch to inspect the private `imageBundles` field. Kept here (not in src) so
+// the property stays hidden from production code, stories, and downstream consumers.
+const internals = (plugin: ImageBundlePlugin) =>
+  plugin as unknown as { imageBundles: ImageBundle[] };
+
 const bundleWith = (entries: Array<[string, string]>): ImageBundle => {
   const bundle = new ImageBundle();
   for (const [key, value] of entries) {
@@ -45,8 +50,8 @@ describe('ImageBundlePlugin', () => {
 
     plugin1.addImageBundle(bundleWith([['key', 'value']]));
 
-    expect(plugin2.imageBundles).toStrictEqual([]);
-    expect(plugin1.imageBundles).not.toBe(plugin2.imageBundles);
+    expect(internals(plugin2).imageBundles).toStrictEqual([]);
+    expect(internals(plugin1).imageBundles).not.toBe(internals(plugin2).imageBundles);
   });
 
   describe('addImageBundle', () => {
@@ -56,8 +61,8 @@ describe('ImageBundlePlugin', () => {
 
       plugin.addImageBundle(bundle);
 
-      expect(plugin.imageBundles).toHaveLength(1);
-      expect(plugin.imageBundles[0]).toBe(bundle);
+      expect(internals(plugin).imageBundles).toHaveLength(1);
+      expect(internals(plugin).imageBundles[0]).toBe(bundle);
     });
 
     test('preserves insertion order across multiple calls', () => {
@@ -68,7 +73,7 @@ describe('ImageBundlePlugin', () => {
       plugin.addImageBundle(first);
       plugin.addImageBundle(second);
 
-      expect(plugin.imageBundles).toEqual([first, second]);
+      expect(internals(plugin).imageBundles).toEqual([first, second]);
     });
   });
 
@@ -84,7 +89,7 @@ describe('ImageBundlePlugin', () => {
 
       plugin.removeImageBundle(target);
 
-      expect(plugin.imageBundles).toEqual([first, last]);
+      expect(internals(plugin).imageBundles).toEqual([first, last]);
     });
 
     test('removes all occurrences of the same bundle', () => {
@@ -96,8 +101,8 @@ describe('ImageBundlePlugin', () => {
 
       plugin.removeImageBundle(duplicated);
 
-      expect(plugin.imageBundles).toHaveLength(1);
-      expect(plugin.imageBundles).not.toContain(duplicated);
+      expect(internals(plugin).imageBundles).toHaveLength(1);
+      expect(internals(plugin).imageBundles).not.toContain(duplicated);
     });
 
     test('is a no-op when the bundle is not registered', () => {
@@ -107,7 +112,7 @@ describe('ImageBundlePlugin', () => {
 
       plugin.removeImageBundle(bundleWith([]));
 
-      expect(plugin.imageBundles).toEqual([registered]);
+      expect(internals(plugin).imageBundles).toEqual([registered]);
     });
   });
 
@@ -148,6 +153,6 @@ describe('ImageBundlePlugin', () => {
 
     plugin.onDestroy();
 
-    expect(plugin.imageBundles).toStrictEqual([]);
+    expect(internals(plugin).imageBundles).toStrictEqual([]);
   });
 });

--- a/packages/core/src/view/plugin/ImageBundlePlugin.ts
+++ b/packages/core/src/view/plugin/ImageBundlePlugin.ts
@@ -39,7 +39,7 @@ export class ImageBundlePlugin implements GraphPlugin {
    * The registered {@link ImageBundle} instances. Bundles are consulted in insertion order; the first match wins.
    * @default [] (empty array)
    */
-  imageBundles: ImageBundle[] = [];
+  private imageBundles: ImageBundle[] = [];
 
   /**
    * Constructs the plugin that manages image bundles.


### PR DESCRIPTION
The property is plugin-internal state; exposing it on the public API serves no caller use case and locks the implementation to today's array shape. Tests still need to inspect it, so they use a local `internals()` cast helper defined inside the test file — production code, stories, and downstream consumers cannot reach the property through the type system.

Not a breaking change: ImageBundlePlugin was introduced in c3e4de18a and has not been released.

### Notes

Generated with Claude Code (claude-opus-4-7).