### PR TITLE
refactor(graph): move the viewport translation members to PanningMixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ _**Note:** Yet to be released breaking changes appear here._
 - The dispatch methods `createHandler` and `createEdgeHandler` are now defined on `SelectionCellsHandler`. If you were overriding them to change the dispatch logic itself (and not only the instantiated class), extend `SelectionCellsHandler` and pass your subclass in the `plugins` option.
 - `SelectionCellsHandler.createHandler` returns a non-nullable `CellHandler` (the new `EdgeHandler | VertexHandler` union type exported from the package), whereas `AbstractGraph.createHandler` was typed as nullable. TypeScript users can drop the now-useless null checks on the returned value.
 
+- `AbstractGraph.isIgnoreScrollbars` and `AbstractGraph.isTranslateToScrollPosition` are now regular methods instead of arrow function properties, following the move of the scrolling members to `PanningMixin`.
+  Calling them on the graph is unaffected: `graph.isIgnoreScrollbars()` keeps working. Only detached references break, because the functions are no longer bound to their instance.
+  If you pass one of them as a callback, for instance `someArray.some(graph.isIgnoreScrollbars)` or `const isIgnored = graph.isIgnoreScrollbars`, bind it explicitly with `graph.isIgnoreScrollbars.bind(graph)` or wrap it in an arrow function.
+  Note that TypeScript does not report this, both forms have the same type, so the failure only appears at runtime.
+
 **Other Changes**:
 - The order of the child elements produced by the XML serialization of `<Graph>` and `<BaseGraph>` has changed: `pageFormat` and `warningImage` are now emitted right after `options`, instead of last.
   This is not a breaking change, decoding matches elements by their `as` attribute and is order-independent, so existing documents keep decoding identically and previously exported documents are still valid.

--- a/packages/core/src/view/AbstractGraph.ts
+++ b/packages/core/src/view/AbstractGraph.ts
@@ -26,7 +26,7 @@ import type PanningHandler from './plugin/PanningHandler.js';
 import GraphView from './GraphView.js';
 import CellRenderer from './cell/CellRenderer.js';
 import Point from './geometry/Point.js';
-import { getCurrentStyle, hasScrollbars, parseCssNumber } from '../util/styleUtils.js';
+import { getCurrentStyle, parseCssNumber } from '../util/styleUtils.js';
 import Cell from './cell/Cell.js';
 import GraphDataModel from './GraphDataModel.js';
 import { Stylesheet } from './style/Stylesheet.js';
