### PR TITLE
chore: add compare-examples-size skill

### DIFF
--- a/.claude/skills/compare-examples-size/SKILL.md
+++ b/.claude/skills/compare-examples-size/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: compare-examples-size
+description: Compare maxGraph example bundle sizes between two git references (commit SHA, branch, or tag) and emit a markdown table with deltas in kB and %. Use when the user asks to compare bundle sizes, measure the size impact of a change or release, diff example sizes between branches/tags/commits, or invokes the /compare-examples-size slash command with two refs.
+---
+
+# Compare Examples Size
+
+## Overview
+
+Builds the maxGraph examples at two git references and produces a markdown table comparing per-example bundle sizes. Useful to assess the size impact of a PR, refactor, or release.
+
+## When to use
+
+Trigger this skill on requests like:
+- "compare bundle sizes between `main` and my branch"
+- "what's the size impact of this branch?"
+- "compare example sizes between `v1.2.0` and `main`"
+- `/compare-examples-size <from> <to>`
+
+## Inputs
+
+Two git references — `<from>` and `<to>`. Each can be:
+- a commit SHA (full or short)
+- a branch name (HEAD of the branch is used)
+- a tag name
+
+If the user only provides one ref, ask for the second. Do not assume `HEAD` silently. If the user provides none, ask for both.
+
+## Workflow
+
+Run the bundled script with the two refs:
+
+```bash
+.claude/skills/compare-examples-size/scripts/compare-examples-size.bash <from> <to>
+```
+
+The script:
+1. Verifies the working tree is strictly clean (`git status --porcelain` empty). Aborts with an error if not.
+2. Resolves both refs via `git rev-parse --verify`. Aborts on unknown refs.
+3. Normalizes the column order: the **older** commit (by committer timestamp) becomes column 1, the **newer** becomes column 2 — regardless of the order the user passed them on the CLI. A note is printed to stderr if a swap happened. Δ is therefore always `newer − older` (positive Δ = size grew over time).
+4. Saves the current branch (or SHA if detached) and installs a `trap` so the original ref is restored on any exit — including build failures or Ctrl-C.
+5. For each ref, in order older then newer:
+   - `git checkout <ref>`
+   - `npm ci` if `package-lock.json` differs from the previous ref (always runs on first ref to guarantee fresh deps). `npm ci` is used instead of `npm install` so the lock file is never rewritten — keeping the working tree clean across the checkout.
+   - `npm run build -w packages/core`
+   - `./scripts/build-all-examples.bash`, capturing its trailing CSV (header line + values line) into a temp file.
+6. Parses both CSVs, joins by example name, and prints a markdown table to stdout.
+7. Restores the original ref and removes the temp dir.
+
+Build logs go to stderr; only the final markdown table goes to stdout, so it can be redirected to a file or piped directly.
+
+## Output format
+
+GitHub-flavored markdown table on stdout:
+
+```
+| Example | <older-label> <older-short-sha> (kB) | <newer-label> <newer-short-sha> (kB) | Δ kB | Δ % |
+```
+
+- Column 1 is always the **older** commit, column 2 the **newer** — even if the user passed them in the reverse order on the CLI.
+- `<label>` is the branch or tag name the user supplied. If the user supplied a raw SHA, the label is omitted and only the short SHA appears.
+- `Δ kB` is signed (`+` or `-`) and equals `newer − older`.
+- `Δ %` is signed and uses the older size as the denominator.
+- Rows are sorted alphabetically by example name.
+- `N/A` is used when an example exists at one ref but not the other.
+
+No commentary on causes of variation — just the numbers.
+
+## Prerequisites and constraints
+
+- The script must run from inside the maxGraph repository (it uses `git rev-parse --show-toplevel`).
+- The active Node.js version should match `.nvmrc`. If `nvm` is available, the user should run `nvm use` before invoking the skill.
+- The working tree must be clean. Do **not** auto-stash. If the user has uncommitted work, surface the error and ask them how to proceed.
+- The script does two full `npm run build -w packages/core` + full examples build, so it takes several minutes. Warn the user before launching if this is the first run in a session.
+
+## Failure handling
+
+- **Dirty working tree**: report the offending files (`git status --short`) and stop.
+- **Unknown ref**: report which ref failed to resolve and stop.
+- **Build failure on a ref**: the `trap` restores the original ref before exiting. Report which ref failed and at which step (`npm ci`, core build, or examples build). Do not retry automatically.
+- **Original ref restoration fails on exit**: surface the warning printed by the script and tell the user to `git checkout <original-ref>` manually.
+- **Forced kill (SIGKILL) mid-run**: bash traps cannot run on SIGKILL, so the user can be left in detached HEAD. To detect this, the script writes a lock file at `.git/compare-examples-size.lock` containing the original ref before any checkout; the `trap` removes it on graceful exit. If the script aborts via SIGKILL, the lock survives. The next invocation will refuse to start and print the original ref to restore. After running `git checkout <that-ref>`, the user must remove the lock file as instructed.

--- a/.claude/skills/compare-examples-size/SKILL.md
+++ b/.claude/skills/compare-examples-size/SKILL.md
@@ -37,7 +37,7 @@ Run the bundled script with the two refs:
 The script:
 1. Verifies the working tree is strictly clean (`git status --porcelain` empty). Aborts with an error if not.
 2. Resolves both refs via `git rev-parse --verify`. Aborts on unknown refs.
-3. Normalizes the column order: the **older** commit (by committer timestamp) becomes column 1, the **newer** becomes column 2, regardless of the order the user passed them on the CLI. A note is printed to stderr if a swap happened. Δ is therefore always `newer − older` (positive Δ = size grew over time).
+3. Normalizes the column order: the commit with the **earlier** committer timestamp becomes column 1, the **later** one becomes column 2, regardless of the order the user passed them on the CLI. A note is printed to stderr if a swap happened. Δ is therefore always `column 2 − column 1`.
 4. Saves the current branch (or SHA if detached) and installs a `trap` so the original ref is restored on any exit, including build failures or Ctrl-C. An interrupted run exits with a non-zero status (130 on Ctrl-C, 143 on `SIGTERM`), so a caller can tell it apart from a successful comparison.
 5. For each ref, in order older then newer:
    - `git checkout <ref>`
@@ -57,14 +57,35 @@ GitHub-flavored markdown table on stdout:
 | Example | <older-label> <older-short-sha> (kB) | <newer-label> <newer-short-sha> (kB) | Δ kB | Δ % |
 ```
 
-- Column 1 is always the **older** commit, column 2 the **newer**, even if the user passed them in the reverse order on the CLI.
+- Column 1 is always the commit with the **earlier** timestamp, column 2 the **later** one, even if the user passed them in the reverse order on the CLI.
 - `<label>` is the branch or tag name the user supplied. If the user supplied a raw SHA, the label is omitted and only the short SHA appears.
-- `Δ kB` is signed (`+` or `-`) and equals `newer − older`.
-- `Δ %` is signed and uses the older size as the denominator.
+- `Δ kB` is signed (`+` or `-`) and equals `column 2 − column 1`.
+- `Δ %` is signed and uses the column 1 size as the denominator.
 - Rows are sorted alphabetically by example name.
 - `N/A` is used when an example exists at one ref but not the other.
 
 No commentary on causes of variation, just the numbers.
+
+### Reading the sign of Δ
+
+The sign is only chronological when one ref is an ancestor of the other. In that case a positive Δ does mean the
+bundle grew as the history advanced.
+
+When the two refs have **diverged** (neither is an ancestor of the other, which is the normal case for a feature
+branch that has fallen behind its base), the timestamp ordering carries no before/after meaning, and a positive Δ
+does **not** mean the size grew over time. A branch based on an old `main` will show a large positive Δ against a
+newer `main` purely because it lacks the size reductions `main` has since gained.
+
+Check the relationship before interpreting the sign:
+
+```bash
+git merge-base --is-ancestor <ref1> <ref2>   # exit 0 means ref1 is an ancestor of ref2
+```
+
+If the refs have diverged, report the Δ as the difference between the two states and say explicitly that it is not a
+chronological progression. Do not describe it as growth or as a regression introduced by either ref. When the intent
+was to measure a branch's own impact, the right comparison is the branch against its merge base
+(`git merge-base <branch> main`), or the branch rebased onto its base.
 
 ## Prerequisites and constraints
 

--- a/.claude/skills/compare-examples-size/SKILL.md
+++ b/.claude/skills/compare-examples-size/SKILL.md
@@ -19,7 +19,7 @@ Trigger this skill on requests like:
 
 ## Inputs
 
-Two git references — `<from>` and `<to>`. Each can be:
+Two git references, `<from>` and `<to>`. Each can be:
 - a commit SHA (full or short)
 - a branch name (HEAD of the branch is used)
 - a tag name
@@ -37,11 +37,11 @@ Run the bundled script with the two refs:
 The script:
 1. Verifies the working tree is strictly clean (`git status --porcelain` empty). Aborts with an error if not.
 2. Resolves both refs via `git rev-parse --verify`. Aborts on unknown refs.
-3. Normalizes the column order: the **older** commit (by committer timestamp) becomes column 1, the **newer** becomes column 2 — regardless of the order the user passed them on the CLI. A note is printed to stderr if a swap happened. Δ is therefore always `newer − older` (positive Δ = size grew over time).
-4. Saves the current branch (or SHA if detached) and installs a `trap` so the original ref is restored on any exit — including build failures or Ctrl-C.
+3. Normalizes the column order: the **older** commit (by committer timestamp) becomes column 1, the **newer** becomes column 2, regardless of the order the user passed them on the CLI. A note is printed to stderr if a swap happened. Δ is therefore always `newer − older` (positive Δ = size grew over time).
+4. Saves the current branch (or SHA if detached) and installs a `trap` so the original ref is restored on any exit, including build failures or Ctrl-C. An interrupted run exits with a non-zero status (130 on Ctrl-C, 143 on `SIGTERM`), so a caller can tell it apart from a successful comparison.
 5. For each ref, in order older then newer:
    - `git checkout <ref>`
-   - `npm ci` if `package-lock.json` differs from the previous ref (always runs on first ref to guarantee fresh deps). `npm ci` is used instead of `npm install` so the lock file is never rewritten — keeping the working tree clean across the checkout.
+   - `npm ci` if `package-lock.json` differs from the previous ref (always runs on first ref to guarantee fresh deps). `npm ci` is used instead of `npm install` so the lock file is never rewritten, keeping the working tree clean across the checkout.
    - `npm run build -w packages/core`
    - `./scripts/build-all-examples.bash`, capturing its trailing CSV (header line + values line) into a temp file.
 6. Parses both CSVs, joins by example name, and prints a markdown table to stdout.
@@ -57,14 +57,14 @@ GitHub-flavored markdown table on stdout:
 | Example | <older-label> <older-short-sha> (kB) | <newer-label> <newer-short-sha> (kB) | Δ kB | Δ % |
 ```
 
