### PR TITLE
fix(graph): honor the constrain and extend parameters of cellsAdded

### DIFF
--- a/packages/core/__tests__/utils.ts
+++ b/packages/core/__tests__/utils.ts
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { expect } from '@jest/globals';
 import { Cell, type CellStateStyle, Graph } from '../src';
 
 /**
@@ -35,4 +36,23 @@ export const createCellWithStyle = (style: CellStateStyle): Cell => {
   const cell = new Cell();
   cell.style = style;
   return cell;
+};
+
+/**
+ * Checks the bounds of the {@link Geometry} of the given {@link Cell}.
+ *
+ * Compare all bounds at once, so that a failure reports the whole geometry instead of the first
+ * property that differs.
+ */
+export const expectGeometryBounds = (
+  cell: Cell,
+  expected: { x: number; y: number; width: number; height: number }
+): void => {
+  const geometry = cell.getGeometry();
+  expect({
+    x: geometry?.x,
+    y: geometry?.y,
+    width: geometry?.width,
+    height: geometry?.height,
+  }).toStrictEqual(expected);
 };

--- a/packages/core/__tests__/view/mixin/CellsMixin.test.ts
+++ b/packages/core/__tests__/view/mixin/CellsMixin.test.ts
@@ -15,7 +15,11 @@ limitations under the License.
 */
 
 import { describe, expect, test } from '@jest/globals';
-import { createCellWithStyle, createGraphWithoutPlugins } from '../../utils';
+import {
+  createCellWithStyle,
+  createGraphWithoutPlugins,
+  expectGeometryBounds,
+} from '../../utils';
 import {
   BaseGraph,
   Cell,
@@ -465,6 +469,87 @@ describe('postProcessCellStyle', () => {
       const result = graph.postProcessCellStyle(style);
 
       expect(result.image).toBe('http://first.example/img.png');
+    });
+  });
+});
+
+// https://github.com/maxGraph/maxGraph/issues/1045
+describe('cellsAdded', () => {
+  const parentBounds = { x: 0, y: 0, width: 100, height: 100 };
+
+  /**
+   * Creates a graph with a `100x100` parent vertex and a child vertex that is not in the parent yet.
+   * The caller adds the child to the parent with the `constrain` and `extend` values under test.
+   */
+  const createGraphWithVertices = (childBounds: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }) => {
+    const graph = createGraphWithoutPlugins();
+    const parent = graph.insertVertex({
+      value: 'parent',
+      position: [parentBounds.x, parentBounds.y],
+      size: [parentBounds.width, parentBounds.height],
+    });
+    const child = graph.insertVertex({
+      value: 'child',
+      position: [childBounds.x, childBounds.y],
+      size: [childBounds.width, childBounds.height],
+    });
+    const addChildToParent = (constrain?: boolean, extend?: boolean): void => {
+      graph.cellsAdded(
+        [child],
+        parent,
+        parent.getChildCount(),
+        null,
+        null,
+        false,
+        constrain,
+        extend
+      );
+    };
+    return { graph, parent, child, addChildToParent };
+  };
+
+  describe('constrain', () => {
+    // A child at negative coordinates fits in the parent bounds, so `extendParent` never triggers and
+    // only `constrainChild` can change the child geometry.
+    const childBounds = { x: -50, y: -50, width: 80, height: 40 };
+    const constrainedBounds = { ...childBounds, x: 0, y: 0 };
+
+    test.each([
+      ['not set, defaults to true', undefined, constrainedBounds],
+      ['true', true, constrainedBounds],
+      ['false', false, childBounds],
+    ])('%s', (_title, constrain, expectedChildBounds) => {
+      const { parent, child, addChildToParent } = createGraphWithVertices(childBounds);
+
+      addChildToParent(constrain);
+
+      expectGeometryBounds(child, expectedChildBounds);
+      expectGeometryBounds(parent, parentBounds);
+    });
+  });
+
+  describe('extend', () => {
+    // A child larger than the parent triggers `extendParent`. `constrain` is always disabled here, as
+    // `constrainChild` runs after `extendParent` and would otherwise hide its effect.
+    const childBounds = { x: 50, y: 50, width: 200, height: 200 };
+    const extendedParentBounds = { ...parentBounds, width: 250, height: 250 };
+
+    test.each([
+      ['not set, defaults to true', undefined, extendedParentBounds],
+      ['true', true, extendedParentBounds],
+      ['false', false, parentBounds],
+    ])('%s', (_title, extend, expectedParentBounds) => {
+      const { parent, child, addChildToParent } = createGraphWithVertices(childBounds);
+
+      addChildToParent(false, extend);
+
+      expectGeometryBounds(parent, expectedParentBounds);
+      expectGeometryBounds(child, childBounds);
     });
   });
 });

