### PR TITLE
refactor(graph): move the cell, validation and overlay members to their mixins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ _**Note:** Yet to be released breaking changes appear here._
 - The dispatch methods `createHandler` and `createEdgeHandler` are now defined on `SelectionCellsHandler`. If you were overriding them to change the dispatch logic itself (and not only the instantiated class), extend `SelectionCellsHandler` and pass your subclass in the `plugins` option.
 - `SelectionCellsHandler.createHandler` returns a non-nullable `CellHandler` (the new `EdgeHandler | VertexHandler` union type exported from the package), whereas `AbstractGraph.createHandler` was typed as nullable. TypeScript users can drop the now-useless null checks on the returned value.
 
-- `AbstractGraph.isIgnoreScrollbars` and `AbstractGraph.isTranslateToScrollPosition` are now regular methods instead of arrow function properties, following the move of the scrolling members to `PanningMixin`.
+- `AbstractGraph.isIgnoreScrollbars`, `AbstractGraph.isTranslateToScrollPosition`, `AbstractGraph.isExportEnabled`, `AbstractGraph.isImportEnabled`, `AbstractGraph.getAlreadyConnectedResource` and `AbstractGraph.getContainsValidationErrorsResource` are now regular methods instead of arrow function properties, following the move of these members to the mixins that own them.
   Calling them on the graph is unaffected: `graph.isIgnoreScrollbars()` keeps working. Only detached references break, because the functions are no longer bound to their instance.
   If you pass one of them as a callback, for instance `someArray.some(graph.isIgnoreScrollbars)` or `const isIgnored = graph.isIgnoreScrollbars`, bind it explicitly with `graph.isIgnoreScrollbars.bind(graph)` or wrap it in an arrow function.
   Note that TypeScript does not report this, both forms have the same type, so the failure only appears at runtime.

