### PR TITLE
refactor: tighten selectionModel type and verify per-instance creation

### DIFF
--- a/packages/core/__tests__/view/BaseGraph.test.ts
+++ b/packages/core/__tests__/view/BaseGraph.test.ts
@@ -366,4 +366,20 @@ describe('Expect no global state for properties coming from mixins', () => {
     graph1.options.foldingEnabled = false;
     expect(graph1.options).not.toBe(graph2.options);
   });
+
+  // Even though SelectionMixin declares `selectionModel: null` on the prototype,
+  // the null value is harmless because BaseGraph.initializeCollaborators calls
+  // this.setSelectionModel(new GraphSelectionModel(this)). The assignment creates
+  // a per-instance property that shadows the prototype null, and GraphSelectionModel's
+  // constructor allocates its own `cells = []` array.
+  test('selectionModel', () => {
+    const graph1 = new BaseGraph();
+    const graph2 = new BaseGraph();
+
+    expect(graph1.getSelectionModel()).not.toBe(graph2.getSelectionModel());
+
+    graph1.getSelectionModel().cells.push(new Cell());
+    expect(graph2.getSelectionModel().cells).toStrictEqual([]);
+    expect(graph1.getSelectionModel().cells).not.toBe(graph2.getSelectionModel().cells);
+  });
 });

--- a/packages/core/__tests__/view/Graph.test.ts
+++ b/packages/core/__tests__/view/Graph.test.ts
@@ -14,11 +14,30 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { test } from '@jest/globals';
+import { describe, test, expect } from '@jest/globals';
+import { Cell, Graph } from '../../src';
 import { createGraphWithoutPlugins } from '../utils';
 
 test('setTooltips - the "TooltipHandler" plugin is not available', () => {
   const graph = createGraphWithoutPlugins();
   // just validate there is no error in this case
   graph.setTooltips(true);
+});
+
+describe('Expect no global state for properties coming from mixins', () => {
+  // Even though SelectionMixin declares `selectionModel: null` on the prototype,
+  // the null value is harmless because Graph.initializeCollaborators calls
+  // this.setSelectionModel(this.createSelectionModel()). The assignment creates
+  // a per-instance property that shadows the prototype null, and GraphSelectionModel's
+  // constructor allocates its own `cells = []` array.
+  test('selectionModel', () => {
+    const graph1 = new Graph();
+    const graph2 = new Graph();
+
+    expect(graph1.getSelectionModel()).not.toBe(graph2.getSelectionModel());
+
+    graph1.getSelectionModel().cells.push(new Cell());
+    expect(graph2.getSelectionModel().cells).toStrictEqual([]);
+    expect(graph1.getSelectionModel().cells).not.toBe(graph2.getSelectionModel().cells);
+  });
 });

--- a/packages/core/src/view/GraphSelectionModel.ts
+++ b/packages/core/src/view/GraphSelectionModel.ts
@@ -135,7 +135,7 @@ class GraphSelectionModel extends EventSource {
    *
    * @param cell {@link Cell} to be selected.
    */
-  setCell(cell: Cell): void {
+  setCell(cell: Cell | null): void {
     this.setCells(cell ? [cell] : []);
   }
 

--- a/packages/core/src/view/mixin/SelectionMixin.ts
+++ b/packages/core/src/view/mixin/SelectionMixin.ts
@@ -68,7 +68,9 @@ type PartialType = PartialGraph & PartialCells;
 
 // @ts-expect-error The properties of PartialGraph are defined elsewhere.
 export const SelectionMixin: PartialType = {
-  selectionModel: null,
+  // Always non-null at runtime: initialized in {@link AbstractGraph.initializeCollaborators}
+  // via {@link setSelectionModel}, which shadows the `null` set on the prototype by the mixin.
+  selectionModel: null!,
 
   getSelectionModel() {
     return this.selectionModel;

--- a/packages/core/src/view/mixin/SelectionMixin.type.ts
+++ b/packages/core/src/view/mixin/SelectionMixin.type.ts
@@ -20,13 +20,11 @@ import type Rectangle from '../geometry/Rectangle.js';
 
 declare module '../AbstractGraph' {
   interface AbstractGraph {
-    cells: Cell[];
     doneResource: string;
     updatingSelectionResource: string;
     singleSelection: boolean;
 
-    /** @default null */
-    selectionModel: any | null;
+    selectionModel: GraphSelectionModel;
 
     /**
      * Returns the {@link GraphSelectionModel} that contains the selection.


### PR DESCRIPTION
Type changes:
- selectionModel: any | null -> GraphSelectionModel on AbstractGraph (matches the model/view/stylesheet convention of typing collaborators as non-null since they are always set in initializeCollaborators)
- Drop the obsolete `cells: Cell[]` declaration that duplicated GraphSelectionModel.cells
- Widen GraphSelectionModel.setCell parameter to `Cell | null` (potential breaking change for subclasses that override setCell with the narrower type; callers passing a non-null Cell are unaffected)

Tests:
- Add 'Expect no global state' test for selectionModel on both Graph and BaseGraph. Verifies that despite the prototype-level null, initializeCollaborators assigns a fresh GraphSelectionModel per instance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed selection state isolation to ensure each graph instance maintains independent selection models without cross-contamination.
  * Improved type safety for selection model properties.

* **New Features**
  * Selection can now be cleared by passing `null` to the selection API.

* **Tests**
  * Added tests verifying selection state independence between graph instances.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maxGraph/maxGraph/pull/1078?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->