### PR TITLE
chore: remove commented clearSelection in CellEditorHandler

### DIFF
--- a/packages/core/src/view/plugin/CellEditorHandler.ts
+++ b/packages/core/src/view/plugin/CellEditorHandler.ts
@@ -806,19 +806,6 @@ class CellEditorHandler implements GraphPlugin {
   }
 
   /**
-  clearSelection() {
-    const selection = window.getSelection();
-
-    if (selection) {
-      if (selection.empty) {
-        selection.empty();
-      } else if (selection.removeAllRanges) {
-        selection.removeAllRanges();
-      }
-    }
-  }
-
-  /**
    * Stops the editor and applies the value if cancel is false.
    */
   stopEditing(cancel = false) {


### PR DESCRIPTION
## Summary

- Remove the commented `clearSelection` method in `CellEditorHandler` (`packages/core/src/view/plugin/CellEditorHandler.ts`).
- The block was a verbatim port of mxGraph's `mxCellEditor.clearSelection`, but `stopEditing` already invokes the equivalent `clearSelection` utility from `domUtils.ts`. The two implementations only differ in the order they probe `removeAllRanges` vs `empty`, which is not observable in modern browsers.
- This is the same mxGraph migration leftover pattern previously addressed in efb5b4bdf, where a stray `/**` left by the initial refactor silently commented out the `GraphHierarchyNode.isAncestor` method.

## Test plan

- [x] `npm run lint` passes for the changed file
- [x] No behavior change at runtime: `stopEditing` already calls the imported `clearSelection` utility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maxGraph/maxGraph/pull/1075?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->