@@ -281,22 +281,6 @@ export abstract class AbstractGraph extends EventSource {
   importEnabled = true;
 
   /**
-   * Specifies if the graph should automatically scroll regardless of the
-   * scrollbars. This will scroll the container using positive values for
-   * scroll positions (ie usually only rightwards and downwards). To avoid
-   * possible conflicts with panning, set {@link translateToScrollPosition} to `true`.
-   */
-  ignoreScrollbars = false;
-
-  /**
-   * Specifies if the graph should automatically convert the current scroll
-   * position to a translate in the graph view when a mouseUp event is received.
-   * This can be used to avoid conflicts when using {@link autoScroll} and
-   * {@link ignoreScrollbars} with no scrollbars in the container.
-   */
-  translateToScrollPosition = false;
-
-  /**
    * {@link Rectangle} that specifies the area in which all cells in the diagram
    * should be placed. Uses in {@link getMaximumGraphBounds}. Use a width or height of
    * `0` if you only want to give a upper, left corner.
@@ -473,8 +457,6 @@ export abstract class AbstractGraph extends EventSource {
   getPageScale = () => this.pageScale;
   isExportEnabled = () => this.exportEnabled;
   isImportEnabled = () => this.importEnabled;
-  isIgnoreScrollbars = () => this.ignoreScrollbars;
-  isTranslateToScrollPosition = () => this.translateToScrollPosition;
 
   getMinimumGraphSize = () => this.minimumGraphSize;
   setMinimumGraphSize = (size: Rectangle | null) => (this.minimumGraphSize = size);
@@ -641,89 +623,6 @@ export abstract class AbstractGraph extends EventSource {
     // Removes the state from the cache by default
     else if (change.cell != null && change.cell instanceof Cell) {
       this.removeStateForCell(change.cell);
-    }
-  }
-
-  /**
-   * Scrolls the graph to the given point, extending the graph container if
-   * specified.
-   */
-  scrollPointToVisible(x: number, y: number, extend = false, border = 20) {
-    const panningHandler = this.getPlugin<PanningHandler>('PanningHandler');
-
-    if (
-      !this.isTimerAutoScroll() &&
-      (this.ignoreScrollbars || hasScrollbars(this.container))
-    ) {
-      const c = <HTMLElement>this.container;
-
-      if (
-        x >= c.scrollLeft &&
-        y >= c.scrollTop &&
-        x <= c.scrollLeft + c.clientWidth &&
-        y <= c.scrollTop + c.clientHeight
-      ) {
-        let dx = c.scrollLeft + c.clientWidth - x;
-
-        if (dx < border) {
-          const old = c.scrollLeft;
-          c.scrollLeft += border - dx;
-
-          // Automatically extends the canvas size to the bottom, right
-          // if the event is outside of the canvas and the edge of the
-          // canvas has been reached. Notes: Needs fix for IE.
-          if (extend && old === c.scrollLeft) {
-            // @ts-ignore
-            const root = this.view.getDrawPane().ownerSVGElement;
-            const width = c.scrollWidth + border - dx;
-
-            // Updates the clipping region. This is an expensive
-            // operation that should not be executed too often.
-            // @ts-ignore
-            root.style.width = `${width}px`;
-
-            c.scrollLeft += border - dx;
-          }
-        } else {
-          dx = x - c.scrollLeft;
-
-          if (dx < border) {
-            c.scrollLeft -= border - dx;
-          }
-        }
-
-        let dy = c.scrollTop + c.clientHeight - y;
-
-        if (dy < border) {
-          const old = c.scrollTop;
-          c.scrollTop += border - dy;
-
-          if (old == c.scrollTop && extend) {
-            // @ts-ignore
-            const root = this.view.getDrawPane().ownerSVGElement;
-            const height = c.scrollHeight + border - dy;
-
-            // Updates the clipping region. This is an expensive
-            // operation that should not be executed too often.
-            // @ts-ignore
-            root.style.height = `${height}px`;
-
-            c.scrollTop += border - dy;
-          }
-        } else {
-          dy = y - c.scrollTop;
-
-          if (dy < border) {
-            c.scrollTop -= border - dy;
-          }
-        }
-      }
-    } else if (
-      this.isAllowAutoPanning() &&
-      panningHandler &&
-      !panningHandler.isActive()
-    ) {
-      panningHandler.getPanningManager().panTo(x + this.getPanDx(), y + this.getPanDy());
     }
   }
 
@@ -907,59 +806,6 @@ export abstract class AbstractGraph extends EventSource {
     this.view.validate();
     this.sizeDidChange();
     this.fireEvent(new EventObject(InternalEvent.REFRESH));
-  }
-
-  /**
-   * Centers the graph in the container.
-   *
-   * @param horizontal Optional boolean that specifies if the graph should be centered
-   * horizontally. Default is `true`.
-   * @param vertical Optional boolean that specifies if the graph should be centered
-   * vertically. Default is `true`.
-   * @param cx Optional float that specifies the horizontal center. Default is `0.5`.
-   * @param cy Optional float that specifies the vertical center. Default is `0.5`.
-   */
-  center(horizontal = true, vertical = true, cx = 0.5, cy = 0.5): void {
-    const container = <HTMLElement>this.container;
-    const _hasScrollbars = hasScrollbars(this.container);
-    const padding = 2 * this.getBorder();
-    const cw = container.clientWidth - padding;
-    const ch = container.clientHeight - padding;
-    const bounds = this.getGraphBounds();
-
-    const t = this.view.translate;
-    const s = this.view.scale;
-
-    let dx = horizontal ? cw - bounds.width : 0;
-    let dy = vertical ? ch - bounds.height : 0;
-
-    if (!_hasScrollbars) {
-      this.view.setTranslate(
-        horizontal ? Math.floor(t.x - bounds.x / s + (dx * cx) / s) : t.x,
-        vertical ? Math.floor(t.y - bounds.y / s + (dy * cy) / s) : t.y
-      );
-    } else {
-      bounds.x -= t.x;
-      bounds.y -= t.y;
-
-      const sw = container.scrollWidth;
-      const sh = container.scrollHeight;
-
-      if (sw > cw) {
-        dx = 0;
-      }
-
-      if (sh > ch) {
-        dy = 0;
-      }
-
-      this.view.setTranslate(
-        Math.floor(dx / 2 - bounds.x),
-        Math.floor(dy / 2 - bounds.y)
-      );
-      container.scrollLeft = (sw - cw) / 2;
-      container.scrollTop = (sh - ch) / 2;
-    }
   }
 
   /**

--- a/packages/core/src/view/mixin/PanningMixin.ts
+++ b/packages/core/src/view/mixin/PanningMixin.ts
@@ -25,7 +25,7 @@ import type SelectionCellsHandler from '../plugin/SelectionCellsHandler.js';
 
 type PartialGraph = Pick<
   AbstractGraph,
-  'getContainer' | 'getView' | 'getPlugin' | 'fireEvent'
+  'getContainer' | 'getView' | 'getPlugin' | 'fireEvent' | 'getBorder' | 'getGraphBounds'
 >;
 type PartialPanning = Pick<
   AbstractGraph,
@@ -34,17 +34,23 @@ type PartialPanning = Pick<
   | 'useScrollbarsForPanning'
   | 'timerAutoScroll'
   | 'allowAutoPanning'
+  | 'ignoreScrollbars'
+  | 'translateToScrollPosition'
   | 'panDx'
   | 'panDy'
   | 'isUseScrollbarsForPanning'
   | 'isTimerAutoScroll'
   | 'isAllowAutoPanning'
+  | 'isIgnoreScrollbars'
+  | 'isTranslateToScrollPosition'
   | 'getPanDx'
   | 'setPanDx'
   | 'getPanDy'
   | 'setPanDy'
   | 'panGraph'
+  | 'center'
   | 'scrollCellToVisible'
+  | 'scrollPointToVisible'
   | 'scrollRectToVisible'
   | 'setPanning'
 >;
@@ -71,6 +77,18 @@ export const PanningMixin: PartialType = {
 
   isAllowAutoPanning() {
     return this.allowAutoPanning;
+  },
+
+  ignoreScrollbars: false,
+
+  isIgnoreScrollbars() {
+    return this.ignoreScrollbars;
+  },
+
+  translateToScrollPosition: false,
+
+  isTranslateToScrollPosition() {
+    return this.translateToScrollPosition;
   },
 
   panDx: 0,
@@ -190,6 +208,129 @@ export const PanningMixin: PartialType = {
       this.panDy = dy;
 
       this.fireEvent(new EventObject(InternalEvent.PAN));
+    }
+  },
+
+  scrollPointToVisible(x, y, extend = false, border = 20) {
+    const panningHandler = this.getPlugin<PanningHandler>('PanningHandler');
+    const container = this.getContainer();
+
+    if (
+      !this.isTimerAutoScroll() &&
+      (this.ignoreScrollbars || hasScrollbars(container))
+    ) {
+      const c = container;
+
+      if (
+        x >= c.scrollLeft &&
+        y >= c.scrollTop &&
+        x <= c.scrollLeft + c.clientWidth &&
+        y <= c.scrollTop + c.clientHeight
+      ) {
+        let dx = c.scrollLeft + c.clientWidth - x;
+
+        if (dx < border) {
+          const old = c.scrollLeft;
+          c.scrollLeft += border - dx;
+
+          // Automatically extends the canvas size to the bottom, right
+          // if the event is outside of the canvas and the edge of the
+          // canvas has been reached. Notes: Needs fix for IE.
+          if (extend && old === c.scrollLeft) {
+            // @ts-ignore
+            const root = this.getView().getDrawPane().ownerSVGElement;
+            const width = c.scrollWidth + border - dx;
+
+            // Updates the clipping region. This is an expensive
+            // operation that should not be executed too often.
+            // @ts-ignore
+            root.style.width = `${width}px`;
+
+            c.scrollLeft += border - dx;
+          }
+        } else {
+          dx = x - c.scrollLeft;
+
+          if (dx < border) {
+            c.scrollLeft -= border - dx;
+          }
+        }
+
+        let dy = c.scrollTop + c.clientHeight - y;
+
+        if (dy < border) {
+          const old = c.scrollTop;
+          c.scrollTop += border - dy;
+
+          if (old == c.scrollTop && extend) {
+            // @ts-ignore
+            const root = this.getView().getDrawPane().ownerSVGElement;
+            const height = c.scrollHeight + border - dy;
+
+            // Updates the clipping region. This is an expensive
+            // operation that should not be executed too often.
+            // @ts-ignore
+            root.style.height = `${height}px`;
+
+            c.scrollTop += border - dy;
+          }
+        } else {
+          dy = y - c.scrollTop;
+
+          if (dy < border) {
+            c.scrollTop -= border - dy;
+          }
+        }
+      }
+    } else if (
+      this.isAllowAutoPanning() &&
+      panningHandler &&
+      !panningHandler.isActive()
+    ) {
+      panningHandler.getPanningManager().panTo(x + this.getPanDx(), y + this.getPanDy());
+    }
+  },
+
+  center(horizontal = true, vertical = true, cx = 0.5, cy = 0.5) {
+    const container = this.getContainer();
+    const _hasScrollbars = hasScrollbars(container);
+    const padding = 2 * this.getBorder();
+    const cw = container.clientWidth - padding;
+    const ch = container.clientHeight - padding;
+    const bounds = this.getGraphBounds();
+
+    const t = this.getView().translate;
+    const s = this.getView().scale;
+
+    let dx = horizontal ? cw - bounds.width : 0;
+    let dy = vertical ? ch - bounds.height : 0;
+
+    if (!_hasScrollbars) {
+      this.getView().setTranslate(
+        horizontal ? Math.floor(t.x - bounds.x / s + (dx * cx) / s) : t.x,
+        vertical ? Math.floor(t.y - bounds.y / s + (dy * cy) / s) : t.y
+      );
+    } else {
+      bounds.x -= t.x;
+      bounds.y -= t.y;
+
+      const sw = container.scrollWidth;
+      const sh = container.scrollHeight;
+
+      if (sw > cw) {
+        dx = 0;
+      }
+
+      if (sh > ch) {
+        dy = 0;
+      }
+
+      this.getView().setTranslate(
+        Math.floor(dx / 2 - bounds.x),
+        Math.floor(dy / 2 - bounds.y)
+      );
+      container.scrollLeft = (sw - cw) / 2;
+      container.scrollTop = (sh - ch) / 2;
     }
   },
 

--- a/packages/core/src/view/mixin/PanningMixin.type.ts
+++ b/packages/core/src/view/mixin/PanningMixin.type.ts
@@ -53,6 +53,24 @@ declare module '../AbstractGraph' {
     allowAutoPanning: boolean;
 
     /**
+     * Specifies if the graph should automatically scroll regardless of the
+     * scrollbars. This will scroll the container using positive values for
+     * scroll positions (ie usually only rightwards and downwards). To avoid
+     * possible conflicts with panning, set {@link translateToScrollPosition} to `true`.
+     * @default false
+     */
+    ignoreScrollbars: boolean;
+
+    /**
+     * Specifies if the graph should automatically convert the current scroll
+     * position to a translate in the graph view when a mouseUp event is received.
+     * This can be used to avoid conflicts when using {@link autoScroll} and
+     * {@link ignoreScrollbars} with no scrollbars in the container.
+     * @default false
+     */
+    translateToScrollPosition: boolean;
+
+    /**
      * Current horizontal panning value.
      * @default 0
      */
@@ -67,6 +85,8 @@ declare module '../AbstractGraph' {
     isUseScrollbarsForPanning: () => boolean;
     isTimerAutoScroll: () => boolean;
     isAllowAutoPanning: () => boolean;
+    isIgnoreScrollbars: () => boolean;
+    isTranslateToScrollPosition: () => boolean;
     getPanDx: () => number;
     setPanDx: (dx: number) => void;
     getPanDy: () => number;
@@ -82,6 +102,39 @@ declare module '../AbstractGraph' {
      * @param dy Amount to shift the graph along the y-axis.
      */
     panGraph: (dx: number, dy: number) => void;
+
+    /**
+     * Scrolls the graph to the given point, extending the graph container if specified.
+     *
+     * If the container has no scrollbars and {@link isAllowAutoPanning} returns `true`, the graph is panned through the
+     * {@link PanningHandler} plugin instead of being scrolled.
+     *
+     * @param x horizontal coordinate to make visible.
+     * @param y vertical coordinate to make visible.
+     * @param extend Optional boolean that specifies if the graph container should be extended. Default is `false`.
+     * @param border Optional distance in pixels to keep between the point and the container edge. Default is `20`.
+     */
+    scrollPointToVisible: (
+      x: number,
+      y: number,
+      extend?: boolean,
+      border?: number
+    ) => void;
+
+    /**
+     * Centers the graph in the container.
+     *
+     * The scale is left unchanged, only the translation and the scroll position are updated. To fit the graph in the
+     * container, changing the scale, use the `fit` plugin instead.
+     *
+     * @param horizontal Optional boolean that specifies if the graph should be centered
+     * horizontally. Default is `true`.
+     * @param vertical Optional boolean that specifies if the graph should be centered
+     * vertically. Default is `true`.
+     * @param cx Optional float that specifies the horizontal center. Default is `0.5`.
+     * @param cy Optional float that specifies the vertical center. Default is `0.5`.
+     */
+    center: (horizontal?: boolean, vertical?: boolean, cx?: number, cy?: number) => void;
 
     /**
      * Pans the graph so that it shows the given cell. Optionally the cell may be centered in the container.


### PR DESCRIPTION
> [!NOTE]
> Stacked on top of #1131. The base of this PR is `refactor/group_and_test_per_instance_properties`, so the diff shown here contains only this step. Merge #1131 first, or let GitHub merge the stack.

Second implementation step of the plan recorded in ADR 0003 (#1130). No behavior change, and the public API is unchanged.

## Problem

`AbstractGraph` still holds members that belong to the panning concern. They all move the viewport without touching the scale, which is exactly what `PanningMixin` already does with `scrollCellToVisible` and `scrollRectToVisible`.

`PanningMixin.type.ts` even documents `scrollPointToVisible` as if the method already lived there, in the `timerAutoScroll` and `allowAutoPanning` descriptions.

## Changes

Moved into `PanningMixin`:

| Member | Why it belongs there |
|---|---|
| `scrollPointToVisible` | Reads `isTimerAutoScroll`, `isAllowAutoPanning`, `getPanDx`, `getPanDy` and the `PanningHandler` plugin, all owned by `PanningMixin` |
| `ignoreScrollbars`, `isIgnoreScrollbars` | Only consumers are `EventsMixin` and `scrollPointToVisible` |
| `translateToScrollPosition`, `isTranslateToScrollPosition` | Same |
| `center` | See below |

`AbstractGraph.ts` loses 156 lines.

## Why `center` lands here and not in `FitPlugin`

`FitPlugin` looks like the obvious target since it owns `fit` and `fitCenter`. It is the wrong one, and the name is what makes it look right.

- **`center` never touches `view.scale`.** It only calls `view.setTranslate` and sets `container.scrollLeft` / `scrollTop`. Scale is the dividing line in this codebase: `ZoomMixin` and `FitPlugin` own scale, `PanningMixin` owns translate and scroll offset. `FitPlugin.fit` computes a new scale and `fitCenter` applies `view.scaleAndTranslate`.
- **It is built exactly like `scrollRectToVisible`**, branching on `hasScrollbars(container)` and then handling two worlds: no scrollbars means adjust `view.translate`, scrollbars means adjust the scroll position. `FitPlugin` never reads or writes `scrollLeft` / `scrollTop` at all.
- **`fitCenter` and `center` answer different questions.** `fitCenter` centers as a consequence of fitting, deriving the translation from the newly computed scale. `center` centers at the current scale.

## One nuance for consumers

`isIgnoreScrollbars` and `isTranslateToScrollPosition` were arrow-function class properties, so they were bound to their instance and could be detached from the graph. They are now prototype methods, like every other mixin member.

`graph.isIgnoreScrollbars()` is unaffected. Only detached references break, for instance `someArray.some(graph.isIgnoreScrollbars)` or `const f = graph.isIgnoreScrollbars`, which now need an explicit `bind`.

This is recorded in the changelog under **Breaking Changes** rather than as a passing note, because TypeScript gives both forms the same type: a detached reference still compiles and fails only at runtime.

## Validation

Run locally on Node 24 (`.nvmrc`): `build`, `test-check`, the full suite (505 tests, 60 suites), `lint`, `check:circular-dependencies`. All passing, and no test needed changing, which is the expected signal for a pure relocation.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced graph panning with options to ignore scrollbars and translate directly to scroll positions.
  - Added support for centering graphs and bringing specific points into view, with optional borders and directional controls.

- **Breaking Changes**
  - Panning and centering controls are now provided through the graph’s panning capabilities.
  - Detached references to certain graph methods may require explicit binding or wrapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->