--- a/packages/core/src/view/AbstractGraph.ts
+++ b/packages/core/src/view/AbstractGraph.ts
@@ -54,7 +54,6 @@ import type {
 import Multiplicity from './other/Multiplicity.js';
 import { applyGraphMixins } from './mixin/_graph-mixins-apply.js';
 import { isNullish } from '../internal/utils.js';
-import { isI18nEnabled } from '../internal/i18n-utils.js';
 import type TooltipHandler from './plugin/TooltipHandler.js';
 
 /**
@@ -188,14 +187,6 @@ export abstract class AbstractGraph extends EventSource {
   dialect: DialectValue = 'svg';
 
   /**
-   * Value returned by {@link getOverlap} if {@link isAllowOverlapParent} returns
-   * `true` for the given cell. {@link getOverlap} is used in {@link constrainChild} if
-   * {@link isConstrainChild} returns `true`. The value specifies the
-   * portion of the child which is allowed to overlap the parent.
-   */
-  defaultOverlap = 0.5;
-
-  /**
    * Specifies the default parent to be used to insert new cells.
    * This is used in {@link getDefaultParent}.
    * @default null
@@ -269,18 +260,6 @@ export abstract class AbstractGraph extends EventSource {
   enabled = true;
 
   /**
-   * Specifies the return value for {@link canExportCell}.
-   * @default true
-   */
-  exportEnabled = true;
-
-  /**
-   * Specifies the return value for {@link canImportCell}.
-   * @default true
-   */
-  importEnabled = true;
-
-  /**
    * {@link Rectangle} that specifies the area in which all cells in the diagram
    * should be placed. Uses in {@link getMaximumGraphBounds}. Use a width or height of
    * `0` if you only want to give a upper, left corner.
@@ -337,23 +316,11 @@ export abstract class AbstractGraph extends EventSource {
   keepEdgesInBackground = false;
 
   /**
-   * Specifies the return value for {@link isRecursiveResize}.
-   * @default false (for backwards compatibility)
-   */
-  recursiveResize = false;
-
-  /**
    * Specifies if the scale and translate should be reset if the root changes in
    * the model.
    * @default true
    */
   resetViewOnRootChange = true;
-
-  /**
-   * Specifies if loops (aka self-references) are allowed.
-   * @default false
-   */
-  allowLoops = false;
 
   /**
    * {@link EdgeStyle} to be used for loops.
@@ -362,31 +329,6 @@ export abstract class AbstractGraph extends EventSource {
    * @default {@link EdgeStyle.Loop}
    */
   defaultLoopStyle = EdgeStyle.Loop;
-
-  /**
-   * Specifies if multiple edges in the same direction between the same pair of
-   * vertices are allowed.
-   * @default true
-   */
-  multigraph = true;
-
-  /**
-   * Specifies the resource key for the error message to be displayed in
-   * non-multigraphs when two vertices are already connected. If the resource
-   * for this key does not exist then the value is used as the error message.
-   * @default 'alreadyConnected'
-   */
-  alreadyConnectedResource: string = isI18nEnabled() ? 'alreadyConnected' : '';
-
-  /**
-   * Specifies the resource key for the warning message to be displayed when
-   * a collapsed cell contains validation errors. If the resource for this
-   * key does not exist then the value is used as the warning message.
-   * @default 'containsValidationErrors'
-   */
-  containsValidationErrorsResource: string = isI18nEnabled()
-    ? 'containsValidationErrors'
-    : '';
 
   // ===================================================================================================================
   // Group: Main graph constructor and functions
@@ -455,8 +397,6 @@ export abstract class AbstractGraph extends EventSource {
   isPreferPageSize = () => this.preferPageSize;
   getPageFormat = () => this.pageFormat;
   getPageScale = () => this.pageScale;
-  isExportEnabled = () => this.exportEnabled;
-  isImportEnabled = () => this.importEnabled;
 
   getMinimumGraphSize = () => this.minimumGraphSize;
   setMinimumGraphSize = (size: Rectangle | null) => (this.minimumGraphSize = size);
@@ -464,14 +404,6 @@ export abstract class AbstractGraph extends EventSource {
   getMinimumContainerSize = () => this.minimumContainerSize;
   setMinimumContainerSize = (size: Rectangle | null) =>
     (this.minimumContainerSize = size);
-
-  getWarningImage() {
-    return this.warningImage;
-  }
-
-  getAlreadyConnectedResource = () => this.alreadyConnectedResource;
-
-  getContainsValidationErrorsResource = () => this.containsValidationErrorsResource;
 
   setTooltips(enabled: boolean): void {
     const tooltipHandler = this.getPlugin<TooltipHandler>('TooltipHandler');
@@ -943,82 +875,6 @@ export abstract class AbstractGraph extends EventSource {
    */
   setEnabled(value: boolean) {
     this.enabled = value;
-  }
-
-  /**
-   * Returns {@link multigraph} as a boolean.
-   */
-  isMultigraph() {
-    return this.multigraph;
-  }
-
-  /**
-   * Specifies if the graph should allow multiple connections between the
-   * same pair of vertices.
-   *
-   * @param value Boolean indicating if the graph allows multiple connections
-   * between the same pair of vertices.
-   */
-  setMultigraph(value: boolean) {
-    this.multigraph = value;
-  }
-
-  /**
-   * Returns {@link allowLoops} as a boolean.
-   */
-  isAllowLoops() {
-    return this.allowLoops;
-  }
-
-  /**
-   * Specifies if loops are allowed.
-   *
-   * @param value Boolean indicating if loops are allowed.
-   */
-  setAllowLoops(value: boolean) {
-    this.allowLoops = value;
-  }
-
-  /**
-   * Returns {@link recursiveResize}.
-   *
-   * @param state {@link CellState} that is being resized.
-   */
-  isRecursiveResize(state: CellState | null = null) {
-    return this.recursiveResize;
-  }
-
-  /**
-   * Sets {@link recursiveResize}.
-   *
-   * @param value New boolean value for {@link recursiveResize}.
-   */
-  setRecursiveResize(value: boolean) {
-    this.recursiveResize = value;
-  }
-
-  /**
-   * Returns a decimal number representing the amount of the width and height
-   * of the given cell that is allowed to overlap its parent. A value of 0
-   * means all children must stay inside the parent, 1 means the child is
-   * allowed to be placed outside of the parent such that it touches one of
-   * the parents sides. If {@link isAllowOverlapParent} returns false for the given
-   * cell, then this method returns 0.
-   *
-   * @param cell {@link Cell} for which the overlap ratio should be returned.
-   */
-  getOverlap(cell: Cell) {
-    return this.isAllowOverlapParent(cell) ? this.defaultOverlap : 0;
-  }
-
-  /**
-   * Returns true if the given cell is allowed to be placed outside the
-   * parents area.
-   *
-   * @param cell {@link Cell} that represents the child to be checked.
-   */
-  isAllowOverlapParent(cell: Cell): boolean {
-    return false;
   }
 
   /*****************************************************************************

--- a/packages/core/src/view/mixin/CellsMixin.ts
+++ b/packages/core/src/view/mixin/CellsMixin.ts
@@ -49,12 +49,8 @@ type PartialGraph = Pick<
   | 'fireEvent'
   | 'getDefaultParent'
   | 'getCurrentRoot'
-  | 'getOverlap'
-  | 'isRecursiveResize'
   | 'getCellRenderer'
   | 'getMaximumGraphBounds'
-  | 'isExportEnabled'
-  | 'isImportEnabled'
   | 'getPlugin'
   | 'getSelectionCells'
   | 'getSelectionCell'
@@ -85,6 +81,16 @@ type PartialGraph = Pick<
 
 type PartialCells = Pick<
   AbstractGraph,
+  | 'defaultOverlap'
+  | 'exportEnabled'
+  | 'importEnabled'
+  | 'recursiveResize'
+  | 'getOverlap'
+  | 'isAllowOverlapParent'
+  | 'isExportEnabled'
+  | 'isImportEnabled'
+  | 'isRecursiveResize'
+  | 'setRecursiveResize'
   | 'cellsResizable'
   | 'cellsBendable'
   | 'cellsSelectable'
@@ -190,6 +196,38 @@ type PartialType = PartialGraph & PartialCells;
 
 // @ts-expect-error The properties of PartialGraph are defined elsewhere.
 export const CellsMixin: PartialType = {
+  defaultOverlap: 0.5,
+
+  getOverlap(cell) {
+    return this.isAllowOverlapParent(cell) ? this.defaultOverlap : 0;
+  },
+
+  isAllowOverlapParent(_cell) {
+    return false;
+  },
+
+  exportEnabled: true,
+
+  isExportEnabled() {
+    return this.exportEnabled;
+  },
+
+  importEnabled: true,
+
+  isImportEnabled() {
+    return this.importEnabled;
+  },
+
+  recursiveResize: false,
+
+  isRecursiveResize(_state = null) {
+    return this.recursiveResize;
+  },
+
+  setRecursiveResize(value) {
+    this.recursiveResize = value;
+  },
+
   cellsResizable: true,
 
   cellsBendable: true,

--- a/packages/core/src/view/mixin/CellsMixin.type.ts
+++ b/packages/core/src/view/mixin/CellsMixin.type.ts
@@ -29,6 +29,73 @@ import type CellState from '../cell/CellState.js';
 declare module '../AbstractGraph' {
   interface AbstractGraph {
     /**
+     * Value returned by {@link getOverlap} if {@link isAllowOverlapParent} returns
+     * `true` for the given cell. {@link getOverlap} is used in {@link constrainChild} if
+     * {@link isConstrainChild} returns `true`. The value specifies the
+     * portion of the child which is allowed to overlap the parent.
+     * @default 0.5
+     */
+    defaultOverlap: number;
+
+    /**
+     * Specifies the return value for {@link canExportCell}.
+     * @default true
+     */
+    exportEnabled: boolean;
+
+    /**
+     * Specifies the return value for {@link canImportCell}.
+     * @default true
+     */
+    importEnabled: boolean;
+
+    /**
+     * Specifies the return value for {@link isRecursiveResize}.
+     * @default false (for backwards compatibility)
+     */
+    recursiveResize: boolean;
+
+    /**
+     * Returns a decimal number representing the amount of the width and height
+     * of the given cell that is allowed to overlap its parent. A value of 0
+     * means all children must stay inside the parent, 1 means the child is
+     * allowed to be placed outside of the parent such that it touches one of
+     * the parents sides. If {@link isAllowOverlapParent} returns false for the given
+     * cell, then this method returns 0.
+     *
+     * @param cell {@link Cell} for which the overlap ratio should be returned.
+     */
+    getOverlap: (cell: Cell) => number;
+
+    /**
+     * Returns true if the given cell is allowed to be placed outside the
+     * parents area.
+     *
+     * @param cell {@link Cell} that represents the child to be checked.
+     */
+    isAllowOverlapParent: (cell: Cell) => boolean;
+
+    /** Returns {@link exportEnabled}. */
+    isExportEnabled: () => boolean;
+
+    /** Returns {@link importEnabled}. */
+    isImportEnabled: () => boolean;
+
+    /**
+     * Returns {@link recursiveResize}.
+     *
+     * @param state {@link CellState} that is being resized.
+     */
+    isRecursiveResize: (state?: CellState | null) => boolean;
+
+    /**
+     * Sets {@link recursiveResize}.
+     *
+     * @param value New boolean value for {@link recursiveResize}.
+     */
+    setRecursiveResize: (value: boolean) => void;
+
+    /**
      * Specifies the return value for {@link isCellsResizable}.
      * @default true
      */

--- a/packages/core/src/view/mixin/OverlaysMixin.ts
+++ b/packages/core/src/view/mixin/OverlaysMixin.ts
@@ -26,7 +26,7 @@ type PartialGraph = Pick<
   | 'fireEvent'
   | 'getDataModel'
   | 'isEnabled'
-  | 'getWarningImage'
+  | 'warningImage'
   | 'getCellRenderer'
   | 'setSelectionCell'
 >;
@@ -38,11 +38,16 @@ type PartialOverlays = Pick<
   | 'removeCellOverlays'
   | 'clearCellOverlays'
   | 'setCellWarning'
+  | 'getWarningImage'
 >;
 type PartialType = PartialGraph & PartialOverlays;
 
 // @ts-expect-error The properties of PartialGraph are defined elsewhere.
 export const OverlaysMixin: PartialType = {
+  getWarningImage() {
+    return this.warningImage;
+  },
+
   addCellOverlay(cell, overlay) {
     cell.overlays.push(overlay);
 

--- a/packages/core/src/view/mixin/OverlaysMixin.type.ts
+++ b/packages/core/src/view/mixin/OverlaysMixin.type.ts
@@ -20,6 +20,9 @@ import type Image from '../image/ImageBox.js';
 
 declare module '../AbstractGraph' {
   interface AbstractGraph {
+    /** Returns the {@link warningImage} used by {@link setCellWarning}. */
+    getWarningImage: () => Image;
+
     /**
      * Adds an {@link CellOverlay} for the specified cell.
      *

--- a/packages/core/src/view/mixin/ValidationMixin.ts
+++ b/packages/core/src/view/mixin/ValidationMixin.ts
@@ -17,18 +17,14 @@ limitations under the License.
 import type Cell from '../cell/Cell.js';
 import { isNode } from '../../util/domUtils.js';
 import type { AbstractGraph } from '../AbstractGraph.js';
-import { translate } from '../../internal/i18n-utils.js';
+import { isI18nEnabled, translate } from '../../internal/i18n-utils.js';
 import { isNullish } from '../../internal/utils.js';
 
 type PartialGraph = Pick<
   AbstractGraph,
   | 'getDataModel'
-  | 'isAllowLoops'
-  | 'isMultigraph'
   | 'getView'
   | 'isValidRoot'
-  | 'getContainsValidationErrorsResource'
-  | 'getAlreadyConnectedResource'
   | 'isAllowDanglingEdges'
   | 'isValidConnection'
   | 'setCellWarning'
@@ -36,6 +32,16 @@ type PartialGraph = Pick<
 type PartialValidation = Pick<
   AbstractGraph,
   | 'multiplicities'
+  | 'multigraph'
+  | 'allowLoops'
+  | 'alreadyConnectedResource'
+  | 'containsValidationErrorsResource'
+  | 'isMultigraph'
+  | 'setMultigraph'
+  | 'isAllowLoops'
+  | 'setAllowLoops'
+  | 'getAlreadyConnectedResource'
+  | 'getContainsValidationErrorsResource'
   | 'validationAlert'
   | 'isEdgeValid'
   | 'getEdgeValidationError'
@@ -48,6 +54,38 @@ type PartialType = PartialGraph & PartialValidation;
 
 // @ts-expect-error The properties of PartialGraph are defined elsewhere.
 export const ValidationMixin: PartialType = {
+  multigraph: true,
+
+  isMultigraph() {
+    return this.multigraph;
+  },
+
+  setMultigraph(value) {
+    this.multigraph = value;
+  },
+
+  allowLoops: false,
+
+  isAllowLoops() {
+    return this.allowLoops;
+  },
+
+  setAllowLoops(value) {
+    this.allowLoops = value;
+  },
+
+  alreadyConnectedResource: isI18nEnabled() ? 'alreadyConnected' : '',
+
+  getAlreadyConnectedResource() {
+    return this.alreadyConnectedResource;
+  },
+
+  containsValidationErrorsResource: isI18nEnabled() ? 'containsValidationErrors' : '',
+
+  getContainsValidationErrorsResource() {
+    return this.containsValidationErrorsResource;
+  },
+
   validationAlert(message: string) {
     alert(message);
   },

--- a/packages/core/src/view/mixin/ValidationMixin.type.ts
+++ b/packages/core/src/view/mixin/ValidationMixin.type.ts
@@ -20,6 +20,63 @@ import type CellState from '../cell/CellState.js';
 declare module '../AbstractGraph' {
   interface AbstractGraph {
     /**
+     * Specifies if multiple edges in the same direction between the same pair of
+     * vertices are allowed.
+     * @default true
+     */
+    multigraph: boolean;
+
+    /**
+     * Specifies if loops (aka self-references) are allowed.
+     * @default false
+     */
+    allowLoops: boolean;
+
+    /**
+     * Specifies the resource key for the error message to be displayed in
+     * non-multigraphs when two vertices are already connected. If the resource
+     * for this key does not exist then the value is used as the error message.
+     * @default 'alreadyConnected'
+     */
+    alreadyConnectedResource: string;
+
+    /**
+     * Specifies the resource key for the warning message to be displayed when
+     * a collapsed cell contains validation errors. If the resource for this
+     * key does not exist then the value is used as the warning message.
+     * @default 'containsValidationErrors'
+     */
+    containsValidationErrorsResource: string;
+
+    /** Returns {@link multigraph} as a boolean. */
+    isMultigraph: () => boolean;
+
+    /**
+     * Specifies if the graph should allow multiple connections between the
+     * same pair of vertices.
+     *
+     * @param value Boolean indicating if the graph allows multiple connections
+     * between the same pair of vertices.
+     */
+    setMultigraph: (value: boolean) => void;
+
+    /** Returns {@link allowLoops} as a boolean. */
+    isAllowLoops: () => boolean;
+
+    /**
+     * Specifies if loops are allowed.
+     *
+     * @param value Boolean indicating if loops are allowed.
+     */
+    setAllowLoops: (value: boolean) => void;
+
+    /** Returns {@link alreadyConnectedResource}. */
+    getAlreadyConnectedResource: () => string;
+
+    /** Returns {@link containsValidationErrorsResource}. */
+    getContainsValidationErrorsResource: () => string;
+
+    /**
      * Displays the given validation error in a dialog.
      *
      * This implementation uses `window.alert`.


### PR DESCRIPTION
> [!NOTE]
> Stacked on top of #1132, which is itself stacked on #1131. The base of this PR is `refactor/move_viewport_translation_to_panning_mixin`, so the diff shown here contains only this step.

Third implementation step of the plan recorded in ADR 0003 (#1130). No behavior change, and the public API is unchanged.

## Problem

`AbstractGraph` holds members whose only consumers live in an existing mixin. Each of them forces that mixin to declare the member as an external dependency in its `Pick<AbstractGraph, ...>` list, which makes the list describe the class rather than the concern.

## Changes

| Target | Members | Only internal callers |
|---|---|---|
| `CellsMixin` | `defaultOverlap`, `getOverlap`, `isAllowOverlapParent`, `exportEnabled`, `isExportEnabled`, `importEnabled`, `isImportEnabled`, `recursiveResize`, `isRecursiveResize`, `setRecursiveResize` | `resizeCells`, `canExportCell`, `canImportCell`, `constrainChild` |
| `ValidationMixin` | `multigraph`, `isMultigraph`, `setMultigraph`, `allowLoops`, `isAllowLoops`, `setAllowLoops`, `alreadyConnectedResource`, `containsValidationErrorsResource` and their getters | `getEdgeValidationError`, `validateCell` |
| `OverlaysMixin` | `getWarningImage` | `setCellWarning` |

The dependency lists shrink accordingly: `CellsMixin` stops declaring `getOverlap`, `isRecursiveResize`, `isExportEnabled` and `isImportEnabled` as external, and `ValidationMixin` stops declaring `isAllowLoops`, `isMultigraph` and the two resource getters.

`AbstractGraph.ts` loses 143 lines and its last use of `isI18nEnabled`.

## One deliberate asymmetry

`getWarningImage` moves to `OverlaysMixin` but **`warningImage` stays in `AbstractGraph`**, in the per-instance group introduced in #1131. Its default is a mutable `Image`, so installing it on the prototype would share one instance across every graph, which is the failure mode the tests in #1131 now guard against.

The getter and its property are therefore split on purpose. They will be reunited when `OverlaysMixin` becomes a plugin, since plugins are instantiated per graph and the constraint disappears. This is step 6 of the ADR plan.

## API note

Four of the moved accessors were arrow function properties and become prototype methods: `isExportEnabled`, `isImportEnabled`, `getAlreadyConnectedResource` and `getContainsValidationErrorsResource`.

Calling them on the graph is unaffected. Only detached references break, and TypeScript will not report it since both forms share the same type. The changelog entry introduced in #1132 for the scrollbar getters is extended to cover these four.

## Validation

Run locally on Node 24 (`.nvmrc`): `build`, `test-check`, the full suite (505 tests, 60 suites), `lint`, `check:circular-dependencies`. All passing, and no test needed changing, which is the expected signal for a pure relocation.
