### PR TITLE
feat: add registerDefaultStyleElements to register all builtin style elements

### DIFF
--- a/packages/core/__tests__/view/register-style-elements.test.ts
+++ b/packages/core/__tests__/view/register-style-elements.test.ts
@@ -1,0 +1,60 @@
+/*
+Copyright 2026-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+import {
+  EdgeMarkerRegistry,
+  EdgeStyleRegistry,
+  PerimeterRegistry,
+  registerDefaultStyleElements,
+  ShapeRegistry,
+  unregisterAllEdgeMarkers,
+  unregisterAllEdgeStylesAndPerimeters,
+  unregisterAllShapes,
+} from '../../src';
+
+const unregisterAll = (): void => {
+  unregisterAllEdgeMarkers();
+  unregisterAllEdgeStylesAndPerimeters();
+  unregisterAllShapes();
+};
+
+beforeEach(unregisterAll);
+afterEach(unregisterAll);
+
+describe('registerDefaultStyleElements', () => {
+  test.each([
+    ['edge marker', EdgeMarkerRegistry, 'classic'],
+    ['edge style', EdgeStyleRegistry, 'orthogonalEdgeStyle'],
+    ['perimeter', PerimeterRegistry, 'ellipsePerimeter'],
+    ['shape', ShapeRegistry, 'ellipse'],
+  ])('registers the builtin %s elements', (_name, registry, key) => {
+    expect(registry.get(key)).toBeNull();
+
+    registerDefaultStyleElements();
+
+    expect(registry.get(key)).not.toBeNull();
+  });
+
+  test('is idempotent', () => {
+    registerDefaultStyleElements();
+    const shape = ShapeRegistry.get('ellipse');
+
+    registerDefaultStyleElements();
+
+    expect(ShapeRegistry.get('ellipse')).toBe(shape);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -204,6 +204,7 @@ export { default as Rectangle } from './view/geometry/Rectangle.js';
 export * from './view/style/builtin-style-elements.js';
 export * from './view/style/config.js';
 export * from './view/style/register.js';
+export * from './view/register-style-elements.js';
 export * from './view/style/edge/EdgeStyleRegistry.js';
 export { EdgeMarkerRegistry } from './view/style/marker/EdgeMarkerRegistry.js';
 export { PerimeterRegistry } from './view/style/perimeter/PerimeterRegistry.js';

--- a/packages/core/src/view/Graph.ts
+++ b/packages/core/src/view/Graph.ts
@@ -23,12 +23,7 @@ import CellRenderer from './cell/CellRenderer.js';
 import GraphDataModel from './GraphDataModel.js';
 import { Stylesheet } from './style/Stylesheet.js';
 import GraphSelectionModel from './GraphSelectionModel.js';
-import { registerDefaultShapes } from './shape/register-shapes.js';
-import {
-  registerDefaultEdgeMarkers,
-  registerDefaultEdgeStyles,
-  registerDefaultPerimeters,
-} from './style/register.js';
+import { registerDefaultStyleElements } from './register-style-elements.js';
 import { getDefaultPlugins } from './plugin/index.js';
 
 /**
@@ -76,10 +71,7 @@ export class Graph extends AbstractGraph {
 
   // Register all builtins provided by maxGraph
   protected override registerDefaults(): void {
-    registerDefaultEdgeMarkers();
-    registerDefaultEdgeStyles();
-    registerDefaultPerimeters();
-    registerDefaultShapes();
+    registerDefaultStyleElements();
   }
 
   // Build cellRenderer/selectionModel/view via the factory methods so subclasses can customize them

--- a/packages/core/src/view/register-style-elements.ts
+++ b/packages/core/src/view/register-style-elements.ts
@@ -1,0 +1,47 @@
+/*
+Copyright 2026-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { registerDefaultShapes } from './shape/register-shapes.js';
+import {
+  registerDefaultEdgeMarkers,
+  registerDefaultEdgeStyles,
+  registerDefaultPerimeters,
+} from './style/register.js';
+
+/**
+ * Register all default builtin style elements provided by `maxGraph`, by calling:
+ * - {@link registerDefaultEdgeMarkers}
+ * - {@link registerDefaultEdgeStyles}
+ * - {@link registerDefaultPerimeters}
+ * - {@link registerDefaultShapes}
+ *
+ * This is exactly what {@link Graph} registers when it is instantiated. {@link BaseGraph} registers nothing, so this
+ * function is the way to get all builtins at once without subclassing it.
+ *
+ * Registering everything defeats tree-shaking: all builtin shapes, edge styles, perimeters and edge markers end up in
+ * the application bundle, whether they are used or not. Prefer registering only the elements used by the application.
+ * See the tree-shaking documentation for guidance.
+ *
+ * @category Configuration
+ * @category Style
+ * @since 0.25.0
+ */
+export const registerDefaultStyleElements = (): void => {
+  registerDefaultEdgeMarkers();
+  registerDefaultEdgeStyles();
+  registerDefaultPerimeters();
+  registerDefaultShapes();
+};

