### PR TITLE
docs: make the plugin examples of the documentation compile

### DIFF
--- a/packages/website/docs/usage/plugins.md
+++ b/packages/website/docs/usage/plugins.md
@@ -55,10 +55,14 @@ Use the `getPlugin` method to retrieve a plugin instance from a `Graph` instance
 
 ```typescript
 const graph = new Graph(container);
-const panningHandler = graph.getPlugin<PanningHandler>('PanningHandler');
+const panningHandler = graph.getPlugin<PanningHandler>('PanningHandler')!;
 panningHandler.useLeftButtonForPanning = true;
 panningHandler.ignoreCell = true;
 ```
+
+`getPlugin` returns `undefined` when no plugin is registered with the given id, so its return type is nullable.
+Here, the non-null assertion (`!`) is intentional: `PanningHandler` is one of the [default plugins](#available-plugins) of `Graph`, so it is always available.
+When the plugin may be absent, for example with `BaseGraph` or with a plugin list built at runtime, use optional chaining (`?.`) or an explicit check instead.
 
 
 ## Choosing the Plugins to Use
@@ -114,7 +118,7 @@ When replacing a built-in plugin with a custom implementation, make sure you do 
 ## Creating a Custom Plugin
 
 A custom plugin is defined as a class:
-- It must implement the `GraphPlugin` interface.
+- It must implement the `GraphPlugin` interface, whose only member, `onDestroy`, is mandatory. It is called when the graph is destroyed.
 - Its constructor must satisfy the `GraphPluginConstructor` type.
 - It can provide new methods to extend the existing API or introduce new behavior (using listeners, for example).
 
@@ -125,6 +129,13 @@ class MyCustomPlugin implements GraphPlugin {
 
   constructor(graph: Graph) {
     // Initialization and configuration code
+  }
+
+  /** Releases the resources acquired by the plugin. */
+  onDestroy(): void {
+    // Unregister the event listeners, clear the timers, drop the references to the graph
+    // and to its cells, and empty the caches, to help garbage collection.
+    // Plugins holding none of these can leave the method empty, as `FitPlugin` does.
   }
 }
 ```


### PR DESCRIPTION
Both TypeScript examples of the plugins documentation page failed to compile as soon as a reader copied them into a project, which is the very first thing the page invites them to do.

## The two defects

**Custom plugin example.** The `MyCustomPlugin` class declared `implements GraphPlugin` but defined only `static pluginId` and a constructor. `GraphPlugin`, in `packages/core/src/types.ts`, requires `onDestroy: () => void`, which is not optional, so the class did not implement the interface it claimed to.

**Plugin retrieval example.** `AbstractGraph.getPlugin` returns `T | undefined`. The example dereferenced its result directly, which is an error under `strictNullChecks`.

Compiling the original snippets with the `packages/core` TypeScript configuration:

```
error TS18048: 'panningHandler' is possibly 'undefined'.   (x2)
error TS2420: Class 'MyCustomPlugin' incorrectly implements interface 'GraphPlugin'.
  Property 'onDestroy' is missing in type 'MyCustomPlugin' but required in type 'GraphPlugin'.
```

## The fix

- `onDestroy` is added to the custom plugin example, with a body describing what is typically released there (listeners, timers, references to the graph and its cells, caches), mirroring what `FitPlugin` and `ImageBundlePlugin` do. The bullet list above the snippet now states that the interface's only member is mandatory.
- The retrieval example uses the non-null assertion, consistent with what the rest of the documentation already teaches: the image bundles and cell handlers pages use `!` for a plugin known to be registered, and reserve `?.` for genuinely optional calls. `PanningHandler` is a default plugin of `Graph`, so it is always present here. A note was added stating that `getPlugin` returns `undefined` for an unregistered id, and pointing to optional chaining or an explicit check when the plugin may be absent, for instance with `BaseGraph`.

## Verification

The fixed snippets were placed in a temporary file under `packages/core/src` and compiled with `tsc --noEmit -p packages/core/tsconfig.json`, which reported no error. The temporary file was then deleted, so this PR only touches the documentation page.

No other plugin example has either defect. `migrate-from-mxgraph.md` only binds the result of `getPlugin` without dereferencing it, and the image bundles page, the cell handlers page, `packages/ts-support` and the TypeScript Storybook stories all already use `!`, `?.` or an explicit guard. The remaining call sites are plain JavaScript files that are not type-checked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated plugin usage guidance to explain handling plugins that may be unavailable.
  - Clarified required cleanup behavior for custom plugins.
  - Added an example demonstrating resource cleanup during plugin destruction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->