### PR TITLE
test(FitPlugin): simplify container dimension setup

### DIFF
--- a/packages/core/__tests__/view/plugin/FitPlugin.test.ts
+++ b/packages/core/__tests__/view/plugin/FitPlugin.test.ts
@@ -25,7 +25,7 @@ const createContainer = (dimensions: {
 }) => {
   const container = document.createElement('div');
   for (const [name, value] of Object.entries(dimensions)) {
-    Object.defineProperty(container, name, { value, configurable: true });
+    value && Object.defineProperty(container, name, { value, configurable: true });
   }
   return container;
 };

--- a/packages/core/__tests__/view/plugin/FitPlugin.test.ts
+++ b/packages/core/__tests__/view/plugin/FitPlugin.test.ts
@@ -24,27 +24,9 @@ const createContainer = (dimensions: {
   clientHeight?: number;
 }) => {
   const container = document.createElement('div');
-  dimensions.clientWidth &&
-    Object.defineProperty(container, 'clientWidth', {
-      value: dimensions.clientWidth,
-      configurable: true,
-    });
-  dimensions.clientHeight &&
-    Object.defineProperty(container, 'clientHeight', {
-      value: dimensions.clientHeight,
-      configurable: true,
-    });
-  dimensions.offsetWidth &&
-    Object.defineProperty(container, 'offsetWidth', {
-      value: dimensions.offsetWidth,
-      configurable: true,
-    });
-  dimensions.offsetHeight &&
-    Object.defineProperty(container, 'offsetHeight', {
-      value: dimensions.offsetHeight,
-      configurable: true,
-    });
-
+  for (const [name, value] of Object.entries(dimensions)) {
+    Object.defineProperty(container, name, { value, configurable: true });
+  }
   return container;
 };
 


### PR DESCRIPTION
## Summary

- Replace the four repetitive `Object.defineProperty` blocks (one per container dimension) with a single loop iterating over `Object.entries(dimensions)`.
- Reduces duplication in the test helper that sets up container dimensions, removing 21 lines while keeping behavior identical.

## Test plan

- [x] `npm test -w packages/core -- FitPlugin.test` (17 tests pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored a test helper that sets container dimensions for cleaner implementation; behavior unchanged — falsy numeric inputs (e.g., 0) remain skipped during testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maxGraph/maxGraph/pull/1079?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->