-- Column 1 is always the **older** commit, column 2 the **newer** — even if the user passed them in the reverse order on the CLI.
+- Column 1 is always the **older** commit, column 2 the **newer**, even if the user passed them in the reverse order on the CLI.
 - `<label>` is the branch or tag name the user supplied. If the user supplied a raw SHA, the label is omitted and only the short SHA appears.
 - `Δ kB` is signed (`+` or `-`) and equals `newer − older`.
 - `Δ %` is signed and uses the older size as the denominator.
 - Rows are sorted alphabetically by example name.
 - `N/A` is used when an example exists at one ref but not the other.
 
-No commentary on causes of variation — just the numbers.
+No commentary on causes of variation, just the numbers.
 
 ## Prerequisites and constraints
 
@@ -79,4 +79,4 @@ No commentary on causes of variation — just the numbers.
 - **Unknown ref**: report which ref failed to resolve and stop.
 - **Build failure on a ref**: the `trap` restores the original ref before exiting. Report which ref failed and at which step (`npm ci`, core build, or examples build). Do not retry automatically.
 - **Original ref restoration fails on exit**: surface the warning printed by the script and tell the user to `git checkout <original-ref>` manually.
-- **Forced kill (SIGKILL) mid-run**: bash traps cannot run on SIGKILL, so the user can be left in detached HEAD. To detect this, the script writes a lock file at `.git/compare-examples-size.lock` containing the original ref before any checkout; the `trap` removes it on graceful exit. If the script aborts via SIGKILL, the lock survives. The next invocation will refuse to start and print the original ref to restore. After running `git checkout <that-ref>`, the user must remove the lock file as instructed.
+- **Forced kill (SIGKILL) mid-run**: bash traps cannot run on SIGKILL, so the user can be left in detached HEAD. To detect this, the script writes a lock file named `compare-examples-size.lock` in the common git dir (`git rev-parse --git-common-dir`, usually `.git/`) containing the original ref before any checkout; the `trap` removes it on graceful exit. If the script aborts via SIGKILL, the lock survives. The next invocation will refuse to start and print the original ref to restore. After running `git checkout <that-ref>`, the user must remove the lock file as instructed.

--- a/.claude/skills/compare-examples-size/SKILL.md
+++ b/.claude/skills/compare-examples-size/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: compare-examples-size
-description: Compare maxGraph example bundle sizes between two git references (commit SHA, branch, or tag) and emit a markdown table with deltas in kB and %. Use when the user asks to compare bundle sizes, measure the size impact of a change or release, diff example sizes between branches/tags/commits, or invokes the /compare-examples-size slash command with two refs.
+description: Compare maxGraph example bundle sizes between two git references (commit SHA, branch, or tag) and emit a markdown table with deltas in kB and %. Also accepts already-measured sizes for one of the two refs (a table or CSV from an earlier run) and then builds only the other ref. Use when the user asks to compare bundle sizes, measure the size impact of a change or release, diff example sizes between branches/tags/commits, reuse sizes they already have for one side, or invokes the /compare-examples-size slash command with two refs.
 ---
 
 # Compare Examples Size