--- a/packages/core/__tests__/view/mixin/GroupingMixin.test.ts
+++ b/packages/core/__tests__/view/mixin/GroupingMixin.test.ts
@@ -1,0 +1,56 @@
+/*
+Copyright 2026-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, expect, test } from '@jest/globals';
+import { createGraphWithoutPlugins, expectGeometryBounds } from '../../utils';
+import type { Cell, Graph } from '../../../src';
+
+const childSize = { width: 80, height: 40 };
+
+const insertChildren = (graph: Graph, x: number, y: number): [Cell, Cell] => [
+  graph.insertVertex({
+    value: 'A',
+    position: [x, y],
+    size: [childSize.width, childSize.height],
+  }),
+  graph.insertVertex({
+    value: 'B',
+    position: [x + 100, y + 100],
+    size: [childSize.width, childSize.height],
+  }),
+];
+
+describe('groupCells', () => {
+  // The children are moved to be relative to the group, so they are always expected at the same
+  // coordinates whatever the coordinates they had in their former parent.
+  test.each([
+    ['positive coordinates', 200, 200],
+    // https://github.com/maxGraph/maxGraph/issues/1045
+    ['negative coordinates', -200, -200],
+  ])('children keep their geometry when they are at %s', (_title, x, y) => {
+    const graph = createGraphWithoutPlugins();
+    const [child1, child2] = insertChildren(graph, x, y);
+    // Same group as the one created by groupCells when no group is passed, but the type of the
+    // parameter does not allow null, contrary to what its documentation states.
+    const cells = [child1, child2];
+
+    const group = graph.groupCells(graph.createGroupCell(cells), 0, cells);
+
+    expect(group.getChildCount()).toBe(2);
+    expectGeometryBounds(child1, { x: 0, y: 0, ...childSize });
+    expectGeometryBounds(child2, { x: 100, y: 100, ...childSize });
+  });
+});

--- a/packages/core/src/view/mixin/CellsMixin.ts
+++ b/packages/core/src/view/mixin/CellsMixin.ts
@@ -618,7 +618,7 @@ export const CellsMixin: PartialType = {
     source = null,
     target = null,
     absolute = false,
-    constrain = false,
+    constrain = true,
     extend = true
   ) {
     this.batchUpdate(() => {
@@ -671,16 +671,12 @@ export const CellsMixin: PartialType = {
         }
 
         // Extends the parent or constrains the child
-        if (
-          (!extend || extend) &&
-          this.isExtendParentsOnAdd(cell) &&
-          this.isExtendParent(cell)
-        ) {
+        if (extend && this.isExtendParentsOnAdd(cell) && this.isExtendParent(cell)) {
           this.extendParent(cell);
         }
 
         // Additionally constrains the child after extending the parent
-        if (!constrain || constrain) {
+        if (constrain) {
           this.constrainChild(cell);
         }
 

--- a/packages/core/src/view/mixin/CellsMixin.type.ts
+++ b/packages/core/src/view/mixin/CellsMixin.type.ts
@@ -335,6 +335,15 @@ declare module '../AbstractGraph' {
     /**
      * Adds the specified cells to the given parent. This method fires
      * {@link Event#CELLS_ADDED} while the transaction is in progress.
+     *
+     * @param cells Array of {@link Cell}s to be added.
+     * @param parent {@link Cell} that represents the new parent.
+     * @param index Index to insert the cells at.
+     * @param source Source {@link Cell} for all added cells, or `null` to not connect them.
+     * @param target Target {@link Cell} for all added cells, or `null` to not connect them.
+     * @param absolute Boolean indicating if the cells should be kept at their absolute position.
+     * @param constrain Optional boolean indicating if {@link constrainChild} should be called for each added cell. Default is `true`.
+     * @param extend Optional boolean indicating if {@link extendParent} should be called for each added cell. Only applies when {@link isExtendParentsOnAdd} and {@link isExtendParent} are enabled. Default is `true`.
      */
     cellsAdded: (
       cells: Cell[],


### PR DESCRIPTION
## Problem

Closes #1045, reported and analyzed by @Dario638.

`cellsAdded` ignored its `constrain` and `extend` parameters. As spotted in the issue, the guards introduced during the TypeScript migration are always true whatever the value of the parameters:

```ts
if ((!extend || extend) && this.isExtendParentsOnAdd(cell) && this.isExtendParent(cell)) { ... }
if (!constrain || constrain) { ... }
```

`groupCells` is the only caller passing an explicit `false` for both, so it was the only one affected: for children located at **negative coordinates**, `extendParent` does not trigger, and `constrainChild` clamps them into the initial 0x0 area of the group, destroying their size and position.

```ts
const v1 = graph.insertVertex({ value: 'A', position: [-200, -200], size: [80, 40] });
const v2 = graph.insertVertex({ value: 'B', position: [-100, -100], size: [80, 40] });
graph.groupCells(null, 0, [v1, v2]);
// before: both children end up at x=180 y=140 with width=0 and height=0
// after:  A is at 0,0 and B at 100,100, both keep their 80x40 size
```

There is a second half to the regression, found by comparing with `mxGraph`. `mxGraph` declares no default values, the defaulting is done by the guards themselves:

```js
if ((extend == null || extend) && ...)   // omitted means true
if (constrain == null || constrain)      // omitted means true
```

The migration moved the defaulting into the signature and set `constrain = false`, the opposite of the `mxGraph` behavior. That mistake was invisible because the always-true guard made `constrainChild` run anyway. All the other defaults of the method were checked against `mxGraph` and are correct.

## Changes

- restore the two guards to plain boolean checks, as `cellsMoved` already does
- restore `constrain` to `true` in the signature, so that fixing the guards does not silently disable `constrainChild` for the callers that omit the parameter, that is `moveCells`, `splitEdge`, `ungroupCells` and `updateGroupBounds`
- document the parameters of `cellsAdded`, including both defaults, in `CellsMixin.type.ts`

Taken together, these changes keep the observable behavior **unchanged for every existing caller**, and let `groupCells` finally get the `false` it passes. This is not a breaking change.

## Tests

- new `GroupingMixin.test.ts`, the mixin had no test file: `groupCells` preserves the geometry of its children, at positive and at negative coordinates. The negative case fails on `main` and passes with this fix, the positive case is the control that passes in both states.
- new `cellsAdded` block in `CellsMixin.test.ts` covering `constrain` and `extend` for the not set, `true` and `false` values. The `constrain` cases use a child that fits in the parent so that `extendParent` cannot fire, and the `extend` cases disable `constrain` so that `constrainChild`, which runs afterwards, cannot mask the result.
- shared `expectGeometryBounds` helper in `__tests__/utils.ts`, comparing the four bounds at once so a failure reports the whole geometry.

Verified: the 3 new cases fail without the production change, and the full suite (61 suites, 529 tests), the test type check, the lint and the build all pass with it.

## Note for a follow-up

`groupCells` is declared as `groupCells: (group: Cell, ...)` while its own documentation and its implementation both accept `null` to auto-create the group, so the snippet of the issue does not type check. Left untouched here, it deserves its own issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved geometry handling when cells are added, including more consistent constraining of child cells and extension of parent geometry.
  * Grouping cells now preserves the relative positions of children, including cells with negative coordinates.

* **Documentation**
  * Clarified the behavior and defaults of cell constraint and parent-extension options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->