### PR TITLE
fix: restore camelCase support in setPrefixedStyle

### DIFF
--- a/packages/core/__tests__/util/styleUtils.test.ts
+++ b/packages/core/__tests__/util/styleUtils.test.ts
@@ -102,6 +102,33 @@ describe('setPrefixedStyle', () => {
     });
   });
 
+  // Custom properties have no attribute on CSSStyleDeclaration, unlike the standard properties above, so they can
+  // only be set with setProperty. They are never vendor prefixed.
+  describe('with a CSS custom property', () => {
+    test.each([
+      ['without vendor prefix', {}],
+      ['with vendor prefix', { IS_GC: true }],
+    ])('sets the custom property %s', (_name, flags) => {
+      simulateBrowser(flags);
+      const style = newStyle();
+
+      setPrefixedStyle(style, '--overlay-offset', '10px');
+
+      expect(style.getPropertyValue('--overlay-offset')).toBe('10px');
+    });
+
+    test('does not add a vendor prefixed variant', () => {
+      simulateBrowser({ IS_GC: true });
+      const style = newStyle();
+
+      setPrefixedStyle(style, '--overlay-offset', '10px');
+
+      expect(style.cssText).toBe('--overlay-offset: 10px;');
+      expect(rawProperty(style, 'Webkit--overlay-offset')).toBeUndefined();
+      expect(rawProperty(style, '--overlay-offset')).toBeUndefined();
+    });
+  });
+
   describe('with vendor prefix', () => {
     test.each([
       ['Safari', { IS_SF: true }, 'WebkitTransformOrigin'],

--- a/packages/core/__tests__/util/styleUtils.test.ts
+++ b/packages/core/__tests__/util/styleUtils.test.ts
@@ -14,15 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { describe, expect, test } from '@jest/globals';
+import { afterEach, describe, expect, test } from '@jest/globals';
 import {
   parseCssNumber,
+  setPrefixedStyle,
   setStyleFlag,
   setCellStyleFlags,
   setCellStyles,
 } from '../../src/util/styleUtils';
 import { FONT_STYLE_MASK } from '../../src/util/Constants';
-import { type CellStyle, BaseGraph } from '../../src';
+import { type CellStyle, BaseGraph, Client } from '../../src';
 import { createGraphWithoutPlugins } from '../utils';
 
 describe('parseCssNumber', () => {
@@ -40,6 +41,126 @@ describe('parseCssNumber', () => {
     ['1.5em', 1.5],
   ])('parses %s correctly to %d', (input, expected) => {
     expect(parseCssNumber(input)).toBe(expected);
+  });
+});
+
+describe('setPrefixedStyle', () => {
+  const browserFlags = ['IS_SF', 'IS_GC', 'IS_MT'] as const;
+  type BrowserFlags = Partial<Record<(typeof browserFlags)[number], boolean>>;
+
+  // Captured while the describe block is evaluated, so before any test runs and mutates them. Do not move this
+  // into a beforeAll hook, which would run later and could capture values already altered by another test.
+  const originalFlags = new Map(browserFlags.map((flag) => [flag, Client[flag]]));
+
+  /** Simulates the browser detected by {@link Client}, defaulting every unset flag to `false`. */
+  const simulateBrowser = (flags: BrowserFlags): void => {
+    for (const flag of browserFlags) {
+      Client[flag] = flags[flag] ?? false;
+    }
+  };
+
+  const newStyle = (): CSSStyleDeclaration => document.createElement('div').style;
+
+  /**
+   * Reads a property by its raw name, without going through the CSSOM.
+   * Vendor prefixed names are not supported by jsdom, so they only exist as plain JavaScript
+   * properties on the declaration. This is what lets the tests below observe them at all.
+   */
+  const rawProperty = (style: CSSStyleDeclaration, name: string): string | undefined =>
+    (style as unknown as Record<string, string | undefined>)[name];
+
+  // Client flags are global mutable state, restore them so that the other tests are not impacted
+  afterEach(() => {
+    for (const [flag, value] of originalFlags) {
+      Client[flag] = value;
+    }
+  });
+
+  describe('without vendor prefix', () => {
+    // The camelCase case is the regression reported in https://github.com/maxGraph/maxGraph/issues/1046
+    test.each([
+      ['camelCase', 'transformOrigin', 'transform-origin'],
+      ['kebab-case', 'transform-origin', 'transform-origin'],
+      ['single word', 'transition', 'transition'],
+    ])('sets the standard property given a %s name', (_name, input, cssProperty) => {
+      simulateBrowser({});
+      const style = newStyle();
+
+      setPrefixedStyle(style, input, '0px 0px');
+
+      expect(style.getPropertyValue(cssProperty)).toBe('0px 0px');
+    });
+
+    test('does not set any vendor prefixed property', () => {
+      simulateBrowser({});
+      const style = newStyle();
+
+      setPrefixedStyle(style, 'transformOrigin', '0px 0px');
+
+      expect(rawProperty(style, 'WebkitTransformOrigin')).toBeUndefined();
+      expect(rawProperty(style, 'MozTransformOrigin')).toBeUndefined();
+    });
+  });
+
+  describe('with vendor prefix', () => {
+    test.each([
+      ['Safari', { IS_SF: true }, 'WebkitTransformOrigin'],
+      ['Chrome', { IS_GC: true }, 'WebkitTransformOrigin'],
+      ['Firefox', { IS_MT: true }, 'MozTransformOrigin'],
+    ])(
+      'sets both the standard and the prefixed property on %s',
+      (_name, flags, prefixedProperty) => {
+        simulateBrowser(flags);
+        const style = newStyle();
+
+        setPrefixedStyle(style, 'transformOrigin', '0px 0px');
+
+        expect(style.getPropertyValue('transform-origin')).toBe('0px 0px');
+        expect(rawProperty(style, prefixedProperty)).toBe('0px 0px');
+      }
+    );
+
+    test('prefixes a single word name', () => {
+      simulateBrowser({ IS_GC: true });
+      const style = newStyle();
+
+      setPrefixedStyle(style, 'transition', 'all 0.2s linear');
+
+      expect(style.getPropertyValue('transition')).toBe('all 0.2s linear');
+      expect(rawProperty(style, 'WebkitTransition')).toBe('all 0.2s linear');
+    });
+
+    test('prefers the Webkit prefix over the Moz one', () => {
+      simulateBrowser({ IS_SF: true, IS_MT: true });
+      const style = newStyle();
+
+      setPrefixedStyle(style, 'transformOrigin', '0px 0px');
+
+      expect(rawProperty(style, 'WebkitTransformOrigin')).toBe('0px 0px');
+      expect(rawProperty(style, 'MozTransformOrigin')).toBeUndefined();
+    });
+
+    test('does not prefix an empty name', () => {
+      simulateBrowser({ IS_GC: true });
+      const style = newStyle();
+
+      setPrefixedStyle(style, '', '0px 0px');
+
+      expect(rawProperty(style, 'Webkit')).toBeUndefined();
+    });
+
+    // Documents the limitation warned about in the JSDoc of setPrefixedStyle: the prefix is built by
+    // capitalizing the first character, which only produces a valid property name from a camelCase input.
+    test('skips the prefixed property given a kebab-case name', () => {
+      simulateBrowser({ IS_GC: true });
+      const style = newStyle();
+
+      setPrefixedStyle(style, 'transform-origin', '0px 0px');
+
+      expect(style.getPropertyValue('transform-origin')).toBe('0px 0px');
+      expect(rawProperty(style, 'WebkitTransformOrigin')).toBeUndefined();
+      expect(rawProperty(style, 'WebkitTransform-origin')).toBe('0px 0px');
+    });
   });
 });
 

--- a/packages/core/src/util/styleUtils.ts
+++ b/packages/core/src/util/styleUtils.ts
@@ -17,7 +17,6 @@ limitations under the License.
 */
 
 import Client from '../Client.js';
-import { isNullish } from '../internal/utils.js';
 import { FONT_STYLE_MASK, LINE_HEIGHT } from './Constants.js';
 import Point from '../view/geometry/Point.js';
 import CellPath from '../view/cell/CellPath.js';
@@ -31,7 +30,7 @@ import type {
   NumericCellStateStyleKeys,
   VAlignValue,
 } from '../types.js';
-import { matchBinaryMask } from '../internal/utils.js';
+import { isNullish, matchBinaryMask } from '../internal/utils.js';
 import { StyleDefaultsConfig } from './config.js';
 
 /**

--- a/packages/core/src/util/styleUtils.ts
+++ b/packages/core/src/util/styleUtils.ts
@@ -17,6 +17,7 @@ limitations under the License.
 */
 
 import Client from '../Client.js';
+import { isNullish } from '../internal/utils.js';
 import { FONT_STYLE_MASK, LINE_HEIGHT } from './Constants.js';
 import Point from '../view/geometry/Point.js';
 import CellPath from '../view/cell/CellPath.js';
@@ -103,13 +104,20 @@ export const parseCssNumber = (value: string) => {
  * ```javascript
  * styleUtils.setPrefixedStyle(node.style, 'transformOrigin', '0% 0%');
  * ```
+ *
+ * **WARNING**: `name` must be written in camelCase, as in the example above.
+ *
+ * A kebab-case name such as `transform-origin` still sets the standard property, but silently skips the
+ * vendor prefixed one: the prefix is built by capitalizing the first character of `name`, which only yields a
+ * valid property name from a camelCase input (`transformOrigin` gives `WebkitTransformOrigin`, whereas
+ * `transform-origin` gives the meaningless `WebkitTransform-origin`).
  */
 export const setPrefixedStyle = (
   style: CSSStyleDeclaration,
   name: string,
   value: string
-) => {
-  let prefix = null;
+): void => {
+  let prefix: string | null = null;
 
   if (Client.IS_SF || Client.IS_GC) {
     prefix = 'Webkit';
@@ -117,11 +125,15 @@ export const setPrefixedStyle = (
     prefix = 'Moz';
   }
 
-  style.setProperty(name, value);
+  // Assign the property instead of calling CSSStyleDeclaration.setProperty, which only accepts kebab-case names
+  // and therefore silently discards both the camelCase names documented above and the vendor prefixed names
+  // computed below. See https://github.com/maxGraph/maxGraph/issues/1046
+  const properties = style as unknown as Record<string, string>;
+  properties[name] = value;
 
-  if (prefix !== null && name.length > 0) {
+  if (!isNullish(prefix) && name.length > 0) {
     name = prefix + name.substring(0, 1).toUpperCase() + name.substring(1);
-    style.setProperty(name, value);
+    properties[name] = value;
   }
 };
 

--- a/packages/core/src/util/styleUtils.ts
+++ b/packages/core/src/util/styleUtils.ts
@@ -110,12 +110,21 @@ export const parseCssNumber = (value: string) => {
  * vendor prefixed one: the prefix is built by capitalizing the first character of `name`, which only yields a
  * valid property name from a camelCase input (`transformOrigin` gives `WebkitTransformOrigin`, whereas
  * `transform-origin` gives the meaningless `WebkitTransform-origin`).
+ *
+ * A CSS custom property such as `--overlay-offset` is set as is, and is never vendor prefixed.
  */
 export const setPrefixedStyle = (
   style: CSSStyleDeclaration,
   name: string,
   value: string
 ): void => {
+  // Custom properties have no attribute on CSSStyleDeclaration, unlike the standard properties handled below, so
+  // assigning one would only create a JavaScript property and no CSS declaration. They are never vendor prefixed.
+  if (name.startsWith('--')) {
+    style.setProperty(name, value);
+    return;
+  }
+
   let prefix: string | null = null;
 
   if (Client.IS_SF || Client.IS_GC) {


### PR DESCRIPTION
## Problem

`setPrefixedStyle` writes CSS properties with `CSSStyleDeclaration.setProperty`, which [only accepts kebab-case names](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/setProperty#propertyname). Any camelCase name is lowercased, matches no known property, and is silently discarded.

The reported symptom is the cell editor: `CellEditorHandler` calls `setPrefixedStyle(this.textarea.style, 'transformOrigin', '0px 0px')`, so the textarea never receives its transform origin and the editing overlay is visibly offset from the cell label at any zoom level other than 1x.

The vendor prefixed write was broken too, for **every** input spelling. The prefix is built by capitalizing the first character of the name, which produces webkit-cased names such as `WebkitTransformOrigin`. Those are CSSOM IDL attribute spellings, not CSS property names, so `setProperty` discards them as well. Feeding the function a kebab-case name does not help either: it yields the meaningless `WebkitTransform-origin`. Consequently the prefixed write in `RubberBandHandler` (`'transition'`) has also been dead, even though its standard write happens to work, single word names surviving the lowercasing intact.

## Root cause

Commit 61648e43c, a large "Converting *Handlers into plugins. Keep resolving errors" refactor, changed exactly two lines of this function:

```diff
-  style[name] = value;
+  style.setProperty(name, value);
   if (prefix !== null && name.length > 0) {
     name = prefix + name.substring(0, 1).toUpperCase() + name.substring(1);
-    style[name] = value;
+    style.setProperty(name, value);
```

`style[name] = value` does not compile here (`TS7015: Element implicitly has an 'any' type because index expression is not of type 'number'`), so this was a type error being silenced during a mass refactor, not a deliberate API change. The kebab-case requirement was never chosen, and the JSDoc has kept documenting camelCase ever since.

## Fix

Restore the property assignment used by `mxGraph`, with the cast that commit was avoiding:

```typescript
const properties = style as unknown as Record<string, string>;
properties[name] = value;

if (!isNullish(prefix) && name.length > 0) {
  name = prefix + name.substring(0, 1).toUpperCase() + name.substring(1);
  properties[name] = value;
}
```

Property assignment reaches the CSSOM camel-cased, dashed **and** webkit-cased attributes, so both writes work again. A comment records why the assignment is deliberate, so it does not get "fixed" back to `setProperty`.

Both call sites are left untouched: their existing camelCase arguments become correct again, rather than needing to change.

CSS custom properties are the one case that must keep using `setProperty`, so they get an early return before the prefix logic:

```typescript
if (name.startsWith('--')) {
  style.setProperty(name, value);
  return;
}
```

Unlike standard properties, a custom property has no attribute on `CSSStyleDeclaration`, so assigning one would create a JavaScript property and no CSS declaration at all, and it is never vendor prefixed. This capability is not inherited from `mxGraph`, which used assignment and had the same limitation: it appeared as a side effect of 61648e43c, the very commit that introduced the bug fixed here. It has been available for four years, so it is preserved rather than silently removed.

Vendor prefixing is deliberately kept rather than removed. It is very likely obsolete (`transform-origin` and `transition` have been unprefixed for over a decade, the browser detection relies on user agent sniffing, and the project targets modern browsers only), but the impact on external consumers calling this exported utility for other properties is unknown, so removing it belongs in its own change.

## Documented limitation

The mangling only produces a valid name from camelCase input, which the JSDoc now states explicitly:

> **WARNING**: `name` must be written in camelCase, as in the example above.
>
> A kebab-case name such as `transform-origin` still sets the standard property, but silently skips the vendor prefixed one.
>
> A CSS custom property such as `--overlay-offset` is set as is, and is never vendor prefixed.

## Tests

The function had no test coverage. 14 cases added in `packages/core/__tests__/util/styleUtils.test.ts`, each written before the corresponding fix and confirmed to fail against the previous implementation (7 failures for the camelCase standard write plus every vendor prefixed write, then 3 more for the custom properties):

- standard property set from camelCase, kebab-case and single word names
- no vendor property written when no prefix applies
- both properties written on Safari, Chrome and Firefox
- single word names get prefixed too, covering the dead `RubberBandHandler` write
- Webkit prefix wins over Moz when both flags are set
- the `name.length > 0` guard for an empty name
- the kebab-case limitation, asserting the malformed `WebkitTransform-origin`, so the JSDoc warning has an executable counterpart
- custom properties set with and without a vendor prefix active, and never given a prefixed variant, asserting `cssText` is exactly `--overlay-offset: 10px;` so a JavaScript property masquerading as a CSS declaration cannot pass

Two implementation notes. `Client.IS_SF` is `true` by default under jsdom, so each test sets the browser flags explicitly instead of inheriting the environment; those flags are global mutable state, captured before any test runs and restored after each one. And jsdom implements no vendor prefixed CSS property, so a prefixed assignment lands as a plain JavaScript property on the declaration, which a helper reads. That is the only way this path is observable in jsdom, and it works precisely because the fix uses assignment rather than `setProperty`.

## Validation

- `npm test -w packages/core`: 535 tests passed, 60 suites
- `npm run test-check -w packages/core` and `tsc --noEmit`: clean
- `npm run lint`: clean

:heavy_check_mark: Not covered by automated tests: the visual outcome. The tests prove `transform-origin` reaches the textarea style, not that the overlay aligns on screen. Manual check for a reviewer: open Storybook, zoom to a non-1x level, double-click a cell, and confirm the editor lines up with the label.

Fixes #1046


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application of standard and vendor-prefixed styles across supported browsers.
  * Added reliable support for camelCase properties and CSS custom properties.
  * Improved prefix selection and handling of empty or missing property names.
  * Ensured style updates use the appropriate browser-compatible format.

* **Tests**
  * Expanded coverage for browser-specific styling, prefix precedence, property naming formats, custom properties, and edge cases.
  * Added checks to ensure browser-state behavior remains consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