--- a/packages/website/docs/usage/global-configuration.md
+++ b/packages/website/docs/usage/global-configuration.md
@@ -82,6 +82,16 @@ registerDefaultPerimeters();
 registerDefaultShapes();
 ```
 
+`registerDefaultStyleElements` (since 0.25.0) calls the four of them at once, which is exactly what `Graph` registers when it is instantiated:
+
+```javascript
+registerDefaultStyleElements();
+```
+
+:::warning
+Registering all default style elements defeats tree-shaking: every built-in shape, edge style, perimeter and edge marker ends up in your bundle, whether the application uses it or not. Register only the elements you need.
+:::
+
 It is possible to unregister all elements from a style registry using the related `unregister` function. For example:
 
 ```javascript


### PR DESCRIPTION
## Problem

Two documentation pages already referred to a `registerDefaultStyleElements` function as the place to check which style elements maxGraph registers by default:

- `packages/website/docs/usage/perimeters.md`: _"To check the list of registered perimeters, refer to the `registerDefaultStyleElements` function."_
- `packages/website/docs/usage/edge-styles.md`: _"To check the list of registered EdgeStyles, refer to the `registerDefaultStyleElements` function."_

No such function existed. The four existing helpers (`registerDefaultEdgeMarkers`, `registerDefaultEdgeStyles`, `registerDefaultPerimeters` and `registerDefaultShapes`) had to be called one by one, and the only place listing them all was the private `Graph.registerDefaults()` override, which is not reachable from user code.

## Solution

Add `registerDefaultStyleElements()`, which calls the four helpers. `BaseGraph` consumers who do want every builtin now get a single entry point without subclassing, and `Graph.registerDefaults()` delegates to it instead of duplicating the list, so there is a single source of truth.

```typescript
import { BaseGraph, registerDefaultStyleElements } from '@maxgraph/core';

registerDefaultStyleElements();

const graph = new BaseGraph({ container });
```

The two documentation pages quoted above now point at something that exists.

### Why a dedicated module

The function lives in `packages/core/src/view/register-style-elements.ts` rather than in `view/style/register.ts`. Adding an import of `view/shape/register-shapes.js` to the latter would create a static edge from a module that applications import for a single edge style helper (`registerOrthogonalEdgeStyle`, for instance) towards all sixteen builtin shapes. Bundlers drop it thanks to the side-effect-free package declaration, but the granularity of that analysis [varies between bundlers](https://github.com/orgs/web-infra-dev/discussions/29), so the edge is better avoided entirely.

### Tree-shaking caveat

Registering everything defeats tree-shaking, which is the whole point of `BaseGraph`. This is stated in the JSDoc and in a warning in the Global Configuration page, so the function does not read as the recommended default. It is meant as a convenience for prototyping, and as the first step of a `Graph` to `BaseGraph` migration: load everything so the application behaves as before, then trim progressively.

## Changes

- `packages/core/src/view/register-style-elements.ts`: the new function
- `packages/core/src/index.ts`: export it
- `packages/core/src/view/Graph.ts`: `registerDefaults()` delegates to it
- `packages/core/__tests__/view/register-style-elements.test.ts`: 5 tests covering the four registries and idempotence
- `packages/website/docs/usage/global-configuration.md`: document it alongside the four granular functions, with the tree-shaking warning

No `CHANGELOG.md` entry: this is not a breaking change.

Related to #665.

## Validation

- `npm run build -w packages/core`
- `npm test -w packages/core`: 540 tests, 61 suites
- `npm run check:circular-dependencies -w packages/core`
- `npm run lint`
- `npm run build -w packages/website`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public helper to register all default styling elements at once.
  * Default graph styling is now registered consistently through this helper.

* **Documentation**
  * Documented the new registration helper and its impact on bundle size, including guidance for preserving tree-shaking.

* **Tests**
  * Added coverage for default markers, styles, perimeters, shapes, and repeated registration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->