### PR TITLE
chore: share Claude build-protection config and trim rule bloat

### DIFF
--- a/.claude/rules/architecture/coding-practices.md
+++ b/.claude/rules/architecture/coding-practices.md
@@ -57,9 +57,9 @@ Applies to new plugins in `packages/core/src/view/plugin/` and the `BuiltinPlugi
 - Const enums are forbidden — use regular enums
 - File extensions required in imports (`n/file-extension-in-import`)
 
-## Prettier Config
+## Formatting
 
-Tab width 2, single quotes, print width 90, trailing comma ES5, end of line auto. See `.prettierrc`.
+Handled automatically by Prettier. See `.prettierrc` for the configured options.
 
 ## TypeScript
 

--- a/.claude/rules/git/commit-conventions.md
+++ b/.claude/rules/git/commit-conventions.md
@@ -1,7 +1,3 @@
----
-paths:
-  - "**"
----
 # Commit Message Conventions
 
 Format: `type(scope): subject` — imperative mood, <72 chars, lowercase, no period.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)"
+    ],
+    "deny": [],
+    "ask": []
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/block-build.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Tidies the repository's Claude Code configuration so the existing build-protection hook actually reaches contributors, and removes two small bits of rule bloat.

## Changes

### Share the build-protection hook (`.claude/settings.json`, new)

The `block-build.sh` PreToolUse hook script was already tracked in the repo, but its **registration** lived only in the gitignored `settings.local.json`. As a result, anyone cloning the repo got the script without it ever firing.

This adds a committed `.claude/settings.json` that:
- registers the `block-build.sh` PreToolUse hook via `$CLAUDE_PROJECT_DIR` (portable across machines), and
- ships a minimal read-only permission allowlist (`git status`/`diff`/`log`/`show`/`branch`) to reduce first-run approval prompts.

Entries are intentionally portable: no IDE/MCP-specific or absolute-path rules, which belong in each contributor's own `settings.local.json`.

### Trim rule bloat

- **`coding-practices.md`**: drop the duplicated `.prettierrc` values (tab width, quotes, print width). Prettier formats automatically, so restating its config prevents no mistake and risks drifting from the source of truth. Replaced with a pointer to `.prettierrc`.
- **`commit-conventions.md`**: remove the `paths: ["**"]` frontmatter. Matching every file is just a roundabout always-on rule; dropping it makes the always-on intent explicit and avoids the overly-broad path anti-pattern.

## Notes

No production code or build behavior is affected; all changes are under `.claude/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture coding practices documentation regarding formatting standards.
  * Updated git commit conventions documentation.

* **Chores**
  * Added development environment configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->