### PR TITLE
refactor(graph): group and test the properties that cannot move to a mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ _**Note:** Yet to be released breaking changes appear here._
 - The dispatch methods `createHandler` and `createEdgeHandler` are now defined on `SelectionCellsHandler`. If you were overriding them to change the dispatch logic itself (and not only the instantiated class), extend `SelectionCellsHandler` and pass your subclass in the `plugins` option.
 - `SelectionCellsHandler.createHandler` returns a non-nullable `CellHandler` (the new `EdgeHandler | VertexHandler` union type exported from the package), whereas `AbstractGraph.createHandler` was typed as nullable. TypeScript users can drop the now-useless null checks on the returned value.
 
+**Other Changes**:
+- The order of the child elements produced by the XML serialization of `<Graph>` and `<BaseGraph>` has changed: `pageFormat` and `warningImage` are now emitted right after `options`, instead of last.
+  This is not a breaking change, decoding matches elements by their `as` attribute and is order-independent, so existing documents keep decoding identically and previously exported documents are still valid.
+  It is mentioned here only for consumers comparing exported XML as text, for instance in golden-file tests.
+
 ## 0.24.0
 
 Release date: `2026-07-08`

--- a/packages/core/__tests__/serialization/codec/all-graph-classes.test.ts
+++ b/packages/core/__tests__/serialization/codec/all-graph-classes.test.ts
@@ -58,6 +58,8 @@ function buildXml(name: string): string {
     <ImageBox src="./collapsed-new.gif" width="10" height="10" as="collapsedImage" />
     <ImageBox src="./expanded.gif" width="9" height="9" as="expandedImage" />
   </Object>
+  <Rectangle _x="123" _y="453" _width="60" _height="60" as="pageFormat" />
+  <ImageBox src="./warning.gif" width="16" height="16" as="warningImage" />
   <GraphDataModel as="model">
     <root>
       <Cell id="0">
@@ -87,8 +89,6 @@ function buildXml(name: string): string {
       <add value="#446299" as="fontColor" />
     </add>
   </Stylesheet>
-  <Rectangle _x="123" _y="453" _width="60" _height="60" as="pageFormat" />
-  <ImageBox src="./warning.gif" width="16" height="16" as="warningImage" />
 </@NAME@>
 `;
 

--- a/packages/core/__tests__/view/BaseGraph.test.ts
+++ b/packages/core/__tests__/view/BaseGraph.test.ts
@@ -17,15 +17,14 @@ limitations under the License.
 import { afterAll, beforeEach, describe, expect, jest, test } from '@jest/globals';
 import {
   BaseGraph,
-  Cell,
   CellState,
   EdgeStyle,
   type EdgeStyleFunction,
   type GraphPlugin,
-  Multiplicity,
   registerDefaultEdgeStyles,
   unregisterAllEdgeStyles,
 } from '../../src';
+import { describeNoGlobalStateForMixinProperties } from './no-global-state-for-mixin-properties';
 
 const customEdgeStyle: EdgeStyleFunction = () => {
   // do nothing, we just need a custom implementation that is not registered by default
@@ -147,85 +146,4 @@ describe('destroy', () => {
   });
 });
 
-// For "complex" properties, for example: arrays or object.
-describe('Expect no global state for properties coming from mixins', () => {
-  test('alternateEdgeStyle', () => {
-    const graph1 = new BaseGraph();
-    const graph2 = new BaseGraph();
-
-    graph1.alternateEdgeStyle.arcSize = 10;
-    graph1.alternateEdgeStyle.fillColor = 'red';
-    expect(graph1.alternateEdgeStyle).not.toEqual(graph2.alternateEdgeStyle);
-    expect(graph1.alternateEdgeStyle).not.toBe(graph2.alternateEdgeStyle);
-  });
-
-  test('cells', () => {
-    const graph1 = new BaseGraph();
-    const graph2 = new BaseGraph();
-
-    graph1.cells.push(new Cell());
-    expect(graph2.cells).toStrictEqual([]);
-    expect(graph1.cells).not.toBe(graph2.cells);
-  });
-
-  test('mouseListeners', () => {
-    const graph1 = new BaseGraph();
-    expect(graph1.mouseListeners).toHaveLength(1);
-    const graph2 = new BaseGraph();
-    expect(graph2.mouseListeners).toHaveLength(1);
-
-    graph1.mouseListeners.push({
-      mouseDown: () => {},
-      mouseMove: () => {},
-      mouseUp: () => {},
-    });
-    expect(graph2.mouseListeners).toHaveLength(1);
-    expect(graph1.mouseListeners).toHaveLength(2);
-    expect(graph1.mouseListeners).not.toBe(graph2.mouseListeners);
-  });
-
-  test('multiplicities', () => {
-    const graph1 = new BaseGraph();
-    const graph2 = new BaseGraph();
-
-    graph1.multiplicities.push(
-      new Multiplicity(
-        true,
-        'rectangle',
-        null,
-        null,
-        0,
-        2,
-        ['circle'],
-        'Only 2 targets allowed',
-        'Only circle targets allowed'
-      )
-    );
-    expect(graph2.multiplicities).toStrictEqual([]);
-    expect(graph1.multiplicities).not.toBe(graph2.multiplicities);
-  });
-
-  test('options', () => {
-    const graph1 = new BaseGraph();
-    const graph2 = new BaseGraph();
-
-    graph1.options.foldingEnabled = false;
-    expect(graph1.options).not.toBe(graph2.options);
-  });
-
-  // Even though SelectionMixin declares `selectionModel: null` on the prototype,
-  // the null value is harmless because BaseGraph.initializeCollaborators calls
-  // this.setSelectionModel(new GraphSelectionModel(this)). The assignment creates
-  // a per-instance property that shadows the prototype null, and GraphSelectionModel's
-  // constructor allocates its own `cells = []` array.
-  test('selectionModel', () => {
-    const graph1 = new BaseGraph();
-    const graph2 = new BaseGraph();
-
-    expect(graph1.getSelectionModel()).not.toBe(graph2.getSelectionModel());
-
-    graph1.getSelectionModel().cells.push(new Cell());
-    expect(graph2.getSelectionModel().cells).toStrictEqual([]);
-    expect(graph1.getSelectionModel().cells).not.toBe(graph2.getSelectionModel().cells);
-  });
-});
+describeNoGlobalStateForMixinProperties(() => new BaseGraph());

--- a/packages/core/__tests__/view/Graph.test.ts
+++ b/packages/core/__tests__/view/Graph.test.ts
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { describe, test, expect } from '@jest/globals';
-import { type AbstractGraph, Cell, Graph, Multiplicity } from '../../src';
+import { test } from '@jest/globals';
+import { Graph } from '../../src';
 import { createGraphWithoutPlugins } from '../utils';
+import { describeNoGlobalStateForMixinProperties } from './no-global-state-for-mixin-properties';
 
 test('setTooltips - the "TooltipHandler" plugin is not available', () => {
   const graph = createGraphWithoutPlugins();
@@ -24,105 +25,4 @@ test('setTooltips - the "TooltipHandler" plugin is not available', () => {
   graph.setTooltips(true);
 });
 
-describe('Expect no global state for properties coming from mixins', () => {
-  // Even though SelectionMixin declares `selectionModel: null` on the prototype,
-  // the null value is harmless because Graph.initializeCollaborators calls
-  // this.setSelectionModel(this.createSelectionModel()). The assignment creates
-  // a per-instance property that shadows the prototype null, and GraphSelectionModel's
-  // constructor allocates its own `cells = []` array.
-  test('selectionModel', () => {
-    const graph1 = new Graph();
-    const graph2 = new Graph();
-
-    expect(graph1.getSelectionModel()).not.toBe(graph2.getSelectionModel());
-
-    graph1.getSelectionModel().cells.push(new Cell());
-    expect(graph2.getSelectionModel().cells).toStrictEqual([]);
-    expect(graph1.getSelectionModel().cells).not.toBe(graph2.getSelectionModel().cells);
-  });
-
-  // `mixInto` installs mixin members on the AbstractGraph prototype, so a mutable default (object or
-  // array) declared in a mixin would be shared by every Graph instance: mutating it on one graph would
-  // mutate it for all of them, with no compile error to signal it.
-  //
-  // The properties below are declared directly in AbstractGraph, in the "Variables that should be in the
-  // mixins but requiring per-instance initialization" group, precisely to avoid that. These tests pin that
-  // guarantee down, so moving one of them into a mixin fails here instead of silently corrupting state.
-  //
-  // When adding a property to that group, add a case here too.
-  type PerInstanceProperty = {
-    name: string;
-    /** Reads the property under test on a graph. */
-    read: (graph: AbstractGraph) => object;
-    /** Alters the value in place, the way user code would. */
-    mutate: (value: never) => void;
-    /** Extracts what the mutation is expected to change, to compare two graphs without deep equality. */
-    signature: (value: never) => unknown;
-  };
-
-  const perInstanceProperties: PerInstanceProperty[] = [
-    {
-      name: 'alternateEdgeStyle',
-      read: (graph) => graph.alternateEdgeStyle,
-      mutate: (value: { fillColor?: string }) => (value.fillColor = 'red'),
-      signature: (value: { fillColor?: string }) => value.fillColor,
-    },
-    {
-      name: 'cells',
-      read: (graph) => graph.cells,
-      mutate: (value: Cell[]) => value.push(new Cell()),
-      signature: (value: Cell[]) => value.length,
-    },
-    {
-      name: 'mouseListeners',
-      read: (graph) => graph.mouseListeners,
-      mutate: (value: object[]) =>
-        value.push({ mouseDown: () => {}, mouseMove: () => {}, mouseUp: () => {} }),
-      signature: (value: object[]) => value.length,
-    },
-    {
-      name: 'multiplicities',
-      read: (graph) => graph.multiplicities,
-      mutate: (value: Multiplicity[]) =>
-        value.push(new Multiplicity(true, 'type', null, null, 0, 1, null, null, null)),
-      signature: (value: Multiplicity[]) => value.length,
-    },
-    {
-      name: 'options',
-      read: (graph) => graph.options,
-      mutate: (value: { foldingEnabled: boolean }) => (value.foldingEnabled = false),
-      signature: (value: { foldingEnabled: boolean }) => value.foldingEnabled,
-    },
-    {
-      name: 'pageFormat',
-      read: (graph) => graph.pageFormat,
-      mutate: (value: { width: number }) => (value.width = 42),
-      signature: (value: { width: number }) => value.width,
-    },
-    {
-      name: 'warningImage',
-      read: (graph) => graph.warningImage,
-      mutate: (value: { src: string }) => (value.src = 'mutated.png'),
-      signature: (value: { src: string }) => value.src,
-    },
-  ];
-
-  test.each(perInstanceProperties)('$name', ({ read, mutate, signature }) => {
-    const graph1 = new Graph();
-    const graph2 = new Graph();
-
-    const value1 = read(graph1) as never;
-    const value2 = read(graph2) as never;
-
-    expect(value1).not.toBe(value2);
-    expect(signature(value1)).toStrictEqual(signature(value2));
-
-    const graph2SignatureBeforeMutation = signature(value2);
-    mutate(value1);
-
-    // the mutation is effective, so the assertion below cannot pass by accident
-    expect(signature(value1)).not.toStrictEqual(graph2SignatureBeforeMutation);
-    // and it did not leak to the other graph
-    expect(signature(value2)).toStrictEqual(graph2SignatureBeforeMutation);
-  });
-});
+describeNoGlobalStateForMixinProperties(() => new Graph());

--- a/packages/core/__tests__/view/Graph.test.ts
+++ b/packages/core/__tests__/view/Graph.test.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { describe, test, expect } from '@jest/globals';
-import { Cell, Graph } from '../../src';
+import { type AbstractGraph, Cell, Graph, Multiplicity } from '../../src';
 import { createGraphWithoutPlugins } from '../utils';
 
 test('setTooltips - the "TooltipHandler" plugin is not available', () => {
@@ -39,5 +39,90 @@ describe('Expect no global state for properties coming from mixins', () => {
     graph1.getSelectionModel().cells.push(new Cell());
     expect(graph2.getSelectionModel().cells).toStrictEqual([]);
     expect(graph1.getSelectionModel().cells).not.toBe(graph2.getSelectionModel().cells);
+  });
+
+  // `mixInto` installs mixin members on the AbstractGraph prototype, so a mutable default (object or
+  // array) declared in a mixin would be shared by every Graph instance: mutating it on one graph would
+  // mutate it for all of them, with no compile error to signal it.
+  //
+  // The properties below are declared directly in AbstractGraph, in the "Variables that should be in the
+  // mixins but requiring per-instance initialization" group, precisely to avoid that. These tests pin that
+  // guarantee down, so moving one of them into a mixin fails here instead of silently corrupting state.
+  //
+  // When adding a property to that group, add a case here too.
+  type PerInstanceProperty = {
+    name: string;
+    /** Reads the property under test on a graph. */
+    read: (graph: AbstractGraph) => object;
+    /** Alters the value in place, the way user code would. */
+    mutate: (value: never) => void;
+    /** Extracts what the mutation is expected to change, to compare two graphs without deep equality. */
+    signature: (value: never) => unknown;
+  };
+
+  const perInstanceProperties: PerInstanceProperty[] = [
+    {
+      name: 'alternateEdgeStyle',
+      read: (graph) => graph.alternateEdgeStyle,
+      mutate: (value: { fillColor?: string }) => (value.fillColor = 'red'),
+      signature: (value: { fillColor?: string }) => value.fillColor,
+    },
+    {
+      name: 'cells',
+      read: (graph) => graph.cells,
+      mutate: (value: Cell[]) => value.push(new Cell()),
+      signature: (value: Cell[]) => value.length,
+    },
+    {
+      name: 'mouseListeners',
+      read: (graph) => graph.mouseListeners,
+      mutate: (value: object[]) =>
+        value.push({ mouseDown: () => {}, mouseMove: () => {}, mouseUp: () => {} }),
+      signature: (value: object[]) => value.length,
+    },
+    {
+      name: 'multiplicities',
+      read: (graph) => graph.multiplicities,
+      mutate: (value: Multiplicity[]) =>
+        value.push(new Multiplicity(true, 'type', null, null, 0, 1, null, null, null)),
+      signature: (value: Multiplicity[]) => value.length,
+    },
+    {
+      name: 'options',
+      read: (graph) => graph.options,
+      mutate: (value: { foldingEnabled: boolean }) => (value.foldingEnabled = false),
+      signature: (value: { foldingEnabled: boolean }) => value.foldingEnabled,
+    },
+    {
+      name: 'pageFormat',
+      read: (graph) => graph.pageFormat,
+      mutate: (value: { width: number }) => (value.width = 42),
+      signature: (value: { width: number }) => value.width,
+    },
+    {
+      name: 'warningImage',
+      read: (graph) => graph.warningImage,
+      mutate: (value: { src: string }) => (value.src = 'mutated.png'),
+      signature: (value: { src: string }) => value.src,
+    },
+  ];
+
+  test.each(perInstanceProperties)('$name', ({ read, mutate, signature }) => {
+    const graph1 = new Graph();
+    const graph2 = new Graph();
+
+    const value1 = read(graph1) as never;
+    const value2 = read(graph2) as never;
+
+    expect(value1).not.toBe(value2);
+    expect(signature(value1)).toStrictEqual(signature(value2));
+
+    const graph2SignatureBeforeMutation = signature(value2);
+    mutate(value1);
+
+    // the mutation is effective, so the assertion below cannot pass by accident
+    expect(signature(value1)).not.toStrictEqual(graph2SignatureBeforeMutation);
+    // and it did not leak to the other graph
+    expect(signature(value2)).toStrictEqual(graph2SignatureBeforeMutation);
   });
 });

--- a/packages/core/__tests__/view/no-global-state-for-mixin-properties.ts
+++ b/packages/core/__tests__/view/no-global-state-for-mixin-properties.ts
@@ -1,0 +1,127 @@
+/*
+Copyright 2026-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, expect, test } from '@jest/globals';
+import { type AbstractGraph, Cell, Multiplicity } from '../../src';
+
+// `mixInto` installs mixin members on the AbstractGraph prototype, so a mutable default (object or
+// array) declared in a mixin would be shared by every graph instance: mutating it on one graph would
+// mutate it for all of them, with no compile error to signal it.
+//
+// The properties below are declared directly in AbstractGraph, in the "Variables that should be in the
+// mixins but requiring per-instance initialization" group, precisely to avoid that. These tests pin that
+// guarantee down, so moving one of them into a mixin fails here instead of silently corrupting state.
+//
+// When adding a property to that group, add a case here too.
+type PerInstanceProperty = {
+  name: string;
+  /** Reads the property under test on a graph. */
+  read: (graph: AbstractGraph) => object;
+  /** Alters the value in place, the way user code would. */
+  mutate: (value: never) => void;
+  /** Extracts what the mutation is expected to change, to compare two graphs without deep equality. */
+  signature: (value: never) => unknown;
+};
+
+const perInstanceProperties: PerInstanceProperty[] = [
+  {
+    name: 'alternateEdgeStyle',
+    read: (graph) => graph.alternateEdgeStyle,
+    mutate: (value: { fillColor?: string }) => (value.fillColor = 'red'),
+    signature: (value: { fillColor?: string }) => value.fillColor,
+  },
+  {
+    name: 'cells',
+    read: (graph) => graph.cells,
+    mutate: (value: Cell[]) => value.push(new Cell()),
+    signature: (value: Cell[]) => value.length,
+  },
+  {
+    name: 'mouseListeners',
+    read: (graph) => graph.mouseListeners,
+    mutate: (value: object[]) =>
+      value.push({ mouseDown: () => {}, mouseMove: () => {}, mouseUp: () => {} }),
+    signature: (value: object[]) => value.length,
+  },
+  {
+    name: 'multiplicities',
+    read: (graph) => graph.multiplicities,
+    mutate: (value: Multiplicity[]) =>
+      value.push(new Multiplicity(true, 'type', null, null, 0, 1, null, null, null)),
+    signature: (value: Multiplicity[]) => value.length,
+  },
+  {
+    name: 'options',
+    read: (graph) => graph.options,
+    mutate: (value: { foldingEnabled: boolean }) => (value.foldingEnabled = false),
+    signature: (value: { foldingEnabled: boolean }) => value.foldingEnabled,
+  },
+  {
+    name: 'pageFormat',
+    read: (graph) => graph.pageFormat,
+    mutate: (value: { width: number }) => (value.width = 42),
+    signature: (value: { width: number }) => value.width,
+  },
+  {
+    name: 'warningImage',
+    read: (graph) => graph.warningImage,
+    mutate: (value: { src: string }) => (value.src = 'mutated.png'),
+    signature: (value: { src: string }) => value.src,
+  },
+  // Not part of the AbstractGraph group above, but shares the same failure mode: even though
+  // SelectionMixin declares `selectionModel: null` on the prototype, the null value is harmless because
+  // initializeCollaborators assigns a new GraphSelectionModel. The assignment creates a per-instance
+  // property that shadows the prototype null, and GraphSelectionModel's constructor allocates its own
+  // `cells = []` array.
+  {
+    name: 'selectionModel',
+    read: (graph) => graph.getSelectionModel(),
+    mutate: (value: { cells: Cell[] }) => value.cells.push(new Cell()),
+    signature: (value: { cells: Cell[] }) => value.cells.length,
+  },
+];
+
+/**
+ * Registers the suite checking that no mutable state is shared between two graphs created by
+ * `createGraph`.
+ *
+ * Called from the test files of each concrete graph implementation, as the shared state, if any, comes
+ * from the mixins applied to the `AbstractGraph` prototype and is therefore observable from all of them.
+ */
+export const describeNoGlobalStateForMixinProperties = (
+  createGraph: () => AbstractGraph
+): void => {
+  describe('Expect no global state for properties coming from mixins', () => {
+    test.each(perInstanceProperties)('$name', ({ read, mutate, signature }) => {
+      const graph1 = createGraph();
+      const graph2 = createGraph();
+
+      const value1 = read(graph1) as never;
+      const value2 = read(graph2) as never;
+
+      expect(value1).not.toBe(value2);
+      expect(signature(value1)).toStrictEqual(signature(value2));
+
+      const graph2SignatureBeforeMutation = signature(value2);
+      mutate(value1);
+
+      // the mutation is effective, so the assertion below cannot pass by accident
+      expect(signature(value1)).not.toStrictEqual(graph2SignatureBeforeMutation);
+      // and it did not leak to the other graph
+      expect(signature(value2)).toStrictEqual(graph2SignatureBeforeMutation);
+    });
+  });
+};

--- a/packages/core/src/view/AbstractGraph.ts
+++ b/packages/core/src/view/AbstractGraph.ts
@@ -89,9 +89,10 @@ export abstract class AbstractGraph extends EventSource {
   // so these are defined here to ensure a fresh instance per Graph.
   // See https://github.com/maxGraph/maxGraph/pull/751 and https://github.com/maxGraph/maxGraph/pull/879
   //
-  // Every property of this group is covered by a per-instance test in __tests__/view/Graph.test.ts,
-  // under "Expect no global state for properties coming from mixins". Add a case there when adding a property here,
-  // otherwise moving it to a mixin later silently shares it across all Graph instances, with no error to signal it.
+  // Every property of this group is covered by a per-instance test in
+  // __tests__/view/no-global-state-for-mixin-properties.ts, run against each concrete graph implementation. Add a case
+  // there when adding a property here, otherwise moving it to a mixin later silently shares it across all Graph
+  // instances, with no error to signal it.
   // ===================================================================================================================
 
   /**

--- a/packages/core/src/view/AbstractGraph.ts
+++ b/packages/core/src/view/AbstractGraph.ts
@@ -88,6 +88,10 @@ export abstract class AbstractGraph extends EventSource {
   // The mixin application currently causes shared state for complex types (object/array),
   // so these are defined here to ensure a fresh instance per Graph.
   // See https://github.com/maxGraph/maxGraph/pull/751 and https://github.com/maxGraph/maxGraph/pull/879
+  //
+  // Every property of this group is covered by a per-instance test in __tests__/view/Graph.test.ts,
+  // under "Expect no global state for properties coming from mixins". Add a case there when adding a property here,
+  // otherwise moving it to a mixin later silently shares it across all Graph instances, with no error to signal it.
   // ===================================================================================================================
 
   /**
@@ -115,6 +119,26 @@ export abstract class AbstractGraph extends EventSource {
     expandedImage: new Image(`${Client.imageBasePath}/expanded.gif`, 9, 9),
     collapseToPreferredSize: true,
   };
+
+  /**
+   * Specifies the page format for the background page.
+   * This is used as the default in {@link PrintPreview} and for painting the background page
+   * if {@link pageVisible} is `true` and the page breaks if {@link pageBreaksVisible} is `true`.
+   * @default {@link PAGE_FORMAT_A4_PORTRAIT}
+   */
+  pageFormat = new Rectangle(...PAGE_FORMAT_A4_PORTRAIT);
+
+  /**
+   * Specifies the {@link Image} for the image to be used to display a warning
+   * overlay. See {@link setCellWarning}. Default value is Client.imageBasePath +
+   * '/warning'.  The extension for the image depends on the platform. It is
+   * '.png' on the Mac and '.gif' on all other platforms.
+   */
+  warningImage: Image = new Image(
+    `${Client.imageBasePath}/warning${Client.IS_MAC ? '.png' : '.gif'}`,
+    16,
+    16
+  );
 
   // ===================================================================================================================
   // Group: Variables managed here (not in mixins)
@@ -229,14 +253,6 @@ export abstract class AbstractGraph extends EventSource {
    * @default false
    */
   preferPageSize = false;
-
-  /**
-   * Specifies the page format for the background page.
-   * This is used as the default in {@link PrintPreview} and for painting the background page
-   * if {@link pageVisible} is `true` and the page breaks if {@link pageBreaksVisible} is `true`.
-   * @default {@link PAGE_FORMAT_A4_PORTRAIT}
-   */
-  pageFormat = new Rectangle(...PAGE_FORMAT_A4_PORTRAIT);
 
   /**
    * Specifies the scale of the background page.
@@ -368,18 +384,6 @@ export abstract class AbstractGraph extends EventSource {
    * @default true
    */
   multigraph = true;
-
-  /**
-   * Specifies the {@link Image} for the image to be used to display a warning
-   * overlay. See {@link setCellWarning}. Default value is Client.imageBasePath +
-   * '/warning'.  The extension for the image depends on the platform. It is
-   * '.png' on the Mac and '.gif' on all other platforms.
-   */
-  warningImage: Image = new Image(
-    `${Client.imageBasePath}/warning${Client.IS_MAC ? '.png' : '.gif'}`,
-    16,
-    16
-  );
 
   /**
    * Specifies the resource key for the error message to be displayed in

--- a/packages/core/src/view/mixin/EventsMixin.ts
+++ b/packages/core/src/view/mixin/EventsMixin.ts
@@ -800,6 +800,13 @@ export const EventsMixin: PartialType = {
   },
 
   sizeDidChange() {
+    // This method reads container-sizing members only (getBorder, getMinimumContainerSize, isResizeContainer,
+    // doResizeContainer, isPreferPageSize, getPreferredPageSize, getMinimumGraphSize) plus updatePageBreaks, so it
+    // looks like an obvious candidate to move to a dedicated sizing unit, away from the event concern of this mixin.
+    // It cannot move to a plugin for now: AbstractGraph calls it from its constructor, from graphModelChanged and from
+    // refresh, and none of these can depend on an optional plugin being registered. Extracting the members it reads
+    // while leaving the caller behind would only turn this method into a chain of getPlugin()?. calls with fallbacks.
+    // Relocating it to AbstractGraph itself remains possible and is the natural next step.
     const bounds = this.getGraphBounds();
 
     const border = this.getBorder();


### PR DESCRIPTION
First implementation step of the plan recorded in ADR 0003 (#1130). No behavior change for library users.

## Problem

`mixInto` installs mixin members on the `AbstractGraph` prototype. A property with a mutable default declared in a mixin is therefore shared by every graph instance: mutating it on one graph mutates it for all of them. There is no compile error, and until this PR, no failing test either.

`AbstractGraph` already has a dedicated group for the properties concerned, `Variables that should be in the mixins but requiring per-instance initialization`. That group was neither complete nor guarded.

## Changes

**`pageFormat` and `warningImage` join the group.** Both have exactly that constraint, yet were declared in the generic `Variables managed here` group, so nothing at the declaration said why they must stay. The source diff is a pure relocation, 20 lines out and the same 20 lines in.

**Every property of the group is now covered by a test**, in the existing `Expect no global state for properties coming from mixins` block: two graphs, distinct references, then mutate one and check the other is untouched. Each case also asserts that its own mutation is effective, so a case cannot pass by accident with a mutation that does nothing.

Verified that the tests can actually fail, by temporarily sharing `pageFormat` between instances the way a mixin would: only that case failed, the other six passed.

The group header now points at these tests, so adding a property there without its case becomes an obvious omission rather than a silent one.

**`sizeDidChange` gets a comment explaining why it cannot be extracted.** It sits in `EventsMixin` but reads container-sizing members only, so it looks like an obvious candidate for a move, and the question would otherwise be re-opened by every contributor who spots the mismatch. `AbstractGraph` calls it from its constructor, from `graphModelChanged` and from `refresh`, none of which can depend on an optional plugin. Written as a plain comment rather than JSDoc on purpose: a reader of the public API has no use for a refactoring constraint.

## One consequence worth reviewing

Declaration order drives the order of the child elements produced by the Codec export, so moving the two properties moved their elements in the exported XML. The expected XML of `all-graph-classes.test.ts` is updated accordingly, and the changelog records it.

This is **not** breaking: decoding matches elements by their `as` attribute and is order-independent, existing documents decode identically, and previously exported documents stay valid. It is recorded only for consumers comparing exported XML as text, for instance in golden-file tests.

The changelog entry sits under a new `Other Changes` heading, since the `Unreleased` section is documented as holding breaking changes only. Happy to drop it if you would rather keep that section strictly for breaking changes.

## Validation

Run locally on Node 24 (`.nvmrc`): `build`, `test-check`, the full suite (505 tests, 60 suites), `lint`, `check:circular-dependencies`. All passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed graph settings so changes to one graph no longer unintentionally affect other graph instances.
  * Ensured graph-specific page formats and warning images remain independently configurable.

* **Serialization**
  * XML exports now place `pageFormat` and `warningImage` immediately after `options` for graphs.
  * XML imports remain compatible regardless of element order.

* **Documentation**
  * Updated the changelog with the XML export ordering change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->