### PR TITLE
fix(ConnectorShape): ignore unset arrows in edge bounding box

### DIFF
--- a/packages/core/__tests__/view/shape/edge/ConnectorShape.test.ts
+++ b/packages/core/__tests__/view/shape/edge/ConnectorShape.test.ts
@@ -1,0 +1,65 @@
+/*
+Copyright 2026-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, expect, test } from '@jest/globals';
+import ConnectorShape from '../../../../src/view/shape/edge/ConnectorShape';
+import Rectangle from '../../../../src/view/geometry/Rectangle';
+import { NONE } from '../../../../src/util/Constants';
+import type { CellStateStyle } from '../../../../src/types';
+
+describe('augmentBoundingBox', () => {
+  // strokeWidth = 0 and scale = 1 make super.augmentBoundingBox a no-op (grow(0)),
+  // so the rectangle only reflects the marker-size contribution of ConnectorShape.
+  const newShape = (style: CellStateStyle): ConnectorShape => {
+    const shape = new ConnectorShape([], NONE, 0);
+    shape.scale = 1;
+    shape.strokeWidth = 0;
+    shape.style = style;
+    return shape;
+  };
+
+  // An absent arrow must be treated as NONE (mxGraph getValue default), so it must not
+  // grow the bounding box. The reported regression treated `undefined` as "present".
+  test.each<[string, CellStateStyle, number]>([
+    // Reported scenario: startSize set unconditionally, but only endArrow is set.
+    // startArrow is absent => only the end branch applies => max(0, 12) + 1 = 13.
+    ['only end arrow set', { startSize: 12, endArrow: 'classic', endSize: 12 }, 13],
+    // Symmetric scenario: endArrow is absent => only the start branch applies => 12 + 1 = 13.
+    ['only start arrow set', { startArrow: 'classic', startSize: 12, endSize: 12 }, 13],
+    // No arrow at all => no growth.
+    ['no arrow set', { startSize: 12, endSize: 12 }, 0],
+    // Explicit none on both sides => no growth.
+    [
+      'explicit none on both sides',
+      { startArrow: NONE, startSize: 12, endArrow: NONE, endSize: 12 },
+      0,
+    ],
+    // Both arrows set => start branch sets 13, end branch applies max(13, 12) + 1 = 14.
+    [
+      'both arrows set',
+      { startArrow: 'classic', startSize: 12, endArrow: 'classic', endSize: 12 },
+      14,
+    ],
+  ])('%s', (_desc, style, expectedGrow) => {
+    const shape = newShape(style);
+    const bbox = new Rectangle(0, 0, 100, 50);
+    shape.augmentBoundingBox(bbox);
+
+    const expected = new Rectangle(0, 0, 100, 50);
+    expected.grow(expectedGrow);
+    expect(bbox).toEqual(expected);
+  });
+});

--- a/packages/core/src/view/shape/edge/ConnectorShape.ts
+++ b/packages/core/src/view/shape/edge/ConnectorShape.ts
@@ -151,11 +151,11 @@ class ConnectorShape extends PolylineShape {
     // Adds marker sizes
     let size = 0;
 
-    if (this.style.startArrow !== NONE) {
+    if ((this.style.startArrow ?? NONE) !== NONE) {
       size = (this.style.startSize ?? StyleDefaultsConfig.markerSize) + 1;
     }
 
-    if (this.style.endArrow !== NONE) {
+    if ((this.style.endArrow ?? NONE) !== NONE) {
       size = Math.max(size, this.style.endSize ?? StyleDefaultsConfig.markerSize) + 1;
     }
 


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: closes #<the_issue_number_here>. If not, explain why (minor changes, etc.).
- [ ] You have discussed this issue with the maintainers of `maxGraph`, and you are assigned to the issue.
- [x] The scope of the PR is sufficiently narrow to be examined in a single session.
- [x] I have added tests to prove my fix is effective or my feature works.
- [ ] I have provided screenshot/videos to demonstrate the change. Not relevant: the change only affects the computed bounding box dimensions, it has no visual rendering output of its own; it is covered by automatic tests.
- [x] I have added or edited necessary documentation, or no docs changes are needed.
- [x] The PR title follows the "Conventional Commits" guidelines.

## Overview

`ConnectorShape.augmentBoundingBox` treated an unset `startArrow`/`endArrow` as present, so an edge with no arrow on a side still grew its bounding box by an extra marker size on that side.

The check was a strict comparison against `NONE`:

```ts
if (this.style.startArrow !== NONE) { ... }
```

When the style does not define the arrow, `this.style.startArrow` is `undefined`, and `undefined !== 'none'` is `true`, so the branch runs for arrows that were never set. This grows the bounding box (and therefore the graph bounds and the computed fit scale) more than it should.

This is a porting regression from mxGraph. `mxConnector.augmentBoundingBox` reads the arrow with `getValue(style, ARROW, NONE)`, which defaults an absent key to `NONE`, so the branch is correctly skipped.

The fix defaults the value before comparing, mirroring mxGraph and aligning with `createMarker` in the same file which already uses `... || NONE`:

```ts
if ((this.style.startArrow ?? NONE) !== NONE) { ... }
if ((this.style.endArrow ?? NONE) !== NONE) { ... }
```

Tests: data-driven coverage was added on `augmentBoundingBox` for the cases only end arrow set, only start arrow set, no arrow set, explicit `none` on both sides, and both arrows set. The first three were red before the fix.

## Notes

While investigating this, it became clear that the mxGraph to maxGraph migration introduced regressions in several places where a style default value is not handled the way mxGraph handled it (mxGraph systematically went through `getValue(style, KEY, default)`, whereas maxGraph sometimes reads the property directly and compares it without applying the default). Several such cases have already been fixed individually, but we will need to conduct a general investigation to systematically compare the default values used in mxGraph and maxGraph, to catch the remaining occurrences rather than fixing them one by one as they are discovered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect bounding box calculations for connector shapes when arrow styles are undefined or set to none.

* **Tests**
  * Added test coverage for connector shape bounding box behavior with various arrow configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->