### PR TITLE
docs: use the object parameter form of insertVertex

### DIFF
--- a/packages/website/docs/tutorials/graph.md
+++ b/packages/website/docs/tutorials/graph.md
@@ -104,15 +104,19 @@ and override the stroke and fill colors, the style would be defined as:
 
 To use the above in Hello, World!, the style name would be passed to the insertVertex method as follows:
 
-[//]: # (TODO migrate to the new insertVertex method using a single object parameter)
 ```javascript
-const v1 = graph.insertVertex(parent, null, 'Hello', 20, 20, 80, 30,
-  {
+const v1 = graph.insertVertex({
+  value: 'Hello',
+  x: 20,
+  y: 20,
+  width: 80,
+  height: 30,
+  style: {
     baseStyleNames: ['rounded'],
     strokeColor: 'red',
     fillColor: 'green'
-  }
-);
+  },
+});
 ```
 
 

--- a/packages/website/docs/usage/migrate-from-mxgraph.md
+++ b/packages/website/docs/usage/migrate-from-mxgraph.md
@@ -321,7 +321,7 @@ const model = graph.getDataModel();
 
 The `insertVertex()` and `insertEdge()` methods in `maxGraph` now also accept one object as parameter instead of multiple parameters. Instead of passing individual parameters, you can pass an object containing all the required properties.
 
-The former methods having several parameters still exist but the new signature should be used instead.
+The former methods having several parameters still exist but the new signature should be used instead because it is more readable and maintainable, and the former is going to be deprecated (see [Issue #856](https://github.com/maxGraph/maxGraph/issues/856)).
 
 Here's an example:
 


### PR DESCRIPTION
The tutorial still documented `insertVertex` with the positional signature, guarded by a `TODO` comment asking for the migration. That signature is a legacy `mxGraph` inheritance and is [going to be formally deprecated](https://github.com/maxGraph/maxGraph/issues/856), so the documentation should not keep teaching it to new users.

## Changes

- `docs/tutorials/graph.md`: convert the styled vertex sample to the single object parameter form and remove the `TODO` that tracked this migration.
- `docs/usage/migrate-from-mxgraph.md`: say **why** the new signature should be preferred (more readable and maintainable, and the positional one is going to be deprecated) instead of only stating that the former one still exists, and link issue #856.

## Note

The converted sample was missing the closing brace of the object literal, which made it invalid JavaScript:

```javascript
    fillColor: 'green'
  },
);      // <- the object literal is never closed
```

This is fixed in this PR, so the published sample now parses. Verified with `node --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the graph tutorial to demonstrate the recommended object-parameter API for inserting vertices.
  * Clarified that legacy multi-argument vertex and edge insertion signatures are deprecated.
  * Added guidance to use the current object-parameter signatures instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->