@@ -9,12 +9,16 @@ description: Compare maxGraph example bundle sizes between two git references (c
 
 Builds the maxGraph examples at two git references and produces a markdown table comparing per-example bundle sizes. Useful to assess the size impact of a PR, refactor, or release.
 
+Each build takes several minutes, so the script also accepts sizes that were already measured for one of the two refs. It then builds only the other ref, halving the runtime.
+
 ## When to use
 
 Trigger this skill on requests like:
 - "compare bundle sizes between `main` and my branch"
 - "what's the size impact of this branch?"
 - "compare example sizes between `v1.2.0` and `main`"
+- "here is the table from my last run on `main`, compare it with my branch"
+- "I already have the sizes for the release, just measure `main`"
 - `/compare-examples-size <from> <to>`
 
 ## Inputs
@@ -25,6 +29,8 @@ Two git references, `<from>` and `<to>`. Each can be:
 - a tag name
 
 If the user only provides one ref, ask for the second. Do not assume `HEAD` silently. If the user provides none, ask for both.
+
+Optionally, already-measured sizes for **one** of the two refs. See [Reusing sizes already measured](#reusing-sizes-already-measured). Both sides cannot be supplied at once: the script requires at least one ref to build, and refuses the combination.
 
 ## Workflow
 
@@ -38,16 +44,55 @@ The script:
 1. Verifies the working tree is strictly clean (`git status --porcelain` empty). Aborts with an error if not.
 2. Resolves both refs via `git rev-parse --verify`. Aborts on unknown refs.
 3. Normalizes the column order: the commit with the **earlier** committer timestamp becomes column 1, the **later** one becomes column 2, regardless of the order the user passed them on the CLI. A note is printed to stderr if a swap happened. Δ is therefore always `column 2 − column 1`.
-4. Saves the current branch (or SHA if detached) and installs a `trap` so the original ref is restored on any exit, including build failures or Ctrl-C. An interrupted run exits with a non-zero status (130 on Ctrl-C, 143 on `SIGTERM`), so a caller can tell it apart from a successful comparison.
-5. For each ref, in order older then newer:
+4. Classifies the relationship of the two refs (`identical`, `ancestor`, `descendant`, or `diverged`) with `git merge-base --is-ancestor`, and reports it on stderr right away, before the builds. This decides whether the sign of Δ means anything chronologically, so it is settled up front rather than left to the reader.
+5. Saves the current branch (or SHA if detached) and installs a `trap` so the original ref is restored on any exit, including build failures or Ctrl-C. An interrupted run exits with a non-zero status (130 on Ctrl-C, 143 on `SIGTERM`), so a caller can tell it apart from a successful comparison.
+6. For each ref whose sizes were **not** supplied, in column order:
    - `git checkout <ref>`
    - `npm ci` if `package-lock.json` differs from the previous ref (always runs on first ref to guarantee fresh deps). `npm ci` is used instead of `npm install` so the lock file is never rewritten, keeping the working tree clean across the checkout.
    - `npm run build -w packages/core`
    - `./scripts/build-all-examples.bash`, capturing its trailing CSV (header line + values line) into a temp file.
-6. Parses both CSVs, joins by example name, and prints a markdown table to stdout.
-7. Restores the original ref and removes the temp dir.
+7. Parses both sides, joins by example name, and prints the markdown table to stdout, followed by a blockquote note giving the ancestry relationship and the provenance of any reused sizes.
+8. Restores the original ref and removes the temp dir.
 
-Build logs go to stderr; only the final markdown table goes to stdout, so it can be redirected to a file or piped directly.
+Build logs go to stderr. Stdout carries the table and its note, so it can be redirected to a file or piped directly.
+
+## Reusing sizes already measured
+
+When the user already has sizes for one of the two refs, pass them instead of rebuilding that side:
+
+```bash
+# reuse the sizes of <from>, build only <to>
+compare-examples-size.bash --from-sizes <file> <from> <to>
+
+# reuse the sizes of <to>, build only <from>
+compare-examples-size.bash --to-sizes <file> <from> <to>
+
+# when <file> holds several size columns, name the one to read
+compare-examples-size.bash --from-sizes <file> --sizes-column <name-or-index> <from> <to>
+```
+
+Both refs are still required, even the one that is not built: they are what the ancestry check and the column labels are computed from.
+
+### Accepted file formats
+
+The parser auto-detects, so no conversion is needed:
+- the markdown table printed by a previous run of this script (has two size columns, so `--sizes-column` is required);
+- the markdown table printed by `scripts/build-all-examples.bash` (its `before` column is empty by design, so the populated `now` column is detected on its own);
+- the 2-line CSV printed by `scripts/build-all-examples.bash` (names line, then values line).
+
+Cell values may be bare (`303.69`), carry the unit (`303.69 kB`), or be `N/A`. If the user pastes a table into the conversation rather than pointing at a file, write it verbatim to a scratch file and pass that path.
+
+### Confirm the ref before running
+
+**Always confirm with the user which ref the supplied sizes were measured at, and never infer it silently.** Reused numbers are indistinguishable from freshly built ones in the output, so a wrong pairing produces a table that looks authoritative and is wrong.
+
+If the file is a previous run's table, its column headers contain the label and short SHA (`main 34a0d3c (kB)`). Use that as the suggestion when asking, rather than as the answer. The script cross-checks it: when the chosen column header embeds a SHA that is not a prefix of the resolved ref, it aborts and names both commits. That guard only fires when a SHA is present in the header, so it is a safety net, not a substitute for asking.
+
+Also confirm the sizes were measured with the same toolchain: a different Node version or a dependency bump between the two measurements makes the comparison meaningless, and nothing in the file records that.
+
+### Ambiguous columns
+
+A previous run's table holds two size columns, so the script aborts and lists the candidates with their indices. Ask the user which one applies, or infer it from the ref they confirmed, then re-run with `--sizes-column`. It accepts a header substring (`--sizes-column main`) or a 1-based index among the size columns (`--sizes-column 1`). Delta columns are never candidates.
 
 ## Output format
 
@@ -64,9 +109,29 @@ GitHub-flavored markdown table on stdout:
 - Rows are sorted alphabetically by example name.
 - `N/A` is used when an example exists at one ref but not the other.
 
-No commentary on causes of variation, just the numbers.
+The table is followed by a blockquote note carrying the context needed to read it: the ancestry relationship of the two refs, and, when one side was supplied, which column was reused and from which file. Keep that note with the table when passing it on, since the table alone does not say whether a column was rebuilt.
+
+## Analysis
+
+After the table, report the comparison in prose. Cover:
+
+- **The headline**: which examples moved, by how much, and in which direction. Lead with the largest absolute Δ in kB, not the largest percentage, since a big percentage on a small bundle is usually noise.
+- **The sign's meaning**, taken from the ancestry note. See [Reading the sign of Δ](#reading-the-sign-of-δ) below. This is not optional: the same `+80 kB` means "this change added 80 kB" under `ancestor` and "this branch is missing 80 kB of reductions its base already has" under `diverged`.
+- **Provenance**, whenever a side was supplied rather than built.
+- **`N/A` rows**, which mean an example exists at one ref and not the other, so it was added or removed rather than resized.
+
+Do not attribute a delta to a specific commit, dependency, or refactor unless the diff was actually inspected. Sizes alone establish that something moved, never why. If the user wants the cause, offer to look at `git log`/`git diff` between the refs as a separate step.
 
 ### Reading the sign of Δ
+
+The script classifies this for you and states it in the note under the table. The four cases:
+
+| Ancestry | Meaning of a positive Δ |
+| --- | --- |
+| `identical` | Both columns are the same commit; every Δ should be 0. |
+| `ancestor` | Column 1 precedes column 2, so the bundle grew as history advanced. |
+| `descendant` | Column 2 is the ancestor despite its later timestamp (rebase or amended date), so the bundle shrank as history advanced. |
+| `diverged` | Nothing chronological; the difference between two independent states. |
 
 The sign is only chronological when one ref is an ancestor of the other. In that case a positive Δ does mean the
 bundle grew as the history advanced.
@@ -92,12 +157,16 @@ was to measure a branch's own impact, the right comparison is the branch against
 - The script must run from inside the maxGraph repository (it uses `git rev-parse --show-toplevel`).
 - The active Node.js version should match `.nvmrc`. If `nvm` is available, the user should run `nvm use` before invoking the skill.
 - The working tree must be clean. Do **not** auto-stash. If the user has uncommitted work, surface the error and ask them how to proceed.
-- The script does two full `npm run build -w packages/core` + full examples build, so it takes several minutes. Warn the user before launching if this is the first run in a session.
+- The script does a full `npm run build -w packages/core` + full examples build per ref that has to be built, so it takes several minutes for two refs and roughly half that when one side's sizes are supplied. Warn the user before launching if this is the first run in a session, and mention that supplying sizes for one side halves the wait when they have them.
 
 ## Failure handling
 
 - **Dirty working tree**: report the offending files (`git status --short`) and stop.
 - **Unknown ref**: report which ref failed to resolve and stop.
+- **Ambiguous size column** (exit 1, before any build): the supplied file holds several size columns. The error lists them with indices. Ask the user which one, then re-run with `--sizes-column`.
+- **SHA mismatch between the supplied column and the ref** (exit 1, before any build): the reused sizes describe a different commit than the ref given on the command line. Do not work around it by picking another column at random. Ask the user which ref those sizes belong to, and re-run with the correct ref.
+- **Unparseable sizes file** (exit 1): no column holds numbers, or a CSV has mismatched header and value counts. Report the path and the parser's message; ask for the file in one of the accepted formats.
+- **Both sides supplied** (exit 2): at least one ref must be built. Ask which side to measure.
 - **Build failure on a ref**: the `trap` restores the original ref before exiting. Report which ref failed and at which step (`npm ci`, core build, or examples build). Do not retry automatically.
 - **Original ref restoration fails on exit**: surface the warning printed by the script and tell the user to `git checkout <original-ref>` manually.
 - **Forced kill (SIGKILL) mid-run**: bash traps cannot run on SIGKILL, so the user can be left in detached HEAD. To detect this, the script writes a lock file named `compare-examples-size.lock` in the common git dir (`git rev-parse --git-common-dir`, usually `.git/`) containing the original ref before any checkout; the `trap` removes it on graceful exit. If the script aborts via SIGKILL, the lock survives. The next invocation will refuse to start and print the original ref to restore. After running `git checkout <that-ref>`, the user must remove the lock file as instructed.

--- a/.claude/skills/compare-examples-size/scripts/compare-examples-size.bash
+++ b/.claude/skills/compare-examples-size/scripts/compare-examples-size.bash
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Compare maxGraph example bundle sizes between two git references.
+#
+# Usage: compare-examples-size.bash <from-ref> <to-ref>
+#   <from-ref> / <to-ref>: commit SHA, branch name, or tag.
+#
+# Output: a markdown table on stdout with per-example sizes for both refs and the delta.
+# Build logs are printed to stderr so stdout stays clean.
+
+usage() {
+  echo "Usage: $0 <from-ref> <to-ref>" >&2
+  echo "  Each ref can be a commit SHA, branch name, or tag." >&2
+}
+
+if [[ $# -ne 2 ]]; then
+  usage
+  exit 2
+fi
+
+FROM_RAW="$1"
+TO_RAW="$2"
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$REPO_ROOT" ]]; then
+  echo "Error: not inside a git repository." >&2
+  exit 1
+fi
+cd "$REPO_ROOT"
+
+# 1. Recovery lock check — must run FIRST. If a previous invocation was killed forcibly
+# (SIGKILL bypasses the trap), the lock survives and points to the ref the user was on.
+# Surface that before any other check so the recovery instructions are the first thing
+# the user sees.
+LOCK_FILE="$(git rev-parse --git-common-dir)/compare-examples-size.lock"
+if [[ -f "$LOCK_FILE" ]]; then
+  prev_ref=$(cat "$LOCK_FILE" 2>/dev/null || echo "<unknown>")
+  echo "Error: a previous run did not clean up (lock file present)." >&2
+  echo "It was started on ref: $prev_ref" >&2
+  echo "If you are not on that ref now, run: git checkout $prev_ref" >&2
+  echo "Then remove the lock: rm $LOCK_FILE" >&2
+  exit 1
+fi
+
+# 2. Strict clean working tree (including untracked files in tracked dirs)
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Error: working tree is not clean. Commit, stash, or discard changes before running." >&2
+  git status --short >&2
+  exit 1
+fi
+
+# 3. Resolve refs (verify they exist; capture commit SHA + label).
+# The `^{commit}` peel forces dereferencing through annotated tags so we end up with the
+# underlying commit SHA, not the tag object SHA. Without it, `git rev-parse --verify v0.23.0`
+# returns the tag object's SHA, which is unfindable via `git log` and confuses readers of the
+# output table.
+resolve_ref() {
+  local raw="$1"
+  local sha
+  if ! sha=$(git rev-parse --verify "$raw^{commit}" 2>/dev/null); then
+    echo "Error: cannot resolve git ref '$raw' to a commit." >&2
+    exit 1
+  fi
+  echo "$sha"
+}
+
+FROM_SHA=$(resolve_ref "$FROM_RAW")
+TO_SHA=$(resolve_ref "$TO_RAW")
+
+# Normalize order: older commit first (column 1), newer commit second (column 2),
+# regardless of CLI argument order. "Older" is determined by committer timestamp,
+# which works even when the two refs are not in an ancestor relationship.
+# Δ semantics become "newer minus older" → positive Δ means size grew over time.
+FROM_TS=$(git show -s --format=%ct "$FROM_SHA")
+TO_TS=$(git show -s --format=%ct "$TO_SHA")
+if (( FROM_TS > TO_TS )); then
+  echo "Note: swapping args so the older commit is in column 1 (was: '$FROM_RAW' newer than '$TO_RAW')." >&2
+  tmp_raw="$FROM_RAW"; FROM_RAW="$TO_RAW"; TO_RAW="$tmp_raw"
+  tmp_sha="$FROM_SHA"; FROM_SHA="$TO_SHA"; TO_SHA="$tmp_sha"
+fi
+FROM_SHORT="${FROM_SHA:0:7}"
+TO_SHORT="${TO_SHA:0:7}"
+
+# Decide the label shown in the markdown header: empty unless user provided a branch/tag name.
+# A raw 40-char (or shorter) SHA passed in is treated as a SHA-only column.
+ref_label() {
+  local raw="$1"
+  local sha="$2"
+  # If raw looks like a SHA (hex, 7-40 chars) AND matches the start of sha, treat as SHA-only.
+  if [[ "$raw" =~ ^[0-9a-fA-F]{7,40}$ ]] && [[ "$sha" == "$raw"* ]]; then
+    echo ""
+  else
+    echo "$raw"
+  fi
+}
+
+FROM_LABEL=$(ref_label "$FROM_RAW" "$FROM_SHA")
+TO_LABEL=$(ref_label "$TO_RAW" "$TO_SHA")
+
+# 4. Save current ref so we can restore it on exit (branch name preferred, fallback to SHA),
+# then write the lock so a forced kill leaves a recovery breadcrumb (see step 1).
+ORIGINAL_REF=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || git rev-parse HEAD)
+echo "$ORIGINAL_REF" > "$LOCK_FILE"
+
+# Temp files for CSV captures
+TMP_DIR=$(mktemp -d -t maxgraph-sizes-XXXXXX)
+FROM_CSV="$TMP_DIR/from.csv"
+TO_CSV="$TMP_DIR/to.csv"
+
+cleanup() {
+  local status=$?
+  echo >&2
+  echo "Restoring original ref: $ORIGINAL_REF" >&2
+  git checkout --quiet "$ORIGINAL_REF" 2>/dev/null || \
+    echo "Warning: failed to restore $ORIGINAL_REF. Run 'git checkout $ORIGINAL_REF' manually." >&2
+  rm -rf "$TMP_DIR"
+  rm -f "$LOCK_FILE"
+  exit $status
+}
+trap cleanup EXIT INT TERM
+
+PREV_LOCK_HASH=""
+
+# 4. Build at each ref and capture CSV
+build_and_capture() {
+  local sha="$1"
+  local out_csv="$2"
+  local raw="$3"
+
+  echo >&2
+  echo "=== Checking out $raw ($sha) ===" >&2
+  git checkout --quiet "$sha"
+
+  local current_lock_hash=""
+  if [[ -f package-lock.json ]]; then
+    current_lock_hash=$(git hash-object package-lock.json)
+  fi
+
+  if [[ -z "$PREV_LOCK_HASH" || "$PREV_LOCK_HASH" != "$current_lock_hash" ]]; then
+    # Use `npm ci` rather than `npm install` so the working tree stays clean:
+    # `npm install` can rewrite package-lock.json and contaminate the tree across the checkout.
+    echo "--- npm ci (package-lock.json changed or first run) ---" >&2
+    npm ci >&2
+  else
+    echo "--- npm ci skipped (package-lock.json unchanged) ---" >&2
+  fi
+  PREV_LOCK_HASH="$current_lock_hash"
+
+  echo "--- Building core ---" >&2
+  npm run build -w packages/core >&2
+
+  echo "--- Building examples and capturing sizes ---" >&2
+  # build-all-examples.bash emits a CSV at the end: a header line and a values line.
+  # Stream to stderr for the user while teeing to a tmp file we parse afterwards.
+  local raw_out
+  raw_out=$(mktemp -t maxgraph-raw-XXXXXX)
+  ./scripts/build-all-examples.bash 2>&1 | tee /dev/stderr > "$raw_out"
+
+  # Extract the last two non-empty lines, which are the CSV header and CSV values.
+  local last_two
+  last_two=$(grep -v '^$' "$raw_out" | tail -n 2)
+  echo "$last_two" > "$out_csv"
+  rm -f "$raw_out"
+
+  if [[ $(wc -l < "$out_csv") -lt 2 ]]; then
+    echo "Error: failed to capture CSV output from build-all-examples.bash." >&2
+    exit 1
+  fi
+}
+
+build_and_capture "$FROM_SHA" "$FROM_CSV" "$FROM_RAW"
+build_and_capture "$TO_SHA" "$TO_CSV" "$TO_RAW"
+
+# 5. Parse CSVs and emit markdown table.
+#    Each CSV file has exactly 2 lines: header (example names) and values (kB sizes).
+python3 - "$FROM_CSV" "$TO_CSV" "$FROM_LABEL" "$FROM_SHORT" "$TO_LABEL" "$TO_SHORT" <<'PY'
+import sys
+
+from_csv, to_csv, from_label, from_short, to_label, to_short = sys.argv[1:]
+
+def load(path):
+    with open(path) as f:
+        lines = [ln.rstrip("\n") for ln in f if ln.strip()]
+    header = lines[0].split(",")
+    values = lines[1].split(",")
+    return dict(zip(header, values))
+
+from_sizes = load(from_csv)
+to_sizes = load(to_csv)
+
+def to_float(v):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+def col_header(label, short):
+    return f"{label} {short}".strip() if label else short
+
+from_col = col_header(from_label, from_short)
+to_col = col_header(to_label, to_short)
+
+examples = sorted(set(from_sizes) | set(to_sizes))
+
+print()
+print(f"| Example | {from_col} (kB) | {to_col} (kB) | Δ kB | Δ % |")
+print("| --- | ---: | ---: | ---: | ---: |")
+
+for name in examples:
+    fv = to_float(from_sizes.get(name))
+    tv = to_float(to_sizes.get(name))
+    fv_s = f"{fv:.2f}" if fv is not None else "N/A"
+    tv_s = f"{tv:.2f}" if tv is not None else "N/A"
+    if fv is not None and tv is not None:
+        delta = tv - fv
+        pct = (delta / fv * 100) if fv != 0 else 0.0
+        delta_s = f"{delta:+.2f}"
+        pct_s = f"{pct:+.2f}%"
+    else:
+        delta_s = "N/A"
+        pct_s = "N/A"
+    print(f"| {name} | {fv_s} | {tv_s} | {delta_s} | {pct_s} |")
+print()
+PY

--- a/.claude/skills/compare-examples-size/scripts/compare-examples-size.bash
+++ b/.claude/skills/compare-examples-size/scripts/compare-examples-size.bash
@@ -260,9 +260,16 @@ build_and_capture() {
   echo "--- Building examples and capturing sizes ---" >&2
   # build-all-examples.bash emits a CSV at the end: a header line and a values line.
   # Stream to stderr for the user while teeing to a tmp file we parse afterwards.
+  #
+  # tee writes the capture file by name and duplicates to the inherited fd 2. The reverse
+  # (`tee /dev/stderr > "$raw_out"`) looks equivalent but corrupts the log whenever stderr is a
+  # regular file: /dev/stderr resolves through /proc/self/fd/2 back to the file's path, so tee
+  # reopens it with O_TRUNC and restarts at offset 0, discarding everything written so far and
+  # leaving NUL padding where the shell's own fd 2 offset had moved past. Redirecting stderr to a
+  # file is a documented use of this script, so it has to survive it.
   local raw_out
   raw_out=$(mktemp -t maxgraph-raw-XXXXXX)
-  ./scripts/build-all-examples.bash 2>&1 | tee /dev/stderr > "$raw_out"
+  ./scripts/build-all-examples.bash 2>&1 | tee "$raw_out" >&2
 
   # Extract the last two non-blank lines, which are the CSV header and CSV values.
   # Whitespace-only lines must be filtered too, otherwise they would displace a real CSV

--- a/.claude/skills/compare-examples-size/scripts/compare-examples-size.bash
+++ b/.claude/skills/compare-examples-size/scripts/compare-examples-size.bash
@@ -3,24 +3,100 @@ set -euo pipefail
 
 # Compare maxGraph example bundle sizes between two git references.
 #
-# Usage: compare-examples-size.bash <from-ref> <to-ref>
+# Usage: compare-examples-size.bash [--from-sizes <file> | --to-sizes <file>]
+#                                   [--sizes-column <name|index>] <from-ref> <to-ref>
 #   <from-ref> / <to-ref>: commit SHA, branch name, or tag.
 #
-# Output: a markdown table on stdout with per-example sizes for both refs and the delta.
-# Build logs are printed to stderr so stdout stays clean.
+# Passing already-measured sizes for one side skips its checkout and build, which halves the
+# runtime. The other side is still built from source.
+#
+# Output: a markdown table on stdout with per-example sizes for both refs and the delta,
+# followed by a blockquote note stating the ancestry relationship of the two refs and the
+# provenance of any reused sizes. Build logs are printed to stderr so stdout stays parseable.
 
 usage() {
-  echo "Usage: $0 <from-ref> <to-ref>" >&2
-  echo "  Each ref can be a commit SHA, branch name, or tag." >&2
+  cat >&2 <<'USAGE'
+Usage:
+  compare-examples-size.bash <from-ref> <to-ref>
+  compare-examples-size.bash --from-sizes <file> [--sizes-column <col>] <from-ref> <to-ref>
+  compare-examples-size.bash --to-sizes <file> [--sizes-column <col>] <from-ref> <to-ref>
+
+Each ref can be a commit SHA, branch name, or tag.
+
+Options:
+  --from-sizes <file>   Reuse already-measured sizes for <from-ref>; do not build it.
+  --to-sizes <file>     Reuse already-measured sizes for <to-ref>; do not build it.
+  --sizes-column <col>  Which size column of <file> to read, given as a header substring or as
+                        a 1-based index among the file's size columns. Required only when the
+                        file holds more than one size column, which is the case for a table
+                        produced by a previous run of this script.
+
+<file> may be any of:
+  - the markdown table printed by a previous run of this script;
+  - the markdown table printed by scripts/build-all-examples.bash;
+  - the 2-line CSV printed by scripts/build-all-examples.bash (names line, then values line).
+USAGE
 }
 
-if [[ $# -ne 2 ]]; then
+FROM_SIZES_FILE=""
+TO_SIZES_FILE=""
+SIZES_COLUMN=""
+POSITIONAL=()
+
+require_value() {
+  # $1 = option name, $2 = number of args left including the option itself
+  if (( $2 < 2 )); then
+    echo "Error: $1 requires a value." >&2
+    usage
+    exit 2
+  fi
+}
+
+while (( $# > 0 )); do
+  case "$1" in
+    --from-sizes) require_value "$1" $#; FROM_SIZES_FILE="$2"; shift 2 ;;
+    --to-sizes)   require_value "$1" $#; TO_SIZES_FILE="$2";   shift 2 ;;
+    --sizes-column) require_value "$1" $#; SIZES_COLUMN="$2";  shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    --) shift; while (( $# > 0 )); do POSITIONAL+=("$1"); shift; done ;;
+    -*) echo "Error: unknown option '$1'." >&2; usage; exit 2 ;;
+    *) POSITIONAL+=("$1"); shift ;;
+  esac
+done
+
+if (( ${#POSITIONAL[@]} != 2 )); then
+  echo "Error: expected exactly 2 refs, got ${#POSITIONAL[@]}." >&2
   usage
   exit 2
 fi
+FROM_RAW="${POSITIONAL[0]}"
+TO_RAW="${POSITIONAL[1]}"
 
-FROM_RAW="$1"
-TO_RAW="$2"
+if [[ -n "$FROM_SIZES_FILE" && -n "$TO_SIZES_FILE" ]]; then
+  echo "Error: --from-sizes and --to-sizes cannot be combined; at least one ref must be built." >&2
+  exit 2
+fi
+if [[ -n "$SIZES_COLUMN" && -z "$FROM_SIZES_FILE$TO_SIZES_FILE" ]]; then
+  echo "Error: --sizes-column applies only together with --from-sizes or --to-sizes." >&2
+  exit 2
+fi
+
+# Sizes files are resolved to absolute paths *before* the cd below, because a relative path
+# given on the command line is relative to the caller's directory, not to the repository root.
+abs_path() {
+  local path="$1"
+  [[ "$path" == /* ]] && { echo "$path"; return; }
+  echo "$PWD/$path"
+}
+
+for sizes_file in "$FROM_SIZES_FILE" "$TO_SIZES_FILE"; do
+  if [[ -n "$sizes_file" && ! -r "$sizes_file" ]]; then
+    echo "Error: cannot read sizes file '$sizes_file'." >&2
+    exit 1
+  fi
+done
+if [[ -n "$FROM_SIZES_FILE" ]]; then FROM_SIZES_FILE=$(abs_path "$FROM_SIZES_FILE"); fi
+if [[ -n "$TO_SIZES_FILE" ]]; then TO_SIZES_FILE=$(abs_path "$TO_SIZES_FILE"); fi
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 if [[ -z "$REPO_ROOT" ]]; then
@@ -79,12 +155,29 @@ TO_SHA=$(resolve_ref "$TO_RAW")
 FROM_TS=$(git show -s --format=%ct "$FROM_SHA")
 TO_TS=$(git show -s --format=%ct "$TO_SHA")
 if (( FROM_TS > TO_TS )); then
-  echo "Note: swapping args so the older commit is in column 1 (was: '$FROM_RAW' newer than '$TO_RAW')." >&2
+  echo "Note: swapping args so the earlier commit is in column 1 (was: '$FROM_RAW' later than '$TO_RAW')." >&2
   tmp_raw="$FROM_RAW"; FROM_RAW="$TO_RAW"; TO_RAW="$tmp_raw"
   tmp_sha="$FROM_SHA"; FROM_SHA="$TO_SHA"; TO_SHA="$tmp_sha"
+  # The supplied sizes belong to a ref, not to a column, so they follow their ref across the swap.
+  tmp_sizes="$FROM_SIZES_FILE"; FROM_SIZES_FILE="$TO_SIZES_FILE"; TO_SIZES_FILE="$tmp_sizes"
 fi
 FROM_SHORT="${FROM_SHA:0:7}"
 TO_SHORT="${TO_SHA:0:7}"
+
+# Classify the relationship between the two refs. This decides whether the sign of Δ carries any
+# chronological meaning at all, so it is reported alongside the table rather than left to the reader.
+# It is computed before the builds so the caller learns about a diverged pair immediately, not after
+# waiting several minutes.
+if [[ "$FROM_SHA" == "$TO_SHA" ]]; then
+  ANCESTRY="identical"
+elif git merge-base --is-ancestor "$FROM_SHA" "$TO_SHA"; then
+  ANCESTRY="ancestor"
+elif git merge-base --is-ancestor "$TO_SHA" "$FROM_SHA"; then
+  ANCESTRY="descendant"
+else
+  ANCESTRY="diverged"
+fi
+echo "Ancestry of the two refs: $ANCESTRY" >&2
 
 # Decide the label shown in the markdown header: empty unless user provided a branch/tag name.
 # A raw 40-char (or shorter) SHA passed in is treated as a SHA-only column.
@@ -185,54 +278,223 @@ build_and_capture() {
   fi
 }
 
-build_and_capture "$FROM_SHA" "$FROM_CSV" "$FROM_RAW"
-build_and_capture "$TO_SHA" "$TO_CSV" "$TO_RAW"
+# A side backed by a supplied sizes file is neither checked out nor built. Its file is handed to the
+# parser as-is, so the parser is what tolerates the several accepted input formats.
+if [[ -n "$FROM_SIZES_FILE" ]]; then
+  echo >&2
+  echo "=== Reusing supplied sizes for $FROM_RAW ($FROM_SHA): $FROM_SIZES_FILE ===" >&2
+  FROM_DATA="$FROM_SIZES_FILE"
+else
+  build_and_capture "$FROM_SHA" "$FROM_CSV" "$FROM_RAW"
+  FROM_DATA="$FROM_CSV"
+fi
 
-# 6. Parse CSVs and emit markdown table.
-#    Each CSV file has exactly 2 lines: header (example names) and values (kB sizes).
-python3 - "$FROM_CSV" "$TO_CSV" "$FROM_LABEL" "$FROM_SHORT" "$TO_LABEL" "$TO_SHORT" <<'PY'
+if [[ -n "$TO_SIZES_FILE" ]]; then
+  echo >&2
+  echo "=== Reusing supplied sizes for $TO_RAW ($TO_SHA): $TO_SIZES_FILE ===" >&2
+  TO_DATA="$TO_SIZES_FILE"
+else
+  build_and_capture "$TO_SHA" "$TO_CSV" "$TO_RAW"
+  TO_DATA="$TO_CSV"
+fi
+
+# 6. Parse both sides and emit the markdown table.
+#    Values are passed through the environment rather than as positional arguments: refs and
+#    labels are arbitrary user input, and named variables keep the contract readable as it grows.
+export CES_FROM_DATA="$FROM_DATA" CES_TO_DATA="$TO_DATA"
+export CES_FROM_LABEL="$FROM_LABEL" CES_FROM_SHORT="$FROM_SHORT" CES_FROM_SHA="$FROM_SHA"
+export CES_TO_LABEL="$TO_LABEL" CES_TO_SHORT="$TO_SHORT" CES_TO_SHA="$TO_SHA"
+export CES_FROM_SUPPLIED="$FROM_SIZES_FILE" CES_TO_SUPPLIED="$TO_SIZES_FILE"
+export CES_SIZES_COLUMN="$SIZES_COLUMN" CES_ANCESTRY="$ANCESTRY"
+python3 - <<'PY'
+import os
+import re
 import sys
 
-from_csv, to_csv, from_label, from_short, to_label, to_short = sys.argv[1:]
+FROM_DATA = os.environ["CES_FROM_DATA"]
+TO_DATA = os.environ["CES_TO_DATA"]
+FROM_SUPPLIED = os.environ["CES_FROM_SUPPLIED"]
+TO_SUPPLIED = os.environ["CES_TO_SUPPLIED"]
+SIZES_COLUMN = os.environ["CES_SIZES_COLUMN"]
+ANCESTRY = os.environ["CES_ANCESTRY"]
+
+SEPARATOR_CELL = re.compile(r"^:?-{3,}:?$")
+TRAILING_UNIT = re.compile(r"\s*kB\s*$", re.IGNORECASE)
+SHA_TOKEN = re.compile(r"\b[0-9a-fA-F]{7,40}\b")
+
+
+def die(message):
+    sys.exit(f"Error: {message}")
+
+
+def parse_size(cell):
+    """Return a float, or None for a missing value. Accepts '303.69', '303.69 kB' and 'N/A'."""
+    text = TRAILING_UNIT.sub("", cell.strip()).lstrip("+")
+    if not text or text.upper() == "N/A":
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def is_delta_header(header):
+    """Delta columns of a previous run's table hold numbers but are not sizes."""
+    return header.startswith("Δ") or "%" in header
+
+
+def load_csv(path, lines):
+    """2-line CSV as emitted by build-all-examples.bash: names line, then values line."""
+    if len(lines) < 2:
+        die(f"{path}: expected 2 CSV lines (names then values), found {len(lines)}.")
+    names = [c.strip() for c in lines[0].split(",")]
+    values = [c.strip() for c in lines[1].split(",")]
+    # zip() would silently truncate to the shorter list, producing a partial table that
+    # still looks trustworthy. Fail loudly instead.
+    if len(names) != len(values):
+        die(
+            f"CSV header/values column count mismatch in {path} "
+            f"({len(names)} vs {len(values)})."
+        )
+    return {name: parse_size(value) for name, value in zip(names, values)}, None
+
+
+def load_markdown(path, lines):
+    """A markdown table from a previous run of this script or from build-all-examples.bash."""
+    rows = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        filled = [cell for cell in cells if cell]
+        if filled and all(SEPARATOR_CELL.match(cell) for cell in filled):
+            continue
+        rows.append(cells)
+    if len(rows) < 2:
+        die(f"{path}: found a markdown table with no data rows.")
+
+    header, data = rows[0], rows[1:]
+    # A size column is any non-leading column that is not a delta column and holds at least one
+    # parseable number. This is what distinguishes the populated 'now' column of
+    # build-all-examples.bash from its deliberately empty 'before' column.
+    candidates = []
+    for index in range(1, len(header)):
+        if is_delta_header(header[index]):
+            continue
+        parsed = sum(
+            1 for row in data if index < len(row) and parse_size(row[index]) is not None
+        )
+        if parsed:
+            candidates.append((index, header[index]))
+
+    if not candidates:
+        die(f"{path}: no column holds parseable sizes. Headers: {header}.")
+
+    if SIZES_COLUMN:
+        chosen = select_column(path, candidates, SIZES_COLUMN)
+    elif len(candidates) == 1:
+        chosen = candidates[0]
+    else:
+        listed = ", ".join(f"[{n}] '{name}'" for n, (_, name) in enumerate(candidates, 1))
+        die(
+            f"{path} holds {len(candidates)} size columns, so the intended one is ambiguous. "
+            f"Re-run with --sizes-column <name-or-index>, choosing from: {listed}."
+        )
+
+    index, chosen_header = chosen
+    sizes = {}
+    for row in data:
+        name = row[0].strip() if row else ""
+        if not name:
+            continue
+        sizes[name] = parse_size(row[index]) if index < len(row) else None
+    return sizes, chosen_header
+
+
+def select_column(path, candidates, spec):
+    spec = spec.strip()
+    listed = ", ".join(f"[{n}] '{name}'" for n, (_, name) in enumerate(candidates, 1))
+    if re.fullmatch(r"\d+", spec):
+        position = int(spec)
+        if not 1 <= position <= len(candidates):
+            die(
+                f"--sizes-column {position} is out of range for {path}, which has "
+                f"{len(candidates)} size columns: {listed}."
+            )
+        return candidates[position - 1]
+    matches = [c for c in candidates if spec.lower() in c[1].lower()]
+    if len(matches) == 1:
+        return matches[0]
+    if not matches:
+        die(f"--sizes-column '{spec}' matches no size column of {path}. Available: {listed}.")
+    die(f"--sizes-column '{spec}' matches several size columns of {path}: {listed}.")
+
 
 def load(path):
     with open(path) as f:
-        lines = [ln.rstrip("\n") for ln in f if ln.strip()]
-    header = lines[0].split(",")
-    values = lines[1].split(",")
-    # zip() would silently truncate to the shorter list, producing a partial table that
-    # still looks trustworthy. Fail loudly instead.
-    if len(header) != len(values):
-        sys.exit(
-            f"Error: CSV header/values column count mismatch in {path} "
-            f"({len(header)} vs {len(values)})."
+        lines = [line.rstrip("\n") for line in f if line.strip()]
+    if not lines:
+        die(f"{path} is empty.")
+    if any(line.strip().startswith("|") for line in lines):
+        return load_markdown(path, lines)
+    return load_csv(path, lines)
+
+
+def check_sha(path, chosen_header, expected_sha, side):
+    """Guard against pairing a supplied table with the wrong ref.
+
+    A table produced by this script carries the short SHA in its column header, so a mismatch
+    with the ref named on the command line means the reused numbers describe a different commit.
+    Silently trusting them would yield a table that looks authoritative and is wrong.
+    """
+    if not chosen_header:
+        return
+    tokens = SHA_TOKEN.findall(chosen_header)
+    if not tokens:
+        return
+    embedded = tokens[-1].lower()
+    if not expected_sha.lower().startswith(embedded):
+        die(
+            f"the column '{chosen_header}' of {path} refers to commit {embedded}, but the "
+            f"{side} ref resolves to {expected_sha[:7]}. Pass the ref those sizes were measured "
+            f"at, or select a different column with --sizes-column."
         )
-    return dict(zip(header, values))
 
-from_sizes = load(from_csv)
-to_sizes = load(to_csv)
 
-def to_float(v):
-    try:
-        return float(v)
-    except (TypeError, ValueError):
-        return None
+from_sizes, from_chosen = load(FROM_DATA)
+to_sizes, to_chosen = load(TO_DATA)
+if FROM_SUPPLIED:
+    check_sha(FROM_DATA, from_chosen, os.environ["CES_FROM_SHA"], "from")
+if TO_SUPPLIED:
+    check_sha(TO_DATA, to_chosen, os.environ["CES_TO_SHA"], "to")
+
+# Silently ignoring a column selection would hide a misunderstanding about the file's shape.
+if SIZES_COLUMN and (from_chosen if FROM_SUPPLIED else to_chosen) is None:
+    die(
+        "--sizes-column was given, but the supplied file is a 2-line CSV: it holds a single set "
+        "of sizes and offers no column to choose from."
+    )
+
 
 def col_header(label, short):
     return f"{label} {short}".strip() if label else short
 
-from_col = col_header(from_label, from_short)
-to_col = col_header(to_label, to_short)
+
+from_col = col_header(os.environ["CES_FROM_LABEL"], os.environ["CES_FROM_SHORT"])
+to_col = col_header(os.environ["CES_TO_LABEL"], os.environ["CES_TO_SHORT"])
 
 examples = sorted(set(from_sizes) | set(to_sizes))
+if not examples:
+    die("no examples found in either side; nothing to compare.")
 
 print()
 print(f"| Example | {from_col} (kB) | {to_col} (kB) | Δ kB | Δ % |")
 print("| --- | ---: | ---: | ---: | ---: |")
 
 for name in examples:
-    fv = to_float(from_sizes.get(name))
-    tv = to_float(to_sizes.get(name))
+    fv = from_sizes.get(name)
+    tv = to_sizes.get(name)
     fv_s = f"{fv:.2f}" if fv is not None else "N/A"
     tv_s = f"{tv:.2f}" if tv is not None else "N/A"
     if fv is not None and tv is not None:
@@ -244,5 +506,41 @@ for name in examples:
         delta_s = "N/A"
         pct_s = "N/A"
     print(f"| {name} | {fv_s} | {tv_s} | {delta_s} | {pct_s} |")
+print()
+
+notes = []
+reused = []
+if FROM_SUPPLIED:
+    reused.append(f"column 1 (`{from_col}`) was supplied from `{FROM_SUPPLIED}`, not rebuilt")
+if TO_SUPPLIED:
+    reused.append(f"column 2 (`{to_col}`) was supplied from `{TO_SUPPLIED}`, not rebuilt")
+if reused:
+    notes.append(
+        "Reused sizes: " + "; ".join(reused) + ". They are comparable only if they were "
+        "measured with the same toolchain and dependencies as the rebuilt side."
+    )
+
+if ANCESTRY == "identical":
+    notes.append("Both columns are the same commit, so every Δ is expected to be 0.")
+elif ANCESTRY == "ancestor":
+    notes.append(
+        f"`{from_col}` is an ancestor of `{to_col}`, so Δ is chronological: a positive Δ means "
+        "the bundle grew as history advanced."
+    )
+elif ANCESTRY == "descendant":
+    notes.append(
+        f"`{to_col}` is an ancestor of `{from_col}` despite carrying the later committer "
+        "timestamp, which happens after a rebase or an amended date. Δ therefore runs against "
+        "history: a positive Δ means the bundle shrank as history advanced."
+    )
+else:
+    notes.append(
+        f"`{from_col}` and `{to_col}` have diverged, so Δ is not chronological: it is the "
+        "difference between two independent states, not growth. A branch that is behind its "
+        "base shows a positive Δ merely for lacking the base's later reductions."
+    )
+
+for note in notes:
+    print(f"> {note}")
 print()
 PY

--- a/.claude/skills/compare-examples-size/scripts/compare-examples-size.bash
+++ b/.claude/skills/compare-examples-size/scripts/compare-examples-size.bash
@@ -29,7 +29,7 @@ if [[ -z "$REPO_ROOT" ]]; then
 fi
 cd "$REPO_ROOT"
 
-# 1. Recovery lock check — must run FIRST. If a previous invocation was killed forcibly
+# 1. Recovery lock check: must run FIRST. If a previous invocation was killed forcibly
 # (SIGKILL bypasses the trap), the lock survives and points to the ref the user was on.
 # Surface that before any other check so the recovery instructions are the first thing
 # the user sees.
@@ -98,9 +98,31 @@ ref_label() {
 FROM_LABEL=$(ref_label "$FROM_RAW" "$FROM_SHA")
 TO_LABEL=$(ref_label "$TO_RAW" "$TO_SHA")
 
-# 4. Save current ref so we can restore it on exit (branch name preferred, fallback to SHA),
-# then write the lock so a forced kill leaves a recovery breadcrumb (see step 1).
+# 4. Save current ref so we can restore it on exit (branch name preferred, fallback to SHA).
 ORIGINAL_REF=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || git rev-parse HEAD)
+TMP_DIR=""
+
+cleanup() {
+  local status=$?
+  # Disarm the traps so a nested exit cannot re-enter cleanup.
+  trap - EXIT INT TERM
+  echo >&2
+  echo "Restoring original ref: $ORIGINAL_REF" >&2
+  git checkout --quiet "$ORIGINAL_REF" 2>/dev/null || \
+    echo "Warning: failed to restore $ORIGINAL_REF. Run 'git checkout $ORIGINAL_REF' manually." >&2
+  [[ -n "$TMP_DIR" ]] && rm -rf "$TMP_DIR"
+  rm -f "$LOCK_FILE"
+  exit $status
+}
+# cleanup is bound to EXIT only, and the signal handlers just `exit`. Binding it to
+# EXIT INT TERM instead would run it twice on a signal (the handler's own `exit` fires
+# the EXIT trap) and would report status 0 for an interrupted run, because `$?` inside a
+# signal handler is the status of the last completed command, not the signal.
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+# The traps are armed, so from here on any exit path removes the lock and the temp dir.
 echo "$ORIGINAL_REF" > "$LOCK_FILE"
 
 # Temp files for CSV captures
@@ -108,21 +130,9 @@ TMP_DIR=$(mktemp -d -t maxgraph-sizes-XXXXXX)
 FROM_CSV="$TMP_DIR/from.csv"
 TO_CSV="$TMP_DIR/to.csv"
 
-cleanup() {
-  local status=$?
-  echo >&2
-  echo "Restoring original ref: $ORIGINAL_REF" >&2
-  git checkout --quiet "$ORIGINAL_REF" 2>/dev/null || \
-    echo "Warning: failed to restore $ORIGINAL_REF. Run 'git checkout $ORIGINAL_REF' manually." >&2
-  rm -rf "$TMP_DIR"
-  rm -f "$LOCK_FILE"
-  exit $status
-}
-trap cleanup EXIT INT TERM
-
 PREV_LOCK_HASH=""
 
-# 4. Build at each ref and capture CSV
+# 5. Build at each ref and capture CSV
 build_and_capture() {
   local sha="$1"
   local out_csv="$2"
@@ -157,9 +167,11 @@ build_and_capture() {
   raw_out=$(mktemp -t maxgraph-raw-XXXXXX)
   ./scripts/build-all-examples.bash 2>&1 | tee /dev/stderr > "$raw_out"
 
-  # Extract the last two non-empty lines, which are the CSV header and CSV values.
+  # Extract the last two non-blank lines, which are the CSV header and CSV values.
+  # Whitespace-only lines must be filtered too, otherwise they would displace a real CSV
+  # line out of the `tail -n 2` window.
   local last_two
-  last_two=$(grep -v '^$' "$raw_out" | tail -n 2)
+  last_two=$(grep -vE '^[[:space:]]*$' "$raw_out" | tail -n 2)
   echo "$last_two" > "$out_csv"
   rm -f "$raw_out"
 
@@ -172,7 +184,7 @@ build_and_capture() {
 build_and_capture "$FROM_SHA" "$FROM_CSV" "$FROM_RAW"
 build_and_capture "$TO_SHA" "$TO_CSV" "$TO_RAW"
 
-# 5. Parse CSVs and emit markdown table.
+# 6. Parse CSVs and emit markdown table.
 #    Each CSV file has exactly 2 lines: header (example names) and values (kB sizes).
 python3 - "$FROM_CSV" "$TO_CSV" "$FROM_LABEL" "$FROM_SHORT" "$TO_LABEL" "$TO_SHORT" <<'PY'
 import sys
@@ -184,6 +196,13 @@ def load(path):
         lines = [ln.rstrip("\n") for ln in f if ln.strip()]
     header = lines[0].split(",")
     values = lines[1].split(",")
+    # zip() would silently truncate to the shorter list, producing a partial table that
+    # still looks trustworthy. Fail loudly instead.
+    if len(header) != len(values):
+        sys.exit(
+            f"Error: CSV header/values column count mismatch in {path} "
+            f"({len(header)} vs {len(values)})."
+        )
     return dict(zip(header, values))
 
 from_sizes = load(from_csv)

--- a/.claude/skills/compare-examples-size/scripts/compare-examples-size.bash
+++ b/.claude/skills/compare-examples-size/scripts/compare-examples-size.bash
@@ -68,10 +68,14 @@ resolve_ref() {
 FROM_SHA=$(resolve_ref "$FROM_RAW")
 TO_SHA=$(resolve_ref "$TO_RAW")
 
-# Normalize order: older commit first (column 1), newer commit second (column 2),
-# regardless of CLI argument order. "Older" is determined by committer timestamp,
-# which works even when the two refs are not in an ancestor relationship.
-# Δ semantics become "newer minus older" → positive Δ means size grew over time.
+# Normalize order: earlier commit first (column 1), later commit second (column 2), regardless of
+# CLI argument order. "Earlier" is determined by committer timestamp, which is always defined, even
+# when the two refs are not in an ancestor relationship. Δ semantics become "column 2 minus column 1".
+#
+# The timestamp only implies a chronological before/after when one ref is an ancestor of the other.
+# For diverged refs a positive Δ does NOT mean the size grew over time: a branch based on an old main
+# reports a large positive Δ against a newer main simply because it lacks main's later size
+# reductions. See "Reading the sign of Δ" in SKILL.md.
 FROM_TS=$(git show -s --format=%ct "$FROM_SHA")
 TO_TS=$(git show -s --format=%ct "$TO_SHA")
 if (( FROM_TS > TO_TS )); then

--- a/packages/website/docs/development/tools.md
+++ b/packages/website/docs/development/tools.md
@@ -34,7 +34,7 @@ Run from the repository root:
 The script prints, for each example:
 
 - the size of every `*.js` file produced under `dist/`;
-- a markdown summary table with the bundle sizes of every example (with an empty "before" column intended to be filled in manually when comparing snapshots);
+- a Markdown summary table with the bundle sizes of every example (with an empty "before" column intended to be filled in manually when comparing snapshots);
 - a CSV summary (one header line listing example names, one value line listing sizes in kB) — convenient to copy into a spreadsheet.
 
 To skip the build step and only display the sizes from an existing `dist/` output:
@@ -54,7 +54,7 @@ It is also useful to:
 
 Two interchangeable entry points are provided:
 
-- a **Claude Code skill** named `compare-examples-size`, intended for users of Claude Code. It produces a markdown table comparing the size of the `maxGraph` chunk for all examples between two git revisions (commit SHAs, branch names, or tag names).
+- a **Claude Code skill** named `compare-examples-size`, intended for users of Claude Code. It produces a Markdown table comparing the size of the `maxGraph` chunk for all examples between two git revisions (commit SHAs, branch names, or tag names).
 - the underlying **bash script**, available for direct use at `.claude/skills/compare-examples-size/scripts/compare-examples-size.bash`. The skill is a thin wrapper around this script, so contributors who do not use Claude Code can still run the comparison from any shell.
 
 ### Usage
@@ -71,8 +71,8 @@ For example, to compare the current `main` branch against the `v0.23.0` release 
 .claude/skills/compare-examples-size/scripts/compare-examples-size.bash main v0.23.0
 ```
 
-For each of the two references, the script checks out the revision, runs `npm ci`, builds `@maxgraph/core`, and runs `scripts/build-all-examples.bash` to capture the bundle sizes. It then prints a markdown table to stdout — build logs go to stderr — with one row per example and the following columns: example name, bundle size at the older revision, bundle size at the newer revision, delta in kB, and delta in %.
+For each of the two references, the script checks out the revision, runs `npm ci`, builds `@maxgraph/core`, and runs `scripts/build-all-examples.bash` to capture the bundle sizes. It then prints a Markdown table to stdout — build logs go to stderr — with one row per example and the following columns: example name, bundle size at the older revision, bundle size at the newer revision, delta in kB, and delta in %.
 
-The column order is normalized by commit date so that the older revision is always in column 1 and the newer one in column 2, regardless of the argument order. The delta is therefore always `newer − older`: a positive delta means the bundle grew between the two revisions.
+The column order is normalized by the commit date so that the older revision is always in column 1 and the newer one in column 2, regardless of the argument order. The delta is therefore always `newer − older`: a positive delta means the bundle grew between the two revisions.
 
 The working tree must be clean before running. The original branch is restored automatically at the end of the run, including on Ctrl-C or build failure.

--- a/packages/website/docs/development/tools.md
+++ b/packages/website/docs/development/tools.md
@@ -1,0 +1,78 @@
+---
+description: Internal tools to help during maxGraph development.
+---
+
+# Development tools
+
+This page documents internal scripts and helpers used during maxGraph development. They are not part of the public API of the library — they are intended for maintainers and contributors who need to measure, inspect, or compare the impact of their changes on the project.
+
+## Build all examples
+
+The script `scripts/build-all-examples.bash` builds every example shipped in the repository (`packages/ts-example*` and `packages/js-example*`) and reports the resulting bundle sizes.
+
+It is useful to:
+
+- give the size of the `maxGraph` chunk for all examples;
+- visualize the tree-shaking effect of the examples, and observe how much each example reduces the size of the `maxGraph` chunk.
+
+### Prerequisites
+
+The `@maxgraph/core` package must be built first so that the examples pick up the latest changes:
+
+```bash
+npm run build -w packages/core
+```
+
+### Usage
+
+Run from the repository root:
+
+```bash
+./scripts/build-all-examples.bash
+```
+
+The script prints, for each example:
+
+- the size of every `*.js` file produced under `dist/`;
+- a markdown summary table with the bundle sizes of every example (with an empty "before" column intended to be filled in manually when comparing snapshots);
+- a CSV summary (one header line listing example names, one value line listing sizes in kB) — convenient to copy into a spreadsheet.
+
+To skip the build step and only display the sizes from an existing `dist/` output:
+
+```bash
+./scripts/build-all-examples.bash --list-size-only
+```
+
+## Comparing the size of the maxGraph chunk between git revisions
+
+Comparing the size of the `maxGraph` chunk between git revisions helps track the evolution of the codebase, the reduction of the size of `maxGraph`, and the impact of tree-shaking improvements over time.
+
+It is also useful to:
+
+- enrich pull request descriptions with a concrete measurement of the impact of a code change on the bundle size;
+- support release notes, where the resulting table can demonstrate positive changes or warn readers about negative impacts on the bundle size.
+
+Two interchangeable entry points are provided:
+
+- a **Claude Code skill** named `compare-examples-size`, intended for users of Claude Code. It produces a markdown table comparing the size of the `maxGraph` chunk for all examples between two git revisions (commit SHAs, branch names, or tag names).
+- the underlying **bash script**, available for direct use at `.claude/skills/compare-examples-size/scripts/compare-examples-size.bash`. The skill is a thin wrapper around this script, so contributors who do not use Claude Code can still run the comparison from any shell.
+
+### Usage
+
+Run from the repository root, passing two git references in any order:
+
+```bash
+.claude/skills/compare-examples-size/scripts/compare-examples-size.bash <ref-1> <ref-2>
+```
+
+For example, to compare the current `main` branch against the `v0.23.0` release tag:
+
+```bash
+.claude/skills/compare-examples-size/scripts/compare-examples-size.bash main v0.23.0
+```
+
+For each of the two references, the script checks out the revision, runs `npm ci`, builds `@maxgraph/core`, and runs `scripts/build-all-examples.bash` to capture the bundle sizes. It then prints a markdown table to stdout — build logs go to stderr — with one row per example and the following columns: example name, bundle size at the older revision, bundle size at the newer revision, delta in kB, and delta in %.
+
+The column order is normalized by commit date so that the older revision is always in column 1 and the newer one in column 2, regardless of the argument order. The delta is therefore always `newer − older`: a positive delta means the bundle grew between the two revisions.
+
+The working tree must be clean before running. The original branch is restored automatically at the end of the run, including on Ctrl-C or build failure.

--- a/packages/website/docs/development/tools.md
+++ b/packages/website/docs/development/tools.md
@@ -4,7 +4,7 @@ description: Internal tools to help during maxGraph development.
 
 # Development tools
 
-This page documents internal scripts and helpers used during maxGraph development. They are not part of the public API of the library — they are intended for maintainers and contributors who need to measure, inspect, or compare the impact of their changes on the project.
+This page documents internal scripts and helpers used during maxGraph development. They are not part of the public API of the library: they are intended for maintainers and contributors who need to measure, inspect, or compare the impact of their changes on the project.
 
 ## Build all examples
 
@@ -35,7 +35,7 @@ The script prints, for each example:
 
 - the size of every `*.js` file produced under `dist/`;
 - a Markdown summary table with the bundle sizes of every example (with an empty "before" column intended to be filled in manually when comparing snapshots);
-- a CSV summary (one header line listing example names, one value line listing sizes in kB) — convenient to copy into a spreadsheet.
+- a CSV summary (one header line listing example names, one value line listing sizes in kB), convenient to copy into a spreadsheet.
 
 To skip the build step and only display the sizes from an existing `dist/` output:
 
@@ -71,7 +71,7 @@ For example, to compare the current `main` branch against the `v0.23.0` release 
 .claude/skills/compare-examples-size/scripts/compare-examples-size.bash main v0.23.0
 ```
 
-For each of the two references, the script checks out the revision, runs `npm ci`, builds `@maxgraph/core`, and runs `scripts/build-all-examples.bash` to capture the bundle sizes. It then prints a Markdown table to stdout — build logs go to stderr — with one row per example and the following columns: example name, bundle size at the older revision, bundle size at the newer revision, delta in kB, and delta in %.
+For each of the two references, the script checks out the revision, runs `npm ci`, builds `@maxgraph/core`, and runs `scripts/build-all-examples.bash` to capture the bundle sizes. It then prints a Markdown table to stdout (build logs go to stderr) with one row per example and the following columns: example name, bundle size at the older revision, bundle size at the newer revision, delta in kB, and delta in %.
 
 The column order is normalized by the commit date so that the older revision is always in column 1 and the newer one in column 2, regardless of the argument order. The delta is therefore always `newer − older`: a positive delta means the bundle grew between the two revisions.
 

--- a/packages/website/docs/development/tools.md
+++ b/packages/website/docs/development/tools.md
@@ -71,8 +71,35 @@ For example, to compare the current `main` branch against the `v0.23.0` release 
 .claude/skills/compare-examples-size/scripts/compare-examples-size.bash main v0.23.0
 ```
 
-For each of the two references, the script checks out the revision, runs `npm ci`, builds `@maxgraph/core`, and runs `scripts/build-all-examples.bash` to capture the bundle sizes. It then prints a Markdown table to stdout (build logs go to stderr) with one row per example and the following columns: example name, bundle size at the older revision, bundle size at the newer revision, delta in kB, and delta in %.
+For each of the two references, the script checks out the revision, runs `npm ci`, builds `@maxgraph/core`, and runs `scripts/build-all-examples.bash` to capture the bundle sizes. It then prints a Markdown table to stdout (build logs go to stderr) with one row per example and the following columns: example name, bundle size at the revision in column 1, bundle size at the revision in column 2, delta in kB, and delta in %.
 
-The column order is normalized by the commit date so that the older revision is always in column 1 and the newer one in column 2, regardless of the argument order. The delta is therefore always `newer − older`: a positive delta means the bundle grew between the two revisions.
+The column order is normalized by the commit date so that the revision with the earlier commit date is always in column 1 and the later one in column 2, regardless of the argument order. The delta is therefore always `column 2 − column 1`.
+
+Below the table, the script prints a short note stating how the two revisions are related, as computed by `git merge-base --is-ancestor`. This matters when reading the sign of the delta: it is chronological only when one revision is an ancestor of the other. Two revisions that have diverged, which is the usual case for a feature branch that has fallen behind its base, produce a delta that is merely the difference between two independent states. A branch behind its base shows a positive delta simply because it lacks the size reductions the base has since gained.
 
 The working tree must be clean before running. The original branch is restored automatically at the end of the run, including on Ctrl-C or build failure.
+
+### Reusing sizes already measured
+
+Building both revisions takes several minutes. When the sizes of one revision are already known, they can be passed to the script, which then builds only the other revision:
+
+```bash
+# reuse the sizes of <ref-1>, build only <ref-2>
+.claude/skills/compare-examples-size/scripts/compare-examples-size.bash --from-sizes sizes.md <ref-1> <ref-2>
+
+# reuse the sizes of <ref-2>, build only <ref-1>
+.claude/skills/compare-examples-size/scripts/compare-examples-size.bash --to-sizes sizes.md <ref-1> <ref-2>
+```
+
+Both revisions are still required, even the one that is not built, because they determine the column labels and the ancestry check. Only one side may be supplied: the script refuses to run without at least one revision to build.
+
+The file may be a Markdown table produced by a previous run of the script, the Markdown table printed by `scripts/build-all-examples.bash`, or its 2-line CSV output. Values are accepted bare (`303.69`), with the unit (`303.69 kB`), or as `N/A`.
+
+A table produced by a previous run holds two size columns, so the intended one must be named with `--sizes-column`, either by a substring of its header or by its 1-based index among the size columns:
+
+```bash
+.claude/skills/compare-examples-size/scripts/compare-examples-size.bash \
+  --from-sizes previous-comparison.md --sizes-column main main my-branch
+```
+
+Reused sizes are only comparable to freshly built ones if they were measured with the same Node version and the same dependencies; nothing in the file records that, so it is up to the caller to check. As a safety net, when the selected column header embeds a short SHA, as the script's own tables do, the script verifies it against the revision given on the command line and aborts on a mismatch rather than emitting a table that pairs sizes with the wrong revision.


### PR DESCRIPTION
## Summary

- Add a Claude Code skill, `compare-examples-size`, and the bash script behind it, comparing the size of the `maxGraph` chunk across all examples between two git references (commit SHA, branch, or tag) and printing a Markdown table with deltas in kB and %.
- Useful to measure the size impact of a PR, refactor, or release without manually checking out, building, and tabulating sizes for each reference. The table is meant to be pasted into a PR description or release notes.
- Accept already-measured sizes for one of the two references (`--from-sizes` / `--to-sizes`), in which case only the other reference is built. This halves the runtime whenever the numbers for one side are already known.
- Report how the two references are related, so the sign of the delta can be read correctly.
- Document both entry points (the skill, and the script for contributors who do not use Claude Code) in the website development docs.

The script is usable on its own from any shell; the skill is a thin wrapper around it.

## Design notes

### Safety of the checkout dance

- The working tree must be strictly clean. The script refuses to auto-stash, to avoid silent data loss.
- The original ref is restored by a `trap` on every graceful exit, including build failure and Ctrl-C.
- `cleanup` is bound to `EXIT` only, while the signal handlers just `exit`. Binding it to `EXIT INT TERM` runs it twice on a signal, because the handler's own `exit` fires the `EXIT` trap in turn, and reports status 0 for an interrupted run, because `$?` inside a signal handler is the status of the last completed command rather than the signal. An interrupted run now exits 130 (Ctrl-C) or 143 (`SIGTERM`), so a caller can tell it apart from a successful comparison.
- A forced kill (`SIGKILL`) cannot run the trap, so a recovery lock is written in the common git dir before any checkout. The next invocation refuses to start and prints which ref to restore. The lock check runs before the trap is armed, so a pre-existing lock is never removed by the run that reports it.
- `npm ci` is used rather than `npm install`, so `package-lock.json` is never rewritten across the two checkouts, and it is skipped when the lock file is unchanged between the two refs.

### Reading the table

- Column order is normalized by committer timestamp: earlier commit in column 1, later in column 2, whatever the argument order. The delta is therefore always `column 2 − column 1`.
- The relationship between the two refs is classified with `git merge-base --is-ancestor` as `identical`, `ancestor`, `descendant`, or `diverged`, and reported on stderr before the builds start, then again in a note below the table. This is not cosmetic: the timestamp only implies a chronological before/after when one ref is an ancestor of the other. For diverged refs, which is the normal case for a branch that has fallen behind its base, the same `+80 kB` means "this branch lacks 80 kB of reductions its base already has" rather than "this change added 80 kB". A `descendant` classification catches the rebase or amended-date case, where the ancestor carries the later timestamp.
- Annotated tags are dereferenced via `^{commit}`, so the short SHAs in the output table are always findable through `git log`.

### Reusing already-measured sizes

- Both refs are still required, including the one that is not built, since they determine the column labels and the ancestry check. Supplying both sides is refused: at least one ref must be built.
- Three input formats are accepted and auto-detected, so no conversion step is needed: a table printed by a previous run of the script, the Markdown table printed by `scripts/build-all-examples.bash`, and its 2-line CSV. Values parse bare (`303.69`), with the unit (`303.69 kB`), or as `N/A`.
- A size column is any non-leading column that holds at least one parseable number and is not a delta column. That is what lets the deliberately empty `before` column of `build-all-examples.bash` be skipped without configuration. A previous comparison table holds two size columns, so the script aborts and lists the candidates with their indices rather than guessing; `--sizes-column` then selects one by header substring or by index.
- Reused numbers are indistinguishable from freshly built ones in the output, so pairing them with the wrong ref would yield a table that looks authoritative and is wrong. Since the script's own tables carry the short SHA in the column header, that SHA is verified against the resolved ref and a mismatch aborts naming both commits. The guard only fires when a SHA is present in the header, so the skill instructions also require confirming the ref with the user.
- The note below the table records which column was reused and from which file, along with the caveat that reused sizes are only comparable if they were measured with the same toolchain and dependencies.

### Output plumbing

- Build logs go to stderr; stdout carries the table and its note, so it stays redirectable.
- The examples build is streamed with `tee "$raw_out" >&2` rather than `tee /dev/stderr > "$raw_out"`. The latter destroys the log whenever stderr is a regular file: `/dev/stderr` resolves through `/proc/self/fd/2` back to the file's own path, so `tee` reopens it with `O_TRUNC` and restarts at offset 0, discarding everything logged so far and leaving NUL padding where the shell's own descriptor offset had moved past. The table was never affected, since it is parsed from a separate capture file, but the diagnostics needed to investigate a failed run were.
- The trailing CSV is located by filtering blank *and* whitespace-only lines before taking the last two, since a whitespace-only line would otherwise displace a real CSV line out of the window. A header/values column count mismatch aborts instead of being silently truncated by `zip`.

### Skill instructions

- The skill asks for both refs rather than defaulting to `HEAD`, confirms which ref supplied sizes belong to before running, and reports an analysis after the table: largest absolute change first (a large percentage on a small bundle is usually noise), what the sign means given the ancestry, provenance of any reused column, and `N/A` rows meaning an example was added or removed rather than resized. Attributing a delta to a specific commit or dependency stays out of scope unless the diff was actually inspected, since sizes establish that something moved, never why.

## Test plan

Verified against a throwaway git repository with stubbed `npm` and `build-all-examples.bash`, so the exit paths could be exercised without waiting on real builds:

- [x] Two-ref mode runs 2 builds; `--from-sizes` and `--to-sizes` each run 1, reusing the correct column.
- [x] All three input formats parse, including the `before`/`now` table of `build-all-examples.bash` with no flag.
- [x] Ambiguous columns, an unmatched `--sizes-column` substring, an out-of-range index, `--sizes-column` against a CSV, and a SHA that disagrees with the ref all abort before any build, with the candidates listed.
- [x] Argument validation: missing refs, both sides supplied, unknown option, unreadable file, option without a value.
- [x] All four ancestry classifications, including `descendant` via a child commit with a backdated committer date.
- [x] `SIGTERM` mid-run exits 143, runs cleanup exactly once, emits no table, restores the branch, and leaves no lock or temp dir. The pre-fix wiring exits 0 with two cleanup passes.
- [x] With stderr redirected to a file, the log keeps all checkout, `npm ci` and build messages in order, ends with the restore line, and contains no NUL bytes.
- [x] Lock refusal path: a pre-existing lock aborts the next run with recovery instructions and is preserved across the refusal.
- [x] Real end-to-end run on this repository (`main` vs branch tip), producing a correct table, restoring the branch, leaving the tree clean and no lock behind.

Left for the reviewer:

- [ ] Try the skill end-to-end with two arbitrary refs from a clean tree. Expect several minutes for two full builds, or roughly half that when passing sizes for one side.
- [ ] Confirm the `SKILL.md` trigger description picks up natural phrasings such as "compare bundle sizes between main and my-branch" and "here is my previous table, compare it with my branch".
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added user-facing docs describing how to run a bundle-size comparison between two revisions, expected CSV/markdown output, prerequisites, and failure-handling guidance.

* **Chores**
  * Added a command-line comparison tool that captures example bundle sizes for two revisions and prints a markdown table of absolute and percentage deltas, with workspace preservation, efficient dependency handling, and interrupted-run recovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maxGraph/maxGraph/pull/1074?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
