### PR TITLE
refactor(graph): move the drill-down members to GroupingMixin

### DIFF
--- a/packages/core/src/view/AbstractGraph.ts
+++ b/packages/core/src/view/AbstractGraph.ts
@@ -25,7 +25,6 @@ import Client from '../Client.js';
 import type PanningHandler from './plugin/PanningHandler.js';
 import GraphView from './GraphView.js';
 import CellRenderer from './cell/CellRenderer.js';
-import Point from './geometry/Point.js';
 import { getCurrentStyle, parseCssNumber } from '../util/styleUtils.js';
 import Cell from './cell/Cell.js';
 import GraphDataModel from './GraphDataModel.js';
@@ -250,13 +249,6 @@ export abstract class AbstractGraph extends EventSource {
    * @default 0
    */
   border = 0;
-
-  /**
-   * Specifies if the scale and translate should be reset if the root changes in
-   * the model.
-   * @default true
-   */
-  resetViewOnRootChange = true;
 
   /**
    * {@link EdgeStyle} to be used for loops.
@@ -522,88 +514,6 @@ export abstract class AbstractGraph extends EventSource {
   /*****************************************************************************
    * Group: Drill down
    *****************************************************************************/
-
-  /**
-   * Returns the current root of the displayed cell hierarchy. This is a
-   * shortcut to {@link GraphView.currentRoot} in {@link GraphView}.
-   */
-  getCurrentRoot() {
-    return this.view.currentRoot;
-  }
-
-  /**
-   * Returns the translation to be used if the given cell is the root cell as
-   * an {@link Point}. This implementation returns null.
-   *
-   * To keep the children at their absolute position while stepping into groups,
-   * this function can be overridden as follows.
-   *
-   * @example
-   * ```javascript
-   * var offset = new mxPoint(0, 0);
-   *
-   * while (cell != null)
-   * {
-   *   var geo = this.model.getGeometry(cell);
-   *
-   *   if (geo != null)
-   *   {
-   *     offset.x -= geo.x;
-   *     offset.y -= geo.y;
-   *   }
-   *
-   *   cell = this.model.getParent(cell);
-   * }
-   *
-   * return offset;
-   * ```
-   *
-   * @param cell {@link Cell} that represents the root.
-   */
-  getTranslateForRoot(cell: Cell | null): Point | null {
-    return null;
-  }
-
-  /**
-   * Returns the offset to be used for the cells inside the given cell. The
-   * root and layer cells may be identified using {@link GraphDataModel.isRoot} and
-   * {@link GraphDataModel.isLayer}. For all other current roots, the
-   * {@link GraphView.currentRoot} field points to the respective cell, so that
-   * the following holds: cell == this.view.currentRoot. This implementation
-   * returns null.
-   *
-   * @param cell {@link Cell} whose offset should be returned.
-   */
-  getChildOffsetForCell(cell: Cell): Point | null {
-    return null;
-  }
-
-  /**
-   * Uses the root of the model as the root of the displayed cell hierarchy
-   * and selects the previous root.
-   */
-  home() {
-    const current = this.getCurrentRoot();
-
-    if (current != null) {
-      this.view.setCurrentRoot(null);
-      const state = this.view.getState(current);
-
-      if (state != null) {
-        this.setSelectionCell(current);
-      }
-    }
-  }
-
-  /**
-   * Returns true if the given cell is a valid root for the cell display
-   * hierarchy. This implementation returns true for all non-null values.
-   *
-   * @param cell {@link Cell} which should be checked as a possible root.
-   */
-  isValidRoot(cell: Cell) {
-    return !!cell;
-  }
 
   /*****************************************************************************
    * Group: Graph display

--- a/packages/core/src/view/mixin/GroupingMixin.ts
+++ b/packages/core/src/view/mixin/GroupingMixin.ts
@@ -30,8 +30,6 @@ type PartialGraph = Pick<
   | 'getView'
   | 'getDefaultParent'
   | 'batchUpdate'
-  | 'isValidRoot'
-  | 'getCurrentRoot'
   | 'cellsAdded'
   | 'cellsMoved'
   | 'cellsResized'
@@ -50,6 +48,12 @@ type PartialGraph = Pick<
 >;
 type PartialGrouping = Pick<
   AbstractGraph,
+  | 'resetViewOnRootChange'
+  | 'getCurrentRoot'
+  | 'getTranslateForRoot'
+  | 'getChildOffsetForCell'
+  | 'home'
+  | 'isValidRoot'
   | 'groupCells'
   | 'getCellsForGroup'
   | 'getBoundsForGroup'
@@ -66,6 +70,37 @@ type PartialType = PartialGraph & PartialGrouping;
 
 // @ts-expect-error The properties of PartialGraph are defined elsewhere.
 export const GroupingMixin: PartialType = {
+  resetViewOnRootChange: true,
+
+  getCurrentRoot() {
+    return this.getView().currentRoot;
+  },
+
+  getTranslateForRoot(_cell) {
+    return null;
+  },
+
+  getChildOffsetForCell(_cell) {
+    return null;
+  },
+
+  home() {
+    const current = this.getCurrentRoot();
+
+    if (current != null) {
+      this.getView().setCurrentRoot(null);
+      const state = this.getView().getState(current);
+
+      if (state != null) {
+        this.setSelectionCell(current);
+      }
+    }
+  },
+
+  isValidRoot(cell) {
+    return !!cell;
+  },
+
   groupCells(group, border = 0, cells) {
     if (!cells) cells = sortCells(this.getSelectionCells(), true);
     if (!cells) cells = this.getCellsForGroup(cells);

--- a/packages/core/src/view/mixin/GroupingMixin.type.ts
+++ b/packages/core/src/view/mixin/GroupingMixin.type.ts
@@ -15,10 +15,81 @@ limitations under the License.
 */
 
 import type Cell from '../cell/Cell.js';
+import type Point from '../geometry/Point.js';
 import type Rectangle from '../geometry/Rectangle.js';
 
 declare module '../AbstractGraph' {
   interface AbstractGraph {
+    /**
+     * Specifies if the scale and translate should be reset if the root changes in
+     * the model.
+     * @default true
+     */
+    resetViewOnRootChange: boolean;
+
+    /**
+     * Returns the current root of the displayed cell hierarchy. This is a
+     * shortcut to {@link GraphView.currentRoot} in {@link GraphView}.
+     */
+    getCurrentRoot: () => Cell | null;
+
+    /**
+     * Returns the translation to be used if the given cell is the root cell as
+     * an {@link Point}. This implementation returns null.
+     *
+     * To keep the children at their absolute position while stepping into groups,
+     * this function can be overridden as follows.
+     *
+     * @example
+     * ```javascript
+     * var offset = new mxPoint(0, 0);
+     *
+     * while (cell != null)
+     * {
+     *   var geo = this.model.getGeometry(cell);
+     *
+     *   if (geo != null)
+     *   {
+     *     offset.x -= geo.x;
+     *     offset.y -= geo.y;
+     *   }
+     *
+     *   cell = this.model.getParent(cell);
+     * }
+     *
+     * return offset;
+     * ```
+     *
+     * @param cell {@link Cell} that represents the root.
+     */
+    getTranslateForRoot: (cell: Cell | null) => Point | null;
+
+    /**
+     * Returns the offset to be used for the cells inside the given cell. The
+     * root and layer cells may be identified using {@link GraphDataModel.isRoot} and
+     * {@link GraphDataModel.isLayer}. For all other current roots, the
+     * {@link GraphView.currentRoot} field points to the respective cell, so that
+     * the following holds: cell == this.view.currentRoot. This implementation
+     * returns null.
+     *
+     * @param cell {@link Cell} whose offset should be returned.
+     */
+    getChildOffsetForCell: (cell: Cell) => Point | null;
+
+    /**
+     * Uses the root of the model as the root of the displayed cell hierarchy
+     * and selects the previous root.
+     */
+    home: () => void;
+
+    /**
+     * Returns true if the given cell is a valid root for the cell display
+     * hierarchy. This implementation returns true for all non-null values.
+     *
+     * @param cell {@link Cell} which should be checked as a possible root.
+     */
+    isValidRoot: (cell: Cell) => boolean;
+
     /**
      * Adds the cells into the given group.
      * The change is carried out using {@link cellsAdded}, {@link cellsMoved} and {@link cellsResized}.


### PR DESCRIPTION
> [!NOTE]
> Last PR of the stack: #1131 → #1132 → #1134 → #1135 → this one. The base is `refactor/move_label_order_page_members_to_mixins`, so the diff shown here contains only this step.

Fifth and final implementation step of the plan recorded in ADR 0003 (#1130). No behavior change, and the public API is unchanged.

## Changes

Moved to `GroupingMixin`: `resetViewOnRootChange`, `getCurrentRoot`, `getTranslateForRoot`, `getChildOffsetForCell`, `home` and `isValidRoot`.

`GroupingMixin` already owns `enterGroup` and `exitGroup`, the two entry points of drill-down navigation, and it already had to declare `isValidRoot` and `getCurrentRoot` as external dependencies in order to implement them. Both now disappear from its dependency list.

`AbstractGraph` keeps calling `home` and `resetViewOnRootChange` from `processChange`, and `getCurrentRoot` from `getDefaultParent`. Declaration merging supports this without any change at the call sites.

`AbstractGraph.ts` loses 89 lines and its last use of `Point`.

## What stays behind, deliberately

`defaultParent`, `getDefaultParent` and `setDefaultParent` are **not** moved, although they belong to the same topic. They are the most used entry point of the whole API and are read from `processChange`, so the cohesion gain does not justify the churn. This is recorded in Appendix B.2 of the ADR.

## A caveat worth recording

Drill-down is view navigation, while grouping is model restructuring. They are two concerns sharing a file because no better home exists under the current rules, not because they belong together.

When `GroupingMixin` is converted to a plugin, the split should be reconsidered rather than carried over. The commit message records this so it does not get lost.

## Result of the whole plan

`AbstractGraph.ts` goes from **1337 to 811 lines** across the five PRs of the stack, with no breaking change other than the accessor binding note already in the changelog.

What remains in the class is what Appendix C of the ADR says should remain: the bootstrap contract, the collaborators, the plugin registry, the model-to-view dispatch, the lifecycle, and the properties parked by the shared-state constraint until their host mixin becomes a plugin.

## Validation

Run locally on Node 24 (`.nvmrc`): `build`, `test-check`, the full suite (505 tests, 60 suites), `lint`, `check:circular-dependencies`. All passing, and no test needed changing.
