### PR TITLE
chore(examples): add bundle analysis and blocking size budgets

### DIFF
--- a/.claude/rules/tooling/bundle-size-budgets.md
+++ b/.claude/rules/tooling/bundle-size-budgets.md
@@ -62,9 +62,16 @@ The two webpack limits therefore differ from each other, and they are not interc
 
 ## Where the guard applies
 
-`npm run build` is the command that enforces a budget, and it is the one the CI runs. Neither bundler enforces anything
-during a development build, since those bundles are not minified and are several times larger, nor during an analyze
-run, which is a diagnostic: failing it would suppress the very report needed to understand the size.
+`npm run build` is the command that enforces a budget, and it is the one the CI runs. Nothing is enforced while
+developing, nor during an analyze run, which is a diagnostic: failing it would suppress the very report needed to
+understand the size.
+
+The two bundlers reach that exemption differently. webpack reads the mode: `isDevMode` is true unless
+`--mode=production` is passed, so `hints` is off for `webpack serve` and for a plain `webpack`, whose bundle is
+unminified and several times larger. Vite needs no such condition: `npm run dev` starts a server that emits no bundle,
+so `generateBundle` never runs, and `build.minify` stays on whatever `--mode` says. Every `vite build` therefore emits
+the same minified chunks the limit was measured on, which is why the plugin declares only `apply: 'build'` and checks a
+`vite build --mode development` as well.
 
 webpack fails the build on its own, so `scripts/webpack/bundle-analysis.cjs` keeps `hints` at `'error'` only when
 neither exemption applies, `isDevMode || isBundleAnalysisEnabled ? false : 'error'`.
@@ -72,9 +79,9 @@ neither exemption applies, `isDevMode || isBundleAnalysisEnabled ? false : 'erro
 Vite does not. `chunkSizeWarningLimit` only makes it log a warning, and the build still exits 0, so a regression ends up
 as one line in a CI log that nobody reads. `scripts/vite/chunk-size-limit.mjs` therefore fails the build and names the
 chunk and both sizes. Declare the limit once, in a `chunkSizeLimitInKB` constant, and pass it to both
-`chunkSizeWarningLimit` and the plugin, so the warning and the error can never drift apart. That plugin is registered
-instead of the analyzer, never alongside it: the analyzer is a post plugin, so the guard's error would abort the build
-before any report is written.
+`chunkSizeWarningLimit` and the plugin, so the two thresholds cannot be set to different values. That plugin is
+registered instead of the analyzer, never alongside it: the analyzer is a post plugin, so the guard's error would abort
+the build before any report is written.
 
 ## Updating a budget
 

--- a/.claude/rules/tooling/bundle-size-budgets.md
+++ b/.claude/rules/tooling/bundle-size-budgets.md
@@ -1,9 +1,12 @@
 # Bundle Size Budgets
 
-Applies to the size guards of the example packages, whichever bundler they use:
+Applies to the size guards of the example packages, whichever bundler they use. Each example declares its own limits,
+while the machinery enforcing them is shared:
 
-- the `performance` section of `packages/*-example*/webpack.config.js`,
-- the chunk size limit of `packages/*-example*/vite.config.js`.
+- webpack: the values are passed to `withBundleAnalysisAndSizeBudget` in `packages/*-example*/webpack.config.js`, and
+  `scripts/webpack/bundle-analysis.cjs` turns them into the `performance` section,
+- vite: the value is the `chunkSizeLimitInKB` constant of `packages/*-example*/vite.config.js`, fed to both
+  `build.chunkSizeWarningLimit` and the `failOnChunkSizeExceeded` plugin of `scripts/vite/chunk-size-limit.mjs`.
 
 The rule for choosing the value is the same for every example. What differs between the two bundlers is the unit, what
 the value is compared against, and what makes the build fail.
@@ -15,20 +18,16 @@ of 1000. Never write the exact byte count, and never add margin on top of the ro
 
 ```javascript
 // Good, webpack: current build is 239 112 B for the asset and 240 095 B for the entrypoint
-performance: {
-  hints: isDevMode ? false : 'error',
-  maxAssetSize: 240_000,
-  maxEntrypointSize: 241_000,
-},
+module.exports = withBundleAnalysisAndSizeBudget(
+  { isDevMode, maxAssetSize: 240_000, maxEntrypointSize: 241_000 },
+  config
+);
 
 // Good, vite: current maxgraph chunk is 220 859 B
 const chunkSizeLimitInKB = 221;
 
 // Bad, exact byte counts
-performance: {
-  maxAssetSize: 239_112,
-  maxEntrypointSize: 240_095,
-},
+{ isDevMode, maxAssetSize: 239_112, maxEntrypointSize: 240_095 },
 ```
 
 The point of these limits is to **follow the size evolution**, not to leave room to grow into. Rounding exists so the
@@ -61,17 +60,21 @@ bytes there silently disables the guard, since no chunk is ever 240 000 kB.
 
 The two webpack limits therefore differ from each other, and they are not interchangeable.
 
-## Make the guard blocking, in production only
+## Where the guard applies
 
-webpack fails the build on its own: set `hints` to `'error'` for production builds and to `false` otherwise.
-Development bundles are not minified and are several times larger, so enforcing a budget there would break
-`npm run dev` on every start.
+`npm run build` is the command that enforces a budget, and it is the one the CI runs. Neither bundler enforces anything
+during a development build, since those bundles are not minified and are several times larger, nor during an analyze
+run, which is a diagnostic: failing it would suppress the very report needed to understand the size.
+
+webpack fails the build on its own, so `scripts/webpack/bundle-analysis.cjs` keeps `hints` at `'error'` only when
+neither exemption applies, `isDevMode || isBundleAnalysisEnabled ? false : 'error'`.
 
 Vite does not. `chunkSizeWarningLimit` only makes it log a warning, and the build still exits 0, so a regression ends up
-as one line in a CI log that nobody reads. The examples therefore pass the same limit to `failOnChunkSizeExceeded` from
-`scripts/vite/chunk-size-limit.mjs`, which fails the build and names the chunk and both sizes. Declare the limit once,
-in a `chunkSizeLimitInKB` constant, and pass it to both `chunkSizeWarningLimit` and the plugin, so the warning and the
-error can never drift apart. The plugin only applies to `build`, so `npm run dev` is unaffected.
+as one line in a CI log that nobody reads. `scripts/vite/chunk-size-limit.mjs` therefore fails the build and names the
+chunk and both sizes. Declare the limit once, in a `chunkSizeLimitInKB` constant, and pass it to both
+`chunkSizeWarningLimit` and the plugin, so the warning and the error can never drift apart. That plugin is registered
+instead of the analyzer, never alongside it: the analyzer is a post plugin, so the guard's error would abort the build
+before any report is written.
 
 ## Updating a budget
 

--- a/.claude/rules/tooling/bundle-size-budgets.md
+++ b/.claude/rules/tooling/bundle-size-budgets.md
@@ -1,0 +1,80 @@
+# Bundle Size Budgets
+
+Applies to the size guards of the example packages, whichever bundler they use:
+
+- the `performance` section of `packages/*-example*/webpack.config.js`,
+- the chunk size limit of `packages/*-example*/vite.config.js`.
+
+The rule for choosing the value is the same for every example. What differs between the two bundlers is the unit, what
+the value is compared against, and what makes the build fail.
+
+## Round the limits up to the next kB
+
+The limit is the **smallest value that makes the check pass**, that is the measured size rounded up to the next multiple
+of 1000. Never write the exact byte count, and never add margin on top of the rounding.
+
+```javascript
+// Good, webpack: current build is 239 112 B for the asset and 240 095 B for the entrypoint
+performance: {
+  hints: isDevMode ? false : 'error',
+  maxAssetSize: 240_000,
+  maxEntrypointSize: 241_000,
+},
+
+// Good, vite: current maxgraph chunk is 220 859 B
+const chunkSizeLimitInKB = 221;
+
+// Bad, exact byte counts
+performance: {
+  maxAssetSize: 239_112,
+  maxEntrypointSize: 240_095,
+},
+```
+
+The point of these limits is to **follow the size evolution**, not to leave room to grow into. Rounding exists so the
+values stay readable and comparable with the table printed by `scripts/build-all-examples.bash`, so the headroom it
+happens to leave is incidental: anywhere between 1 B and 999 B depending on where the current size falls in its kB.
+
+That is accepted, with its consequence: an increase of 50 B can fail the build while an increase of 700 B passes
+unnoticed. Choosing a wider margin would not remove that asymmetry, it would only move the boundary further away and
+delay the moment the growth becomes visible. When a build does fail, check that the increase is intended, then update
+the value in the same commit rather than padding it.
+
+Use kB (1000 bytes), not KiB (1024), to stay consistent with `scripts/build-all-examples.bash`, which reports sizes
+divided by 1000. Note that webpack prints KiB in its own output, so convert before rounding.
+
+## Mind the unit: bytes for webpack, kB for vite
+
+`maxAssetSize` and `maxEntrypointSize` are expressed in **bytes**, so use a numeric separator to keep them readable:
+`240_000`. Vite's `chunkSizeWarningLimit` is expressed in **kB**, so the same budget reads `240`, not `240_000`. Writing
+bytes there silently disables the guard, since no chunk is ever 240 000 kB.
+
+## Which size feeds which limit
+
+- webpack `maxAssetSize` is checked against **each emitted file** taken individually, so it comes from the largest one.
+  Source maps are excluded by webpack's default `assetFilter`, nothing else is.
+- webpack `maxEntrypointSize` is checked against the **sum of the files needed to load one entry**, typically the
+  JavaScript bundle plus the extracted CSS. Files emitted outside any entry, such as a favicon copied by
+  `CopyWebpackPlugin` or an image referenced from the CSS, are not counted.
+- vite compares the limit against **each emitted chunk** individually. The examples isolate `@maxgraph/core` in a
+  dedicated `maxgraph` chunk, which is by far the largest, so that chunk is what sets the value.
+
+The two webpack limits therefore differ from each other, and they are not interchangeable.
+
+## Make the guard blocking, in production only
+
+webpack fails the build on its own: set `hints` to `'error'` for production builds and to `false` otherwise.
+Development bundles are not minified and are several times larger, so enforcing a budget there would break
+`npm run dev` on every start.
+
+Vite does not. `chunkSizeWarningLimit` only makes it log a warning, and the build still exits 0, so a regression ends up
+as one line in a CI log that nobody reads. The examples therefore pass the same limit to `failOnChunkSizeExceeded` from
+`scripts/vite/chunk-size-limit.mjs`, which fails the build and names the chunk and both sizes. Declare the limit once,
+in a `chunkSizeLimitInKB` constant, and pass it to both `chunkSizeWarningLimit` and the plugin, so the warning and the
+error can never drift apart. The plugin only applies to `build`, so `npm run dev` is unaffected.
+
+## Updating a budget
+
+When an increase is intended, rebuild, read the new size, round up to the next kB and update the value in the same
+commit as the change that caused it, explaining in the commit body why the bundle grew. `npm run build:analyze`, which
+every bundled example provides, shows what was added.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,8 +56,13 @@ updates:
           - "jsdom"
           - "jsdom-*"
           - "ts-jest"
+      vite:
+        patterns:
+          - "vite"
+          - "vite-*"
       webpack:
         patterns:
+          - "@rsdoctor/*"
           - "copy-webpack-plugin"
           - "css-loader"
           - "html-webpack-plugin"

--- a/.github/workflows/_reusable_build_examples.yml
+++ b/.github/workflows/_reusable_build_examples.yml
@@ -30,9 +30,13 @@ jobs:
 
       - name: Build all examples
         shell: bash
-        run: ./scripts/build-all-examples.bash
+        run: ./scripts/build-all-examples.bash --fail-at-end
 
+      # Runs even when the build step failed, so that the examples that did build can still be inspected. This is the
+      # point of '--fail-at-end': get the whole picture from a single run. A failed build job still blocks the jobs
+      # that depend on it, the release included.
       - name: Upload all examples as artifact
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs['artifact-name'] }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ Key patterns:
 - See `.claude/rules/architecture/coding-practices.md` for core package rules (imports, nullish checks, logging, i18n)
 - See `.claude/rules/architecture/graph-api-usage.md` for calling the maxGraph API (applies to sources, tests, stories and examples)
 - See `.claude/rules/testing/conventions.md` for test patterns
+- See `.claude/rules/tooling/bundle-size-budgets.md` for the size budgets of the example packages (webpack and Vite)
 - See `.claude/rules/git/commit-conventions.md` for commit message style
 
 ## References

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -118,6 +118,24 @@ export default tsEslint.config(
     files: ['packages/html/stories/**/*.stories.@(ts|tsx|js|jsx|mjs|cjs)'],
   })),
 
+  // The webpack configurations of the examples and the module they share are CommonJS build tooling, not sources.
+  // Without this, every 'require', 'module', 'process' and '__dirname' of those files is reported as undefined.
+  {
+    files: ['**/webpack.config.js', 'scripts/**/*.cjs'],
+    languageOptions: {
+      sourceType: 'commonjs',
+      globals: {
+        __dirname: 'readonly',
+        module: 'writable',
+        process: 'readonly',
+        require: 'readonly',
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-require-imports': 'off',
+    },
+  },
+
   // Enables eslint-plugin-prettier, eslint-config-prettier and prettier/prettier. This will display prettier errors as ESLint errors. Make sure this is always the last configuration.
   prettierRecommendedConfig
 );

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -118,24 +118,6 @@ export default tsEslint.config(
     files: ['packages/html/stories/**/*.stories.@(ts|tsx|js|jsx|mjs|cjs)'],
   })),
 
-  // The webpack configurations of the examples and the module they share are CommonJS build tooling, not sources.
-  // Without this, every 'require', 'module', 'process' and '__dirname' of those files is reported as undefined.
-  {
-    files: ['**/webpack.config.js', 'scripts/**/*.cjs'],
-    languageOptions: {
-      sourceType: 'commonjs',
-      globals: {
-        __dirname: 'readonly',
-        module: 'writable',
-        process: 'readonly',
-        require: 'readonly',
-      },
-    },
-    rules: {
-      '@typescript-eslint/no-require-imports': 'off',
-    },
-  },
-
   // Enables eslint-plugin-prettier, eslint-config-prettier and prettier/prettier. This will display prettier errors as ESLint errors. Make sure this is always the last configuration.
   prettierRecommendedConfig
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -4901,6 +4901,13 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
@@ -10195,6 +10202,280 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rsbuild/plugin-check-syntax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@rsbuild/plugin-check-syntax/-/plugin-check-syntax-1.6.1.tgz",
+      "integrity": "sha512-26xtEYN0QjZYoyt0lWnvIztBWjEZJvcfw7MN4f5B4SpNggmnF7F7aNPrgkY3EccXVFx1VGQBhnCkBV//OoS07Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "browserslist-to-es-version": "^1.2.0",
+        "htmlparser2": "10.0.0",
+        "picocolors": "^1.1.1",
+        "source-map": "^0.7.6"
+      },
+      "peerDependencies": {
+        "@rsbuild/core": "^1.0.0 || ^2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@rsbuild/core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rsbuild/plugin-check-syntax/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@rsbuild/plugin-check-syntax/node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      }
+    },
+    "node_modules/@rsdoctor/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@rsdoctor/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-UWc8uyXPtcGZuQtVX+jBZwPxMXrMrrp0GrbVvHoHjzTxWufdn4RcG1g4PFgZLPz5smcCGYOEaNvlNn5WOtVyMw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rsdoctor/core": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@rsdoctor/core/-/core-1.6.1.tgz",
+      "integrity": "sha512-PkNe5Z45gR3dEhFdOcN/ZTwUxTltJR66cJA4DHXj1Zuo9s8d6SKWHFBLi5zMqPV3ZyBAQl4tsGv2LoJDQa69wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rsbuild/plugin-check-syntax": "^1.6.1",
+        "@rsdoctor/graph": "1.6.1",
+        "@rsdoctor/sdk": "1.6.1",
+        "@rsdoctor/types": "1.6.1",
+        "@rsdoctor/utils": "1.6.1",
+        "@rspack/resolver": "^0.2.8",
+        "browserslist-load-config": "^1.0.2",
+        "es-toolkit": "^1.49.0",
+        "filesize": "^11.0.17",
+        "fs-extra": "^11.1.1",
+        "semver": "^7.8.5",
+        "source-map": "^0.7.6"
+      }
+    },
+    "node_modules/@rsdoctor/core/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@rsdoctor/graph": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@rsdoctor/graph/-/graph-1.6.1.tgz",
+      "integrity": "sha512-LHbJKwO31BujQNUsD28kDoQKa5EkRxtSOABuHWRTv62drzz4NF9ZGSIHmrd6/jkbDBdCZEngZIwBkTSi3gtFoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rsdoctor/types": "1.6.1",
+        "@rsdoctor/utils": "1.6.1",
+        "es-toolkit": "^1.49.0",
+        "path-browserify": "1.0.1",
+        "source-map": "^0.7.6"
+      }
+    },
+    "node_modules/@rsdoctor/sdk": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@rsdoctor/sdk/-/sdk-1.6.1.tgz",
+      "integrity": "sha512-9dBk9SDVcY2Z8mHepUKDpHc3eaAsYNSioLlbNPNVLH4XinzcRe/4kJiX37VNjUVPv93IzZ6GTJhkiax/6O+fGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rsdoctor/client": "1.6.1",
+        "@rsdoctor/graph": "1.6.1",
+        "@rsdoctor/types": "1.6.1",
+        "@rsdoctor/utils": "1.6.1",
+        "launch-editor": "^2.13.2",
+        "safer-buffer": "2.1.2",
+        "socket.io": "4.8.1",
+        "tapable": "2.3.3"
+      }
+    },
+    "node_modules/@rsdoctor/types": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@rsdoctor/types/-/types-1.6.1.tgz",
+      "integrity": "sha512-E01VGaDGvXGig3rqQC+YRRPbGQ6tBLi9XkYCl579Hq01iYHeuVYLl1bfnODAt8SkdDYGJDMFuUWj/01A0vVy7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "3.4.38",
+        "@types/estree": "1.0.5",
+        "@types/tapable": "2.3.0",
+        "source-map": "^0.7.6"
+      },
+      "peerDependencies": {
+        "@rspack/core": "*",
+        "webpack": "5.x"
+      },
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rsdoctor/types/node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rsdoctor/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@rsdoctor/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-Ll+X1nAE3eBq9BpBNZvAT+4hZZMQt/rxrBRzL/I8o6S3CBpo5Kh2A2JaYgCJLiYKh0kFQfuIWuOVpR3/yoFWJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "7.26.2",
+        "@rsdoctor/types": "1.6.1",
+        "@types/estree": "1.0.5",
+        "acorn": "^8.10.0",
+        "acorn-import-attributes": "^1.9.5",
+        "acorn-walk": "8.3.5",
+        "deep-eql": "4.1.4",
+        "envinfo": "7.21.0",
+        "fs-extra": "^11.1.1",
+        "get-port": "5.1.1",
+        "json-stream-stringify": "3.0.1",
+        "lines-and-columns": "2.0.4",
+        "picocolors": "^1.1.1",
+        "rslog": "^2.1.2",
+        "strip-ansi": "^7.2.0"
+      }
+    },
+    "node_modules/@rsdoctor/utils/node_modules/@babel/code-frame": {
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@rsdoctor/utils/node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rsdoctor/utils/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@rsdoctor/utils/node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rsdoctor/utils/node_modules/lines-and-columns": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
+      "integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/@rsdoctor/utils/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@rsdoctor/webpack-plugin": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@rsdoctor/webpack-plugin/-/webpack-plugin-1.6.1.tgz",
+      "integrity": "sha512-kX9X1GO8EAuqhXhseyVqW01LayS2LP3WO78gO7GcmcevIeBu529VdCDwLd6NOeKtDJfYl/+is8S6coqHpvDIzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rsdoctor/core": "1.6.1",
+        "@rsdoctor/graph": "1.6.1",
+        "@rsdoctor/sdk": "1.6.1",
+        "@rsdoctor/types": "1.6.1",
+        "@rsdoctor/utils": "1.6.1"
+      },
+      "peerDependencies": {
+        "webpack": "5.x"
+      }
+    },
     "node_modules/@rspack/binding": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.6.0.tgz",
@@ -10386,6 +10667,202 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@rspack/resolver": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@rspack/resolver/-/resolver-0.2.8.tgz",
+      "integrity": "sha512-FBWqdHhzS8mcf/WN4Ktzr7EaeaN+hsxbN98EweegX3924beZuY6H70CSFWCv1fIHAieCUv/9XCjKggHvhCsLwA==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "@rspack/resolver-binding-darwin-arm64": "0.2.8",
+        "@rspack/resolver-binding-darwin-x64": "0.2.8",
+        "@rspack/resolver-binding-linux-arm64-gnu": "0.2.8",
+        "@rspack/resolver-binding-linux-arm64-musl": "0.2.8",
+        "@rspack/resolver-binding-linux-x64-gnu": "0.2.8",
+        "@rspack/resolver-binding-linux-x64-musl": "0.2.8",
+        "@rspack/resolver-binding-wasm32-wasi": "0.2.8",
+        "@rspack/resolver-binding-win32-arm64-msvc": "0.2.8",
+        "@rspack/resolver-binding-win32-ia32-msvc": "0.2.8",
+        "@rspack/resolver-binding-win32-x64-msvc": "0.2.8"
+      }
+    },
+    "node_modules/@rspack/resolver-binding-darwin-arm64": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@rspack/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-0.2.8.tgz",
+      "integrity": "sha512-nTnK17kmxXEvR+WpOIZPSIzUFYeWCHoffgU9tvOLOwuTBH41kWnSQXXWu+AiMVwvJ6wdRO6Vo30hPhlXEG7Pyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rspack/resolver-binding-darwin-x64": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@rspack/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-0.2.8.tgz",
+      "integrity": "sha512-Aqr4TK2rA6XVYUOmM5YCtYyCMZhOIR53P4cOGgGARg99A7OuMBMzUL4r1n0M0Fx35v6/sSx1OBe+odHmPxksEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rspack/resolver-binding-linux-arm64-gnu": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@rspack/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-0.2.8.tgz",
+      "integrity": "sha512-wGvkxm2G4mNTztslaOzLzx5JuySQSy5DcOWEZxHcjJJzp5L3ODbYLK18HtUc6cvmaVOmjaGrrYPrqJJ0hHTVFg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/resolver-binding-linux-arm64-musl": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@rspack/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-0.2.8.tgz",
+      "integrity": "sha512-EqRJ9zLQsLAvyDKJKVZ45BSqRIMS12f5HtJdy3KkAHU14ZmsGv8e5IKkwUZN5CNBRad8xVlOMMx3dOfF4whJzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/resolver-binding-linux-x64-gnu": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@rspack/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-0.2.8.tgz",
+      "integrity": "sha512-eXbeotNCTntL4/+mxJRVCxK63YeWzTfp0F3POeHJFSs6Nt0f2J/mZNFlasJmd6xm7zvE80h/HWOwbwjRBLcElA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/resolver-binding-linux-x64-musl": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@rspack/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-0.2.8.tgz",
+      "integrity": "sha512-KWFHlOWGkT+eMngoUgPGXrDi+rU04VCh9jyk0U6Ot2RTWvhGxwKykjmLS+CWZI/EBrzr9A6g2U3jzKTMNz9oCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/resolver-binding-wasm32-wasi": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@rspack/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-0.2.8.tgz",
+      "integrity": "sha512-I6GIhgICFViE88jejIV74oiiWHnpLpQ5ogaZM1ozM9KDnfqcHoX0IVEyrIh5KqA8iLDyhuoFSW+Hf0qN7VTBBQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rspack/resolver-binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.3.tgz",
+      "integrity": "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
+      }
+    },
+    "node_modules/@rspack/resolver-binding-win32-arm64-msvc": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@rspack/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-0.2.8.tgz",
+      "integrity": "sha512-ZXCt3qUfDAEbtc2sHpvxM7lNFZM+DxfblgXUIl3Jy6BuEZbHe1i6z+t9c34ayHoGTVbVSNCtaYuG/MaWdSnPHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rspack/resolver-binding-win32-ia32-msvc": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@rspack/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-0.2.8.tgz",
+      "integrity": "sha512-2LRymjDK8MpUERD8CL0PPae5y2crU5TAg4T4EzpeL5jLARVq6izsEruiWzB6Y+D15vUYlvmgs2370GXVSB861w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rspack/resolver-binding-win32-x64-msvc": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@rspack/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-0.2.8.tgz",
+      "integrity": "sha512-hzRpfbtvv4M4EVrKKIAaHDs5wT8lVcbSUjtwPs5u4IeLEix45nQPQ6ZQjmE4lIH0GP/3L3XQhZroYmTcH/xdsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -10508,6 +10985,13 @@
         "micromark-util-character": "^1.1.0",
         "micromark-util-symbol": "^1.0.1"
       }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.0.0",
@@ -11522,6 +12006,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -11828,6 +12322,16 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
+    },
+    "node_modules/@types/tapable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-oMnbAXeVo+KUnje3hzdORXUbfnzTfqD0H92mLl19NE5hFqH9Q4ktq+xehNSxcNeeLm1COopYwa0zeP6Iz+oIXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tapable": "^2.3.0"
+      }
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
@@ -12725,6 +13229,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -12734,9 +13248,9 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
@@ -13658,13 +14172,26 @@
         }
       ]
     },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "version": "2.11.13",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.13.tgz",
+      "integrity": "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==",
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/basic-auth": {
@@ -13881,9 +14408,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "funding": [
         {
           "type": "opencollective",
@@ -13900,17 +14427,37 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/browserslist-load-config": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/browserslist-load-config/-/browserslist-load-config-1.0.3.tgz",
+      "integrity": "sha512-boNaPS4KlW6AITZQ60G+1oDJLuxauljDd7QNQFOYpRtldzcTDknMZ8awbwI0BT/8h1/Y/CG4k/tDOLip9lAGcg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/browserslist-to-es-version": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/browserslist-to-es-version/-/browserslist-to-es-version-1.4.2.tgz",
+      "integrity": "sha512-3NV13pCv0wmPxxZZcekHAG6vt8rQ94w2c4/UBe3ZU3NDUm5TP+QFK3rjS6XeKWSHWpnPYNfQzlhnljka0BrEOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.2"
+      },
+      "bin": {
+        "browserslist-to-es-version": "dist/cli.js"
       }
     },
     "node_modules/bs-logger": {
@@ -14122,9 +14669,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001769",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
-      "integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -15184,6 +15731,24 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/corser": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
@@ -15217,6 +15782,24 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {
@@ -16388,9 +16971,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.286",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
-      "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+      "version": "1.5.405",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.405.tgz",
+      "integrity": "sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -16480,6 +17063,38 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.9",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.9.tgz",
+      "integrity": "sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "@types/ws": "^8.5.12",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.21.0"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -16687,6 +17302,18 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types"
+      ]
     },
     "node_modules/esast-util-from-estree": {
       "version": "2.0.0",
@@ -18347,6 +18974,16 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/filesize": {
+      "version": "11.0.22",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-11.0.22.tgz",
+      "integrity": "sha512-RlCVs9CY+oSsRnNZn95J9vDXjNjOwddKyTFjOYtA4yxYVIxBnwiVVGJX+TFhsmu3uUf81JDGyijtYL9xgawlTw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 10.8.0"
+      }
+    },
     "node_modules/filing-cabinet": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-5.0.3.tgz",
@@ -18759,6 +19396,19 @@
       "dev": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-port": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-proto": {
@@ -24371,6 +25021,13 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/json-stream-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-stream-stringify/-/json-stream-stringify-3.0.1.tgz",
+      "integrity": "sha512-vuxs3G1ocFDiAQ/SX0okcZbtqXwgj1g71qE9+vrjJ2EkjKQlEFDAcUNRxRU8O+GekV4v5cM2qXP0Wyt/EMDBiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -28032,10 +28689,13 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-      "license": "MIT"
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/node-source-walk": {
       "version": "7.0.1",
@@ -28983,6 +29643,13 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -32367,6 +33034,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rslog": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/rslog/-/rslog-2.3.0.tgz",
+      "integrity": "sha512-g2wW/ermwzGTLlzGdJBDRc4YKz2/yPBjf57w9g5CvhtpZ91Xq95OaWku0oNHYi+XsuV6v8QrCo2oJJR/pCUR8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/rtlcss": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-4.3.0.tgz",
@@ -33135,6 +33812,68 @@
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/socket.io": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
+      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.3.2",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.8.tgz",
+      "integrity": "sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.4.1",
+        "ws": "~8.21.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/sockjs": {
@@ -35064,9 +35803,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -35409,6 +36148,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite-bundle-analyzer": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/vite-bundle-analyzer/-/vite-bundle-analyzer-1.3.9.tgz",
+      "integrity": "sha512-hhy975B+ToseJaSJp3mURHriZUrMgaM2qx0BkP62kN6Yp46rw7EE3dl8ExFWYdn00OIwe7GbsA5PknvstNWG4Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "analyze": "dist/bin.js"
       }
     },
     "node_modules/w3c-xmlserializer": {
@@ -36823,7 +37572,9 @@
     "packages/js-example": {
       "name": "@maxgraph/js-example-webpack",
       "devDependencies": {
+        "@rsdoctor/webpack-plugin": "~1.6.1",
         "copy-webpack-plugin": "~14.0.0",
+        "cross-env": "~10.1.0",
         "css-loader": "~7.1.4",
         "html-webpack-plugin": "~5.6.8",
         "http-server": "~14.1.1",
@@ -36831,7 +37582,7 @@
         "style-loader": "~4.0.0",
         "webpack": "~5.109.2",
         "webpack-cli": "~7.2.2",
-        "webpack-dev-server": "^6.0.0"
+        "webpack-dev-server": "~6.0.0"
       }
     },
     "packages/js-example-nodejs": {
@@ -36846,7 +37597,9 @@
     "packages/js-example-selected-features": {
       "name": "@maxgraph/js-example-webpack-selected-features",
       "devDependencies": {
+        "@rsdoctor/webpack-plugin": "~1.6.1",
         "copy-webpack-plugin": "~14.0.0",
+        "cross-env": "~10.1.0",
         "css-loader": "~7.1.4",
         "html-webpack-plugin": "~5.6.8",
         "http-server": "~14.1.1",
@@ -36854,7 +37607,7 @@
         "style-loader": "~4.0.0",
         "webpack": "~5.109.2",
         "webpack-cli": "~7.2.2",
-        "webpack-dev-server": "^6.0.0"
+        "webpack-dev-server": "~6.0.0"
       }
     },
     "packages/js-example-selected-features/node_modules/@types/express": {
@@ -37476,7 +38229,9 @@
     "packages/js-example-without-defaults": {
       "name": "@maxgraph/js-example-webpack-without-defaults",
       "devDependencies": {
+        "@rsdoctor/webpack-plugin": "~1.6.1",
         "copy-webpack-plugin": "~14.0.0",
+        "cross-env": "~10.1.0",
         "css-loader": "~7.1.4",
         "html-webpack-plugin": "~5.6.8",
         "http-server": "~14.1.1",
@@ -37484,7 +38239,7 @@
         "style-loader": "~4.0.0",
         "webpack": "~5.109.2",
         "webpack-cli": "~7.2.2",
-        "webpack-dev-server": "^6.0.0"
+        "webpack-dev-server": "~6.0.0"
       }
     },
     "packages/js-example-without-defaults/node_modules/@types/express": {
@@ -38723,7 +39478,9 @@
       "name": "@maxgraph/ts-example-vite-custom-shapes",
       "license": "Apache-2.0",
       "devDependencies": {
-        "vite": "~8.2.1"
+        "cross-env": "~10.1.0",
+        "vite": "~8.2.1",
+        "vite-bundle-analyzer": "~1.3.9"
       }
     },
     "packages/ts-example-jest-commonjs": {
@@ -38741,7 +39498,9 @@
       "name": "@maxgraph/ts-example-vite-with-selected-features",
       "license": "Apache-2.0",
       "devDependencies": {
-        "vite": "~8.2.1"
+        "cross-env": "~10.1.0",
+        "vite": "~8.2.1",
+        "vite-bundle-analyzer": "~1.3.9"
       }
     },
     "packages/ts-example-selected-features/node_modules/picomatch": {
@@ -38839,7 +39598,9 @@
       "name": "@maxgraph/ts-example-vite-without-defaults",
       "license": "Apache-2.0",
       "devDependencies": {
-        "vite": "~8.2.1"
+        "cross-env": "~10.1.0",
+        "vite": "~8.2.1",
+        "vite-bundle-analyzer": "~1.3.9"
       }
     },
     "packages/ts-example-without-defaults/node_modules/picomatch": {

--- a/packages/js-example-selected-features/README.md
+++ b/packages/js-example-selected-features/README.md
@@ -34,3 +34,17 @@ For more build information see: [@maxgraph/core](../../README.md#development).
 Run `npm run dev` from this directory and go to http://localhost:8080/
 
 If you want to bundle the application, run `npm run build` and then run `npm run preview` to access to a preview of the bundle application.
+## Analyze the bundle
+
+[Rsdoctor](https://rsdoctor.rs/) is available to inspect what ends up in the bundle, which is useful to check the effect
+of the tree-shaking of `maxGraph`.
+
+Run `npm run build:analyze` from this directory. This builds in production mode with Rsdoctor enabled, then opens the
+report in the browser. Press `Ctrl+C` to stop the report server.
+
+Rsdoctor is intentionally not part of `npm run build`: it slows the build down and starts a server, so it is only
+enabled by the `build:analyze` script. The report is generated locally and is never published by the CI.
+
+The production build also enforces a size budget, see `performance` in `webpack.config.js`. The limits are the current
+bundle size rounded up to the next kB, so `npm run build` fails when the bundle grows. Use `npm run build:analyze` to
+find out what was added, and update the limits in `webpack.config.js` when the increase is intended.

--- a/packages/js-example-selected-features/README.md
+++ b/packages/js-example-selected-features/README.md
@@ -34,6 +34,8 @@ For more build information see: [@maxgraph/core](../../README.md#development).
 Run `npm run dev` from this directory and go to http://localhost:8080/
 
 If you want to bundle the application, run `npm run build` and then run `npm run preview` to access to a preview of the bundle application.
+
+
 ## Analyze the bundle
 
 [Rsdoctor](https://rsdoctor.rs/) is available to inspect what ends up in the bundle, which is useful to check the effect

--- a/packages/js-example-selected-features/README.md
+++ b/packages/js-example-selected-features/README.md
@@ -47,6 +47,7 @@ report in the browser. Press `Ctrl+C` to stop the report server.
 Rsdoctor is intentionally not part of `npm run build`: it slows the build down and starts a server, so it is only
 enabled by the `build:analyze` script. The report is generated locally and is never published by the CI.
 
-The production build also enforces a size budget, see `performance` in `webpack.config.js`. The limits are the current
-bundle size rounded up to the next kB, so `npm run build` fails when the bundle grows. Use `npm run build:analyze` to
-find out what was added, and update the limits in `webpack.config.js` when the increase is intended.
+The production build also enforces a size budget, see the limits passed to `withBundleAnalysisAndSizeBudget` at the
+bottom of `webpack.config.js`. They are the current bundle size rounded up to the next kB, so `npm run build` fails when
+the bundle grows. Use `npm run build:analyze` to find out what was added, and update the limits when the increase is
+intended.

--- a/packages/js-example-selected-features/package.json
+++ b/packages/js-example-selected-features/package.json
@@ -4,10 +4,13 @@
   "scripts": {
     "dev": "webpack serve --open",
     "build": "webpack --mode=production",
+    "build:analyze": "cross-env ANALYZE=true webpack --mode=production",
     "preview": "http-server -c-1 dist"
   },
   "devDependencies": {
+    "@rsdoctor/webpack-plugin": "~1.6.1",
     "copy-webpack-plugin": "~14.0.0",
+    "cross-env": "~10.1.0",
     "css-loader": "~7.1.4",
     "http-server": "~14.1.1",
     "html-webpack-plugin": "~5.6.8",

--- a/packages/js-example-selected-features/webpack.config.js
+++ b/packages/js-example-selected-features/webpack.config.js
@@ -3,13 +3,21 @@ const path = require('path');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const { RsdoctorWebpackPlugin } = require('@rsdoctor/webpack-plugin');
 
 // hack to get the webpack mode
 const isDevMode = !process.argv.includes('--mode=production');
+// Rsdoctor slows the build down, so only analyze the production bundle when explicitly asked for it: see 'build:analyze'
+const isBundleAnalysisEnabled = !isDevMode && process.env.ANALYZE === 'true';
 
 module.exports = {
   mode: 'development',
   entry: './src/index.js',
+  // Rsdoctor needs a source map to attribute the bytes of the minified bundle to individual modules, which is what the
+  // 'Parsed Size' of a module is. 'hidden-source-map' emits the map without adding a sourceMappingURL comment to the
+  // bundle, so the analyzed bundle stays byte for byte the one that the regular build produces. The key is only set
+  // when analyzing, to keep the webpack defaults everywhere else, in particular the source maps of the dev server.
+  ...(isBundleAnalysisEnabled ? { devtool: 'hidden-source-map' } : {}),
   output: {
     filename: '[name].[contenthash].js',
     path: path.resolve(__dirname, 'dist'),
@@ -33,5 +41,15 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: 'index.html',
     }),
-  ].concat(isDevMode ? [] : [new MiniCssExtractPlugin()]),
+  ]
+    .concat(isDevMode ? [] : [new MiniCssExtractPlugin()])
+    .concat(isBundleAnalysisEnabled ? [new RsdoctorWebpackPlugin()] : []),
+  // Fail the production build when the bundle grows, which is the signal that something new was pulled in.
+  // Sizes are in bytes, rounded up to the next kB from the current build: update them when an increase is intended.
+  // Development bundles are not minified, so no budget is enforced there.
+  performance: {
+    hints: isDevMode ? false : 'error',
+    maxAssetSize: 385_000,
+    maxEntrypointSize: 391_000,
+  },
 };

--- a/packages/js-example-selected-features/webpack.config.js
+++ b/packages/js-example-selected-features/webpack.config.js
@@ -3,21 +3,16 @@ const path = require('path');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const { RsdoctorWebpackPlugin } = require('@rsdoctor/webpack-plugin');
+const {
+  withBundleAnalysisAndSizeBudget,
+} = require('../../scripts/webpack/bundle-analysis.cjs');
 
 // hack to get the webpack mode
 const isDevMode = !process.argv.includes('--mode=production');
-// Rsdoctor slows the build down, so only analyze the production bundle when explicitly asked for it: see 'build:analyze'
-const isBundleAnalysisEnabled = !isDevMode && process.env.ANALYZE === 'true';
 
-module.exports = {
+const config = {
   mode: 'development',
   entry: './src/index.js',
-  // Rsdoctor needs a source map to attribute the bytes of the minified bundle to individual modules, which is what the
-  // 'Parsed Size' of a module is. 'hidden-source-map' emits the map without adding a sourceMappingURL comment to the
-  // bundle, so the analyzed bundle stays byte for byte the one that the regular build produces. The key is only set
-  // when analyzing, to keep the webpack defaults everywhere else, in particular the source maps of the dev server.
-  ...(isBundleAnalysisEnabled ? { devtool: 'hidden-source-map' } : {}),
   output: {
     filename: '[name].[contenthash].js',
     path: path.resolve(__dirname, 'dist'),
@@ -41,16 +36,10 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: 'index.html',
     }),
-  ]
-    .concat(isDevMode ? [] : [new MiniCssExtractPlugin()])
-    .concat(isBundleAnalysisEnabled ? [new RsdoctorWebpackPlugin()] : []),
-  // Fail the production build when the bundle grows, which is the signal that something new was pulled in.
-  // Sizes are in bytes, rounded up to the next kB from the current build: update them when an increase is intended.
-  // Development bundles are not minified, so no budget is enforced there, and an analyze run is a diagnostic:
-  // reporting a size error there would only add noise to the report that was asked for to understand the size.
-  performance: {
-    hints: isDevMode || isBundleAnalysisEnabled ? false : 'error',
-    maxAssetSize: 385_000,
-    maxEntrypointSize: 391_000,
-  },
+  ].concat(isDevMode ? [] : [new MiniCssExtractPlugin()]),
 };
+
+module.exports = withBundleAnalysisAndSizeBudget(
+  { isDevMode, maxAssetSize: 385_000, maxEntrypointSize: 391_000 },
+  config
+);

--- a/packages/js-example-selected-features/webpack.config.js
+++ b/packages/js-example-selected-features/webpack.config.js
@@ -46,9 +46,10 @@ module.exports = {
     .concat(isBundleAnalysisEnabled ? [new RsdoctorWebpackPlugin()] : []),
   // Fail the production build when the bundle grows, which is the signal that something new was pulled in.
   // Sizes are in bytes, rounded up to the next kB from the current build: update them when an increase is intended.
-  // Development bundles are not minified, so no budget is enforced there.
+  // Development bundles are not minified, so no budget is enforced there, and an analyze run is a diagnostic:
+  // reporting a size error there would only add noise to the report that was asked for to understand the size.
   performance: {
-    hints: isDevMode ? false : 'error',
+    hints: isDevMode || isBundleAnalysisEnabled ? false : 'error',
     maxAssetSize: 385_000,
     maxEntrypointSize: 391_000,
   },

--- a/packages/js-example-without-defaults/README.md
+++ b/packages/js-example-without-defaults/README.md
@@ -30,3 +30,20 @@ For more build information see: [@maxgraph/core](../../README.md#development).
 Run `npm run dev` from this directory and go to http://localhost:8080/
 
 If you want to bundle the application, run `npm run build` and then run `npm run preview` to access to a preview of the bundle application.
+
+
+## Analyze the bundle
+
+[Rsdoctor](https://rsdoctor.rs/) is available to inspect what ends up in the bundle, which is useful to check that the
+tree-shaking of `maxGraph` behaves as expected.
+
+Run `npm run build:analyze` from this directory. This builds in production mode with Rsdoctor enabled, then opens the
+report in the browser. Press `Ctrl+C` to stop the report server.
+
+Rsdoctor is intentionally not part of `npm run build`: it slows the build down and starts a server, so it is only
+enabled by the `build:analyze` script. The report is generated locally and is never published by the CI.
+
+The production build also enforces a size budget, see `performance` in `webpack.config.js`. The limits are the current
+bundle size rounded up to the next kB, so `npm run build` fails when the bundle grows, which usually means that
+defaults are no longer tree-shaken. Use `npm run build:analyze` to find out what was added, and update the limits in
+`webpack.config.js` when the increase is intended.

--- a/packages/js-example-without-defaults/README.md
+++ b/packages/js-example-without-defaults/README.md
@@ -43,7 +43,7 @@ report in the browser. Press `Ctrl+C` to stop the report server.
 Rsdoctor is intentionally not part of `npm run build`: it slows the build down and starts a server, so it is only
 enabled by the `build:analyze` script. The report is generated locally and is never published by the CI.
 
-The production build also enforces a size budget, see `performance` in `webpack.config.js`. The limits are the current
-bundle size rounded up to the next kB, so `npm run build` fails when the bundle grows, which usually means that
-defaults are no longer tree-shaken. Use `npm run build:analyze` to find out what was added, and update the limits in
-`webpack.config.js` when the increase is intended.
+The production build also enforces a size budget, see the limits passed to `withBundleAnalysisAndSizeBudget` at the
+bottom of `webpack.config.js`. They are the current bundle size rounded up to the next kB, so `npm run build` fails when
+the bundle grows, which usually means that defaults are no longer tree-shaken. Use `npm run build:analyze` to find out
+what was added, and update the limits when the increase is intended.

--- a/packages/js-example-without-defaults/package.json
+++ b/packages/js-example-without-defaults/package.json
@@ -4,10 +4,13 @@
   "scripts": {
     "dev": "webpack serve --open",
     "build": "webpack --mode=production",
+    "build:analyze": "cross-env ANALYZE=true webpack --mode=production",
     "preview": "http-server -c-1 dist"
   },
   "devDependencies": {
+    "@rsdoctor/webpack-plugin": "~1.6.1",
     "copy-webpack-plugin": "~14.0.0",
+    "cross-env": "~10.1.0",
     "css-loader": "~7.1.4",
     "http-server": "~14.1.1",
     "html-webpack-plugin": "~5.6.8",

--- a/packages/js-example-without-defaults/webpack.config.js
+++ b/packages/js-example-without-defaults/webpack.config.js
@@ -3,13 +3,21 @@ const path = require('path');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const { RsdoctorWebpackPlugin } = require('@rsdoctor/webpack-plugin');
 
 // hack to get the webpack mode
 const isDevMode = !process.argv.includes('--mode=production');
+// Rsdoctor slows the build down, so only analyze the production bundle when explicitly asked for it: see 'build:analyze'
+const isBundleAnalysisEnabled = !isDevMode && process.env.ANALYZE === 'true';
 
 module.exports = {
   mode: 'development',
   entry: './src/index.js',
+  // Rsdoctor needs a source map to attribute the bytes of the minified bundle to individual modules, which is what the
+  // 'Parsed Size' of a module is. 'hidden-source-map' emits the map without adding a sourceMappingURL comment to the
+  // bundle, so the analyzed bundle stays byte for byte the one that the regular build produces. The key is only set
+  // when analyzing, to keep the webpack defaults everywhere else, in particular the source maps of the dev server.
+  ...(isBundleAnalysisEnabled ? { devtool: 'hidden-source-map' } : {}),
   output: {
     filename: '[name].[contenthash].js',
     path: path.resolve(__dirname, 'dist'),
@@ -33,5 +41,15 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: 'index.html',
     }),
-  ].concat(isDevMode ? [] : [new MiniCssExtractPlugin()]),
+  ]
+    .concat(isDevMode ? [] : [new MiniCssExtractPlugin()])
+    .concat(isBundleAnalysisEnabled ? [new RsdoctorWebpackPlugin()] : []),
+  // Fail the production build when the bundle grows, which would mean that defaults are no longer tree-shaken.
+  // Sizes are in bytes, rounded up to the next kB from the current build: update them when an increase is intended.
+  // Development bundles are not minified, so no budget is enforced there.
+  performance: {
+    hints: isDevMode ? false : 'error',
+    maxAssetSize: 240_000,
+    maxEntrypointSize: 241_000,
+  },
 };

--- a/packages/js-example-without-defaults/webpack.config.js
+++ b/packages/js-example-without-defaults/webpack.config.js
@@ -3,21 +3,16 @@ const path = require('path');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const { RsdoctorWebpackPlugin } = require('@rsdoctor/webpack-plugin');
+const {
+  withBundleAnalysisAndSizeBudget,
+} = require('../../scripts/webpack/bundle-analysis.cjs');
 
 // hack to get the webpack mode
 const isDevMode = !process.argv.includes('--mode=production');
-// Rsdoctor slows the build down, so only analyze the production bundle when explicitly asked for it: see 'build:analyze'
-const isBundleAnalysisEnabled = !isDevMode && process.env.ANALYZE === 'true';
 
-module.exports = {
+const config = {
   mode: 'development',
   entry: './src/index.js',
-  // Rsdoctor needs a source map to attribute the bytes of the minified bundle to individual modules, which is what the
-  // 'Parsed Size' of a module is. 'hidden-source-map' emits the map without adding a sourceMappingURL comment to the
-  // bundle, so the analyzed bundle stays byte for byte the one that the regular build produces. The key is only set
-  // when analyzing, to keep the webpack defaults everywhere else, in particular the source maps of the dev server.
-  ...(isBundleAnalysisEnabled ? { devtool: 'hidden-source-map' } : {}),
   output: {
     filename: '[name].[contenthash].js',
     path: path.resolve(__dirname, 'dist'),
@@ -41,16 +36,10 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: 'index.html',
     }),
-  ]
-    .concat(isDevMode ? [] : [new MiniCssExtractPlugin()])
-    .concat(isBundleAnalysisEnabled ? [new RsdoctorWebpackPlugin()] : []),
-  // Fail the production build when the bundle grows, which would mean that defaults are no longer tree-shaken.
-  // Sizes are in bytes, rounded up to the next kB from the current build: update them when an increase is intended.
-  // Development bundles are not minified, so no budget is enforced there, and an analyze run is a diagnostic:
-  // reporting a size error there would only add noise to the report that was asked for to understand the size.
-  performance: {
-    hints: isDevMode || isBundleAnalysisEnabled ? false : 'error',
-    maxAssetSize: 240_000,
-    maxEntrypointSize: 241_000,
-  },
+  ].concat(isDevMode ? [] : [new MiniCssExtractPlugin()]),
 };
+
+module.exports = withBundleAnalysisAndSizeBudget(
+  { isDevMode, maxAssetSize: 240_000, maxEntrypointSize: 241_000 },
+  config
+);

--- a/packages/js-example-without-defaults/webpack.config.js
+++ b/packages/js-example-without-defaults/webpack.config.js
@@ -46,9 +46,10 @@ module.exports = {
     .concat(isBundleAnalysisEnabled ? [new RsdoctorWebpackPlugin()] : []),
   // Fail the production build when the bundle grows, which would mean that defaults are no longer tree-shaken.
   // Sizes are in bytes, rounded up to the next kB from the current build: update them when an increase is intended.
-  // Development bundles are not minified, so no budget is enforced there.
+  // Development bundles are not minified, so no budget is enforced there, and an analyze run is a diagnostic:
+  // reporting a size error there would only add noise to the report that was asked for to understand the size.
   performance: {
-    hints: isDevMode ? false : 'error',
+    hints: isDevMode || isBundleAnalysisEnabled ? false : 'error',
     maxAssetSize: 240_000,
     maxEntrypointSize: 241_000,
   },

--- a/packages/js-example/README.md
+++ b/packages/js-example/README.md
@@ -35,6 +35,7 @@ report in the browser. Press `Ctrl+C` to stop the report server.
 Rsdoctor is intentionally not part of `npm run build`: it slows the build down and starts a server, so it is only
 enabled by the `build:analyze` script. The report is generated locally and is never published by the CI.
 
-The production build also enforces a size budget, see `performance` in `webpack.config.js`. The limits are the current
-bundle size rounded up to the next kB, so `npm run build` fails when the bundle grows. Use `npm run build:analyze` to
-find out what was added, and update the limits in `webpack.config.js` when the increase is intended.
+The production build also enforces a size budget, see the limits passed to `withBundleAnalysisAndSizeBudget` at the
+bottom of `webpack.config.js`. They are the current bundle size rounded up to the next kB, so `npm run build` fails when
+the bundle grows. Use `npm run build:analyze` to find out what was added, and update the limits when the increase is
+intended.

--- a/packages/js-example/README.md
+++ b/packages/js-example/README.md
@@ -22,6 +22,8 @@ For more build information see: [@maxgraph/core](../../README.md#development).
 Run `npm run dev` from this directory and go to http://localhost:8080/
 
 If you want to bundle the application, run `npm run build` and then run `npm run preview` to access to a preview of the bundle application.
+
+
 ## Analyze the bundle
 
 [Rsdoctor](https://rsdoctor.rs/) is available to inspect what ends up in the bundle, which is useful to check the effect

--- a/packages/js-example/README.md
+++ b/packages/js-example/README.md
@@ -22,3 +22,17 @@ For more build information see: [@maxgraph/core](../../README.md#development).
 Run `npm run dev` from this directory and go to http://localhost:8080/
 
 If you want to bundle the application, run `npm run build` and then run `npm run preview` to access to a preview of the bundle application.
+## Analyze the bundle
+
+[Rsdoctor](https://rsdoctor.rs/) is available to inspect what ends up in the bundle, which is useful to check the effect
+of the tree-shaking of `maxGraph`.
+
+Run `npm run build:analyze` from this directory. This builds in production mode with Rsdoctor enabled, then opens the
+report in the browser. Press `Ctrl+C` to stop the report server.
+
+Rsdoctor is intentionally not part of `npm run build`: it slows the build down and starts a server, so it is only
+enabled by the `build:analyze` script. The report is generated locally and is never published by the CI.
+
+The production build also enforces a size budget, see `performance` in `webpack.config.js`. The limits are the current
+bundle size rounded up to the next kB, so `npm run build` fails when the bundle grows. Use `npm run build:analyze` to
+find out what was added, and update the limits in `webpack.config.js` when the increase is intended.

--- a/packages/js-example/package.json
+++ b/packages/js-example/package.json
@@ -4,10 +4,13 @@
   "scripts": {
     "dev": "webpack serve --open",
     "build": "webpack --mode=production",
+    "build:analyze": "cross-env ANALYZE=true webpack --mode=production",
     "preview": "http-server -c-1 dist"
   },
   "devDependencies": {
+    "@rsdoctor/webpack-plugin": "~1.6.1",
     "copy-webpack-plugin": "~14.0.0",
+    "cross-env": "~10.1.0",
     "css-loader": "~7.1.4",
     "http-server": "~14.1.1",
     "html-webpack-plugin": "~5.6.8",

--- a/packages/js-example/webpack.config.js
+++ b/packages/js-example/webpack.config.js
@@ -46,9 +46,10 @@ module.exports = {
     .concat(isBundleAnalysisEnabled ? [new RsdoctorWebpackPlugin()] : []),
   // Fail the production build when the bundle grows, which is the signal that something new was pulled in.
   // Sizes are in bytes, rounded up to the next kB from the current build: update them when an increase is intended.
-  // Development bundles are not minified, so no budget is enforced there.
+  // Development bundles are not minified, so no budget is enforced there, and an analyze run is a diagnostic:
+  // reporting a size error there would only add noise to the report that was asked for to understand the size.
   performance: {
-    hints: isDevMode ? false : 'error',
+    hints: isDevMode || isBundleAnalysisEnabled ? false : 'error',
     maxAssetSize: 467_000,
     maxEntrypointSize: 473_000,
   },

--- a/packages/js-example/webpack.config.js
+++ b/packages/js-example/webpack.config.js
@@ -3,13 +3,21 @@ const path = require('path');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const { RsdoctorWebpackPlugin } = require('@rsdoctor/webpack-plugin');
 
 // hack to get the webpack mode
 const isDevMode = !process.argv.includes('--mode=production');
+// Rsdoctor slows the build down, so only analyze the production bundle when explicitly asked for it: see 'build:analyze'
+const isBundleAnalysisEnabled = !isDevMode && process.env.ANALYZE === 'true';
 
 module.exports = {
   mode: 'development',
   entry: './src/index.js',
+  // Rsdoctor needs a source map to attribute the bytes of the minified bundle to individual modules, which is what the
+  // 'Parsed Size' of a module is. 'hidden-source-map' emits the map without adding a sourceMappingURL comment to the
+  // bundle, so the analyzed bundle stays byte for byte the one that the regular build produces. The key is only set
+  // when analyzing, to keep the webpack defaults everywhere else, in particular the source maps of the dev server.
+  ...(isBundleAnalysisEnabled ? { devtool: 'hidden-source-map' } : {}),
   output: {
     filename: '[name].[contenthash].js',
     path: path.resolve(__dirname, 'dist'),
@@ -33,5 +41,15 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: 'index.html',
     }),
-  ].concat(isDevMode ? [] : [new MiniCssExtractPlugin()]),
+  ]
+    .concat(isDevMode ? [] : [new MiniCssExtractPlugin()])
+    .concat(isBundleAnalysisEnabled ? [new RsdoctorWebpackPlugin()] : []),
+  // Fail the production build when the bundle grows, which is the signal that something new was pulled in.
+  // Sizes are in bytes, rounded up to the next kB from the current build: update them when an increase is intended.
+  // Development bundles are not minified, so no budget is enforced there.
+  performance: {
+    hints: isDevMode ? false : 'error',
+    maxAssetSize: 467_000,
+    maxEntrypointSize: 473_000,
+  },
 };

--- a/packages/js-example/webpack.config.js
+++ b/packages/js-example/webpack.config.js
@@ -3,21 +3,16 @@ const path = require('path');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const { RsdoctorWebpackPlugin } = require('@rsdoctor/webpack-plugin');
+const {
+  withBundleAnalysisAndSizeBudget,
+} = require('../../scripts/webpack/bundle-analysis.cjs');
 
 // hack to get the webpack mode
 const isDevMode = !process.argv.includes('--mode=production');
-// Rsdoctor slows the build down, so only analyze the production bundle when explicitly asked for it: see 'build:analyze'
-const isBundleAnalysisEnabled = !isDevMode && process.env.ANALYZE === 'true';
 
-module.exports = {
+const config = {
   mode: 'development',
   entry: './src/index.js',
-  // Rsdoctor needs a source map to attribute the bytes of the minified bundle to individual modules, which is what the
-  // 'Parsed Size' of a module is. 'hidden-source-map' emits the map without adding a sourceMappingURL comment to the
-  // bundle, so the analyzed bundle stays byte for byte the one that the regular build produces. The key is only set
-  // when analyzing, to keep the webpack defaults everywhere else, in particular the source maps of the dev server.
-  ...(isBundleAnalysisEnabled ? { devtool: 'hidden-source-map' } : {}),
   output: {
     filename: '[name].[contenthash].js',
     path: path.resolve(__dirname, 'dist'),
@@ -41,16 +36,10 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: 'index.html',
     }),
-  ]
-    .concat(isDevMode ? [] : [new MiniCssExtractPlugin()])
-    .concat(isBundleAnalysisEnabled ? [new RsdoctorWebpackPlugin()] : []),
-  // Fail the production build when the bundle grows, which is the signal that something new was pulled in.
-  // Sizes are in bytes, rounded up to the next kB from the current build: update them when an increase is intended.
-  // Development bundles are not minified, so no budget is enforced there, and an analyze run is a diagnostic:
-  // reporting a size error there would only add noise to the report that was asked for to understand the size.
-  performance: {
-    hints: isDevMode || isBundleAnalysisEnabled ? false : 'error',
-    maxAssetSize: 467_000,
-    maxEntrypointSize: 473_000,
-  },
+  ].concat(isDevMode ? [] : [new MiniCssExtractPlugin()]),
 };
+
+module.exports = withBundleAnalysisAndSizeBudget(
+  { isDevMode, maxAssetSize: 467_000, maxEntrypointSize: 473_000 },
+  config
+);

--- a/packages/ts-example-selected-features/README.md
+++ b/packages/ts-example-selected-features/README.md
@@ -28,3 +28,18 @@ Run `npm run dev` and go to http://localhost:5173/
 
 If you want to bundle the application, run `npm run build` and then run `npm run preview` to access to a preview of the
 bundle application.
+## Analyze the bundle
+
+[vite-bundle-analyzer](https://github.com/nonzzz/vite-bundle-analyzer) is available to inspect what ends up in the
+bundle, which is useful to check the effect of the tree-shaking of `maxGraph`.
+
+Run `npm run build:analyze` from this directory. This builds in production mode with the analyzer enabled, then opens
+the report in the browser. Press `Ctrl+C` to stop the report server.
+
+The analyzer is intentionally not part of `npm run build`: it slows the build down and starts a server, so it is only
+enabled by the `build:analyze` script. The report is generated locally and is never published by the CI.
+
+The production build also enforces a size limit on the `maxgraph` chunk, declared once at the top of `vite.config.js`.
+Vite only logs a warning when a chunk exceeds `chunkSizeWarningLimit`, so the same limit is passed to a shared plugin
+that turns it into an error: `npm run build` fails when the chunk grows. The limit is the current size rounded up to the
+next kB. Use `npm run build:analyze` to find out what was added, and update it when the increase is intended.

--- a/packages/ts-example-selected-features/README.md
+++ b/packages/ts-example-selected-features/README.md
@@ -28,6 +28,7 @@ Run `npm run dev` and go to http://localhost:5173/
 
 If you want to bundle the application, run `npm run build` and then run `npm run preview` to access to a preview of the
 bundle application.
+
 ## Analyze the bundle
 
 [vite-bundle-analyzer](https://github.com/nonzzz/vite-bundle-analyzer) is available to inspect what ends up in the

--- a/packages/ts-example-selected-features/README.md
+++ b/packages/ts-example-selected-features/README.md
@@ -40,7 +40,8 @@ the report in the browser. Press `Ctrl+C` to stop the report server.
 The analyzer is intentionally not part of `npm run build`: it slows the build down and starts a server, so it is only
 enabled by the `build:analyze` script. The report is generated locally and is never published by the CI.
 
-The production build also enforces a size limit on the `maxgraph` chunk, declared once at the top of `vite.config.js`.
-Vite only logs a warning when a chunk exceeds `chunkSizeWarningLimit`, so the same limit is passed to a shared plugin
-that turns it into an error: `npm run build` fails when the chunk grows. The limit is the current size rounded up to the
-next kB. Use `npm run build:analyze` to find out what was added, and update it when the increase is intended.
+The production build also enforces a size limit, declared once at the top of `vite.config.js` and checked against every
+emitted chunk. In practice the `maxgraph` chunk is the one that sets it, being by far the largest. Vite only logs a
+warning when a chunk exceeds `chunkSizeWarningLimit`, so the same limit is passed to a shared plugin that turns it into
+an error: `npm run build` fails when a chunk grows. The limit is the current size of that chunk rounded up to the next
+kB. Use `npm run build:analyze` to find out what was added, and update it when the increase is intended.

--- a/packages/ts-example-selected-features/package.json
+++ b/packages/ts-example-selected-features/package.json
@@ -6,9 +6,12 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --version && tsc && vite build --base ./",
+    "build:analyze": "cross-env ANALYZE=true npm run build",
     "preview": "vite preview"
   },
   "devDependencies": {
-    "vite": "~8.2.1"
+    "cross-env": "~10.1.0",
+    "vite": "~8.2.1",
+    "vite-bundle-analyzer": "~1.3.9"
   }
 }

--- a/packages/ts-example-selected-features/vite.config.js
+++ b/packages/ts-example-selected-features/vite.config.js
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import process from 'node:process';
 import { defineConfig } from 'vite';
 
 import { analyzer } from 'vite-bundle-analyzer';

--- a/packages/ts-example-selected-features/vite.config.js
+++ b/packages/ts-example-selected-features/vite.config.js
@@ -14,39 +14,42 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { realpathSync } from 'node:fs';
-import { createRequire } from 'node:module';
-import { dirname } from 'node:path';
-import { defineConfig, normalizePath } from 'vite';
+import { defineConfig } from 'vite';
 
-// Vite resolves symlinks to their real path, so the module ids of @maxgraph/core point to the workspace directory
-// instead of node_modules. Matching the resolved package directory keeps the chunk correct in both setups.
-// Both sides are normalized because realpathSync returns native separators on Windows, and the trailing separator
-// prevents matching a sibling directory whose name merely starts with 'core'.
-const maxGraphCoreDirectory = `${normalizePath(
-  realpathSync(
-    dirname(createRequire(import.meta.url).resolve('@maxgraph/core/package.json'))
-  )
-)}/`;
+import { analyzer } from 'vite-bundle-analyzer';
+
+import { failOnChunkSizeExceeded } from '../../scripts/vite/chunk-size-limit.mjs';
+import { maxGraphCodeSplitting } from '../../scripts/vite/maxgraph-chunk.mjs';
+
+// The maximum size of the maxgraph chunk, in kB. Declared once and passed to both the Vite warning and the blocking
+// check, so they cannot drift apart.
+const chunkSizeLimitInKB = 362;
 
 export default defineConfig(({ mode }) => {
+  // The analyzer slows the build down and starts a report server, so only analyze the production bundle when
+  // explicitly asked for it: see the 'build:analyze' script.
+  const isBundleAnalysisEnabled = mode === 'production' && process.env.ANALYZE === 'true';
+
   return {
+    plugins: [
+      // The analyzer runs after the size check, which aborts the build, so an oversized chunk would leave no report at
+      // all: exactly the case where the report is needed to find out what grew. Only one of the two is registered, and
+      // the plain 'npm run build' remains the one that enforces the limit.
+      ...(isBundleAnalysisEnabled
+        ? [analyzer()]
+        : [failOnChunkSizeExceeded(chunkSizeLimitInKB)]),
+    ],
     build: {
+      // The analyzer relies on the source map to report how much each module contributes to the bundle. 'hidden' emits
+      // the map without appending a sourceMappingURL comment, so what gets analyzed is byte for byte what the regular
+      // build produces. false is the Vite default, restated here to make the analysis-only nature explicit.
+      sourcemap: isBundleAnalysisEnabled ? 'hidden' : false,
       rolldownOptions: {
         output: {
-          codeSplitting: {
-            groups: [
-              {
-                // put the maxgraph code in a dedicated file. It lets know the size the produced bundle in an external application and if tree shaking works
-                name: 'maxgraph',
-                test: (moduleId) =>
-                  normalizePath(moduleId).startsWith(maxGraphCoreDirectory),
-              },
-            ],
-          },
+          codeSplitting: maxGraphCodeSplitting(),
         },
       },
-      chunkSizeWarningLimit: 362, // @maxgraph/core
+      chunkSizeWarningLimit: chunkSizeLimitInKB,
     },
   };
 });

--- a/packages/ts-example-without-defaults/README.md
+++ b/packages/ts-example-without-defaults/README.md
@@ -38,8 +38,9 @@ the report in the browser. Press `Ctrl+C` to stop the report server.
 The analyzer is intentionally not part of `npm run build`: it slows the build down and starts a server, so it is only
 enabled by the `build:analyze` script. The report is generated locally and is never published by the CI.
 
-The production build also enforces a size limit on the `maxgraph` chunk, declared once at the top of `vite.config.js`.
-Vite only logs a warning when a chunk exceeds `chunkSizeWarningLimit`, so the same limit is passed to a shared plugin
-that turns it into an error: `npm run build` fails when the chunk grows, which usually means that defaults are no longer
-tree-shaken. The limit is the current size rounded up to the next kB. Use `npm run build:analyze` to find out what was
+The production build also enforces a size limit, declared once at the top of `vite.config.js` and checked against every
+emitted chunk. In practice the `maxgraph` chunk is the one that sets it, being by far the largest. Vite only logs a
+warning when a chunk exceeds `chunkSizeWarningLimit`, so the same limit is passed to a shared plugin that turns it into
+an error: `npm run build` fails when a chunk grows, which usually means that defaults are no longer tree-shaken. The
+limit is the current size of that chunk rounded up to the next kB. Use `npm run build:analyze` to find out what was
 added, and update it when the increase is intended.

--- a/packages/ts-example-without-defaults/README.md
+++ b/packages/ts-example-without-defaults/README.md
@@ -26,3 +26,20 @@ Run `npm run dev` and go to http://localhost:5173/
 
 If you want to bundle the application, run `npm run build` and then run `npm run preview` to access to a preview of the
 bundle application.
+
+## Analyze the bundle
+
+[vite-bundle-analyzer](https://github.com/nonzzz/vite-bundle-analyzer) is available to inspect what ends up in the
+bundle, which is useful to check that the tree-shaking of `maxGraph` behaves as expected.
+
+Run `npm run build:analyze` from this directory. This builds in production mode with the analyzer enabled, then opens
+the report in the browser. Press `Ctrl+C` to stop the report server.
+
+The analyzer is intentionally not part of `npm run build`: it slows the build down and starts a server, so it is only
+enabled by the `build:analyze` script. The report is generated locally and is never published by the CI.
+
+The production build also enforces a size limit on the `maxgraph` chunk, declared once at the top of `vite.config.js`.
+Vite only logs a warning when a chunk exceeds `chunkSizeWarningLimit`, so the same limit is passed to a shared plugin
+that turns it into an error: `npm run build` fails when the chunk grows, which usually means that defaults are no longer
+tree-shaken. The limit is the current size rounded up to the next kB. Use `npm run build:analyze` to find out what was
+added, and update it when the increase is intended.

--- a/packages/ts-example-without-defaults/package.json
+++ b/packages/ts-example-without-defaults/package.json
@@ -6,9 +6,12 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --version && tsc && vite build --base ./",
+    "build:analyze": "cross-env ANALYZE=true npm run build",
     "preview": "vite preview"
   },
   "devDependencies": {
-    "vite": "~8.2.1"
+    "cross-env": "~10.1.0",
+    "vite": "~8.2.1",
+    "vite-bundle-analyzer": "~1.3.9"
   }
 }

--- a/packages/ts-example-without-defaults/vite.config.js
+++ b/packages/ts-example-without-defaults/vite.config.js
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import process from 'node:process';
 import { defineConfig } from 'vite';
 
 import { analyzer } from 'vite-bundle-analyzer';

--- a/packages/ts-example-without-defaults/vite.config.js
+++ b/packages/ts-example-without-defaults/vite.config.js
@@ -14,39 +14,42 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { realpathSync } from 'node:fs';
-import { createRequire } from 'node:module';
-import { dirname } from 'node:path';
-import { defineConfig, normalizePath } from 'vite';
+import { defineConfig } from 'vite';
 
-// Vite resolves symlinks to their real path, so the module ids of @maxgraph/core point to the workspace directory
-// instead of node_modules. Matching the resolved package directory keeps the chunk correct in both setups.
-// Both sides are normalized because realpathSync returns native separators on Windows, and the trailing separator
-// prevents matching a sibling directory whose name merely starts with 'core'.
-const maxGraphCoreDirectory = `${normalizePath(
-  realpathSync(
-    dirname(createRequire(import.meta.url).resolve('@maxgraph/core/package.json'))
-  )
-)}/`;
+import { analyzer } from 'vite-bundle-analyzer';
+
+import { failOnChunkSizeExceeded } from '../../scripts/vite/chunk-size-limit.mjs';
+import { maxGraphCodeSplitting } from '../../scripts/vite/maxgraph-chunk.mjs';
+
+// The maximum size of the maxgraph chunk, in kB. Declared once and passed to both the Vite warning and the blocking
+// check, so they cannot drift apart.
+const chunkSizeLimitInKB = 221;
 
 export default defineConfig(({ mode }) => {
+  // The analyzer slows the build down and starts a report server, so only analyze the production bundle when
+  // explicitly asked for it: see the 'build:analyze' script.
+  const isBundleAnalysisEnabled = mode === 'production' && process.env.ANALYZE === 'true';
+
   return {
+    plugins: [
+      // The analyzer runs after the size check, which aborts the build, so an oversized chunk would leave no report at
+      // all: exactly the case where the report is needed to find out what grew. Only one of the two is registered, and
+      // the plain 'npm run build' remains the one that enforces the limit.
+      ...(isBundleAnalysisEnabled
+        ? [analyzer()]
+        : [failOnChunkSizeExceeded(chunkSizeLimitInKB)]),
+    ],
     build: {
+      // The analyzer relies on the source map to report how much each module contributes to the bundle. 'hidden' emits
+      // the map without appending a sourceMappingURL comment, so what gets analyzed is byte for byte what the regular
+      // build produces. false is the Vite default, restated here to make the analysis-only nature explicit.
+      sourcemap: isBundleAnalysisEnabled ? 'hidden' : false,
       rolldownOptions: {
         output: {
-          codeSplitting: {
-            groups: [
-              {
-                // put the maxgraph code in a dedicated file. It lets know the size the produced bundle in an external application and if tree shaking works
-                name: 'maxgraph',
-                test: (moduleId) =>
-                  normalizePath(moduleId).startsWith(maxGraphCoreDirectory),
-              },
-            ],
-          },
+          codeSplitting: maxGraphCodeSplitting(),
         },
       },
-      chunkSizeWarningLimit: 221, // @maxgraph/core
+      chunkSizeWarningLimit: chunkSizeLimitInKB,
     },
   };
 });

--- a/packages/ts-example/README.md
+++ b/packages/ts-example/README.md
@@ -37,7 +37,8 @@ the report in the browser. Press `Ctrl+C` to stop the report server.
 The analyzer is intentionally not part of `npm run build`: it slows the build down and starts a server, so it is only
 enabled by the `build:analyze` script. The report is generated locally and is never published by the CI.
 
-The production build also enforces a size limit on the `maxgraph` chunk, declared once at the top of `vite.config.js`.
-Vite only logs a warning when a chunk exceeds `chunkSizeWarningLimit`, so the same limit is passed to a shared plugin
-that turns it into an error: `npm run build` fails when the chunk grows. The limit is the current size rounded up to the
-next kB. Use `npm run build:analyze` to find out what was added, and update it when the increase is intended.
+The production build also enforces a size limit, declared once at the top of `vite.config.js` and checked against every
+emitted chunk. In practice the `maxgraph` chunk is the one that sets it, being by far the largest. Vite only logs a
+warning when a chunk exceeds `chunkSizeWarningLimit`, so the same limit is passed to a shared plugin that turns it into
+an error: `npm run build` fails when a chunk grows. The limit is the current size of that chunk rounded up to the next
+kB. Use `npm run build:analyze` to find out what was added, and update it when the increase is intended.

--- a/packages/ts-example/README.md
+++ b/packages/ts-example/README.md
@@ -25,6 +25,7 @@ Run `npm run dev` and go to http://localhost:5173/
 
 If you want to bundle the application, run `npm run build` and then run `npm run preview` to access to a preview of the
 bundle application.
+
 ## Analyze the bundle
 
 [vite-bundle-analyzer](https://github.com/nonzzz/vite-bundle-analyzer) is available to inspect what ends up in the

--- a/packages/ts-example/README.md
+++ b/packages/ts-example/README.md
@@ -25,3 +25,18 @@ Run `npm run dev` and go to http://localhost:5173/
 
 If you want to bundle the application, run `npm run build` and then run `npm run preview` to access to a preview of the
 bundle application.
+## Analyze the bundle
+
+[vite-bundle-analyzer](https://github.com/nonzzz/vite-bundle-analyzer) is available to inspect what ends up in the
+bundle, which is useful to check the effect of the tree-shaking of `maxGraph`.
+
+Run `npm run build:analyze` from this directory. This builds in production mode with the analyzer enabled, then opens
+the report in the browser. Press `Ctrl+C` to stop the report server.
+
+The analyzer is intentionally not part of `npm run build`: it slows the build down and starts a server, so it is only
+enabled by the `build:analyze` script. The report is generated locally and is never published by the CI.
+
+The production build also enforces a size limit on the `maxgraph` chunk, declared once at the top of `vite.config.js`.
+Vite only logs a warning when a chunk exceeds `chunkSizeWarningLimit`, so the same limit is passed to a shared plugin
+that turns it into an error: `npm run build` fails when the chunk grows. The limit is the current size rounded up to the
+next kB. Use `npm run build:analyze` to find out what was added, and update it when the increase is intended.

--- a/packages/ts-example/package.json
+++ b/packages/ts-example/package.json
@@ -6,9 +6,12 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --version && tsc && vite build --base ./",
+    "build:analyze": "cross-env ANALYZE=true npm run build",
     "preview": "vite preview"
   },
   "devDependencies": {
-    "vite": "~8.2.1"
+    "cross-env": "~10.1.0",
+    "vite": "~8.2.1",
+    "vite-bundle-analyzer": "~1.3.9"
   }
 }

--- a/packages/ts-example/vite.config.js
+++ b/packages/ts-example/vite.config.js
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import process from 'node:process';
 import { defineConfig } from 'vite';
 
 import { analyzer } from 'vite-bundle-analyzer';

--- a/packages/ts-example/vite.config.js
+++ b/packages/ts-example/vite.config.js
@@ -14,39 +14,42 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { realpathSync } from 'node:fs';
-import { createRequire } from 'node:module';
-import { dirname } from 'node:path';
-import { defineConfig, normalizePath } from 'vite';
+import { defineConfig } from 'vite';
 
-// Vite resolves symlinks to their real path, so the module ids of @maxgraph/core point to the workspace directory
-// instead of node_modules. Matching the resolved package directory keeps the chunk correct in both setups.
-// Both sides are normalized because realpathSync returns native separators on Windows, and the trailing separator
-// prevents matching a sibling directory whose name merely starts with 'core'.
-const maxGraphCoreDirectory = `${normalizePath(
-  realpathSync(
-    dirname(createRequire(import.meta.url).resolve('@maxgraph/core/package.json'))
-  )
-)}/`;
+import { analyzer } from 'vite-bundle-analyzer';
+
+import { failOnChunkSizeExceeded } from '../../scripts/vite/chunk-size-limit.mjs';
+import { maxGraphCodeSplitting } from '../../scripts/vite/maxgraph-chunk.mjs';
+
+// The maximum size of the maxgraph chunk, in kB. Declared once and passed to both the Vite warning and the blocking
+// check, so they cannot drift apart.
+const chunkSizeLimitInKB = 429;
 
 export default defineConfig(({ mode }) => {
+  // The analyzer slows the build down and starts a report server, so only analyze the production bundle when
+  // explicitly asked for it: see the 'build:analyze' script.
+  const isBundleAnalysisEnabled = mode === 'production' && process.env.ANALYZE === 'true';
+
   return {
+    plugins: [
+      // The analyzer runs after the size check, which aborts the build, so an oversized chunk would leave no report at
+      // all: exactly the case where the report is needed to find out what grew. Only one of the two is registered, and
+      // the plain 'npm run build' remains the one that enforces the limit.
+      ...(isBundleAnalysisEnabled
+        ? [analyzer()]
+        : [failOnChunkSizeExceeded(chunkSizeLimitInKB)]),
+    ],
     build: {
+      // The analyzer relies on the source map to report how much each module contributes to the bundle. 'hidden' emits
+      // the map without appending a sourceMappingURL comment, so what gets analyzed is byte for byte what the regular
+      // build produces. false is the Vite default, restated here to make the analysis-only nature explicit.
+      sourcemap: isBundleAnalysisEnabled ? 'hidden' : false,
       rolldownOptions: {
         output: {
-          codeSplitting: {
-            groups: [
-              {
-                // put the maxgraph code in a dedicated file. It lets know the size the produced bundle in an external application and if tree shaking works
-                name: 'maxgraph',
-                test: (moduleId) =>
-                  normalizePath(moduleId).startsWith(maxGraphCoreDirectory),
-              },
-            ],
-          },
+          codeSplitting: maxGraphCodeSplitting(),
         },
       },
-      chunkSizeWarningLimit: 429, // @maxgraph/core
+      chunkSizeWarningLimit: chunkSizeLimitInKB,
     },
   };
 });

--- a/scripts/build-all-examples.bash
+++ b/scripts/build-all-examples.bash
@@ -3,6 +3,7 @@ set -euo pipefail
 
 # This script builds all examples in the packages directory.
 # From the root of the repository, run " ./scripts/build-all-examples.bash"
+# Options can be combined, run with "--help" for the list.
 
 
 usage() {
@@ -11,19 +12,29 @@ usage() {
   echo "Build all examples and display bundle sizes."
   echo
   echo "Options:"
+  echo "  --fail-at-end     Keep building the remaining examples after a failure, and report all the failures at the"
+  echo "                    very end, after the size sections. Exit non-zero if any build failed. Without this option,"
+  echo "                    the script stops at the first failing build. No effect with --list-size-only, which builds"
+  echo "                    nothing."
   echo "  --list-size-only  Skip building, only display bundle sizes from existing dist/ directories"
   echo "  --help            Show this help message"
   return 0
 }
 
 LIST_SIZE_ONLY=false
-if [[ $# -gt 0 ]]; then
+FAIL_AT_END=false
+while [[ $# -gt 0 ]]; do
   case "$1" in
     --help) usage; exit 0 ;;
+    --fail-at-end) FAIL_AT_END=true ;;
     --list-size-only) LIST_SIZE_ONLY=true ;;
     *) echo "Unknown option: $1"; usage; exit 1 ;;
   esac
-fi
+  shift
+done
+
+# Names of the examples whose build failed, only filled when FAIL_AT_END is true
+FAILED_EXAMPLES=()
 
 if [[ "$LIST_SIZE_ONLY" = true ]]; then
   echo "Skip building examples."
@@ -36,11 +47,26 @@ else
       echo "##################################################"
       echo "Building $dir"
       echo "##################################################"
-      (cd "$dir" && npm run build)
+      if [[ "$FAIL_AT_END" = true ]]; then
+        # '|| build_exit_code=$?' keeps 'set -e' from aborting here, and only here, so the remaining examples are still
+        # built and the size sections are still printed
+        build_exit_code=0
+        (cd "$dir" && npm run build) || build_exit_code=$?
+        if [[ "$build_exit_code" -ne 0 ]]; then
+          echo "Build of $dir FAILED with exit code $build_exit_code"
+          FAILED_EXAMPLES+=("$(basename "$dir") (exit code $build_exit_code)")
+        fi
+      else
+        (cd "$dir" && npm run build)
+      fi
     fi
   done
 
-  echo "All examples built successfully."
+  if [[ ${#FAILED_EXAMPLES[@]} -eq 0 ]]; then
+    echo "All examples built successfully."
+  else
+    echo "${#FAILED_EXAMPLES[@]} example(s) failed to build, see the summary at the end."
+  fi
 fi
 
 
@@ -74,9 +100,11 @@ for dir in packages/ts-example* packages/js-example*; do
 done
 
 # Collect bundle sizes (largest JS file per example = the one containing maxGraph)
-# Use indexed array instead of associative array for bash 3.x compatibility (macOS)
+# Use indexed array instead of associative array for bash 3.x compatibility (macOS). For the same reason, the loops
+# below are counted rather than iterating over '${!EXAMPLES_FOR_TABLE[@]}', which aborts under 'set -u' in bash 3.x
+# when the array is empty. --fail-at-end makes that case reachable, since every build failing leaves no dist at all.
 BUNDLE_SIZES=()
-for i in "${!EXAMPLES_FOR_TABLE[@]}"; do
+for ((i = 0; i < ${#EXAMPLES_FOR_TABLE[@]}; i++)); do
   dir="packages/${EXAMPLES_FOR_TABLE[$i]}"
   if [[ -d "$dir/dist" ]]; then
     BUNDLE_SIZES[$i]=$(find "$dir/dist" -name "*.js" -type f -exec ls -l {} \; | LC_NUMERIC=C awk '
@@ -96,7 +124,7 @@ echo "##################################################"
 echo
 echo "| Example | before | now |"
 echo "| --- | --- | --- |"
-for i in "${!EXAMPLES_FOR_TABLE[@]}"; do
+for ((i = 0; i < ${#EXAMPLES_FOR_TABLE[@]}; i++)); do
   size="${BUNDLE_SIZES[$i]}"
   if [[ -n "$size" ]]; then
     echo "| ${EXAMPLES_FOR_TABLE[$i]} | kB | $size kB |"
@@ -113,11 +141,26 @@ echo "##################################################"
 echo
 csv_header=""
 csv_values=""
-for i in "${!EXAMPLES_FOR_TABLE[@]}"; do
+for ((i = 0; i < ${#EXAMPLES_FOR_TABLE[@]}; i++)); do
   size="${BUNDLE_SIZES[$i]:-N/A}"
   csv_header="${csv_header:+$csv_header,}${EXAMPLES_FOR_TABLE[$i]}"
   csv_values="${csv_values:+$csv_values,}$size"
 done
 echo "$csv_header"
 echo "$csv_values"
+
+# Report the failed builds last, so that the sizes above stay readable in the CI log, and fail the script
+if [[ ${#FAILED_EXAMPLES[@]} -gt 0 ]]; then
+  echo
+  echo "##################################################"
+  echo "Failed builds"
+  echo "##################################################"
+  echo
+  for failed_example in "${FAILED_EXAMPLES[@]}"; do
+    echo "- $failed_example"
+  done
+  echo
+  echo "${#FAILED_EXAMPLES[@]} example(s) failed to build."
+  exit 1
+fi
 

--- a/scripts/vite/chunk-size-limit.mjs
+++ b/scripts/vite/chunk-size-limit.mjs
@@ -23,8 +23,8 @@ import { Buffer } from 'node:buffer';
  * and lets the build exit 0. A bundle regression then produces a single line in a CI log that nobody reads. See
  * https://github.com/vitejs/vite/issues/18496 for the upstream feature request.
  *
- * Pass the same value to `build.chunkSizeWarningLimit` and to this plugin, so the warning and the error cannot drift
- * apart. Sizes are computed in kB (1000 bytes) from the generated code, which matches both what Vite reports and what
+ * Pass the same value to `build.chunkSizeWarningLimit` and to this plugin, so the two thresholds cannot be set to
+ * different values. Sizes are computed in kB (1000 bytes) from the generated code, which matches what
  * `scripts/build-all-examples.bash` prints.
  *
  * @param {number} limitInKB the maximum size, in kB, allowed for a single chunk.

--- a/scripts/vite/chunk-size-limit.mjs
+++ b/scripts/vite/chunk-size-limit.mjs
@@ -1,0 +1,51 @@
+/*
+Copyright 2026-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { Buffer } from 'node:buffer';
+
+/**
+ * Vite plugin that fails the build when an emitted chunk is larger than `limitInKB`.
+ *
+ * `build.chunkSizeWarningLimit` is warn only: Vite passes it to its native reporter, which logs the oversized chunks
+ * and lets the build exit 0. A bundle regression then produces a single line in a CI log that nobody reads. See
+ * https://github.com/vitejs/vite/issues/18496 for the upstream feature request.
+ *
+ * Pass the same value to `build.chunkSizeWarningLimit` and to this plugin, so the warning and the error cannot drift
+ * apart. Sizes are computed in kB (1000 bytes) from the generated code, which matches both what Vite reports and what
+ * `scripts/build-all-examples.bash` prints.
+ *
+ * @param {number} limitInKB the maximum size, in kB, allowed for a single chunk.
+ * @returns {import('vite').Plugin} the plugin to add to the `plugins` of a Vite configuration.
+ */
+export function failOnChunkSizeExceeded(limitInKB) {
+  return {
+    name: 'maxgraph:fail-on-chunk-size-exceeded',
+    apply: 'build',
+    generateBundle(_options, bundle) {
+      for (const [fileName, output] of Object.entries(bundle)) {
+        if (output.type !== 'chunk') {
+          continue;
+        }
+        const sizeInKB = Buffer.byteLength(output.code) / 1000;
+        if (sizeInKB > limitInKB) {
+          this.error(
+            `Chunk "${fileName}" is ${sizeInKB.toFixed(2)} kB, above the ${limitInKB} kB limit.`
+          );
+        }
+      }
+    },
+  };
+}

--- a/scripts/vite/maxgraph-chunk.mjs
+++ b/scripts/vite/maxgraph-chunk.mjs
@@ -1,0 +1,61 @@
+/*
+Copyright 2026-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { realpathSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, posix, sep } from 'node:path';
+
+/**
+ * Same behavior as Vite's `normalizePath`, on node builtins only.
+ *
+ * Importing it from 'vite' works, but 'vite' is a dependency of each example package and not of the repository root, so
+ * resolving it from here relies on the bundled configuration being written to the example's `node_modules/.vite-temp`
+ * directory, and rolldown reports UNRESOLVED_IMPORT on every build.
+ *
+ * Backslashes are converted only on Windows, where they are the path separator, because a backslash is a legal
+ * character in a POSIX file name.
+ */
+function normalizePath(id) {
+  return posix.normalize(sep === '\\' ? id.replaceAll('\\', '/') : id);
+}
+
+// Vite resolves symlinks to their real path, so the module ids of @maxgraph/core point to the workspace directory
+// instead of node_modules. Matching the resolved package directory keeps the chunk correct in both setups.
+// Both sides are normalized because realpathSync returns native separators on Windows, and the trailing separator
+// prevents matching a sibling directory whose name merely starts with 'core'.
+const maxGraphCoreDirectory = `${normalizePath(
+  realpathSync(
+    dirname(createRequire(import.meta.url).resolve('@maxgraph/core/package.json'))
+  )
+)}/`;
+
+/**
+ * Code splitting that puts the @maxgraph/core code in a dedicated 'maxgraph' chunk. It makes the size that maxGraph
+ * takes in an external application visible, and shows whether tree shaking works.
+ *
+ * @returns {{ groups: Array<{ name: string, test: (moduleId: string) => boolean }> }} the value to set on
+ * `build.rolldownOptions.output.codeSplitting` of a Vite configuration.
+ */
+export function maxGraphCodeSplitting() {
+  return {
+    groups: [
+      {
+        name: 'maxgraph',
+        test: (moduleId) => normalizePath(moduleId).startsWith(maxGraphCoreDirectory),
+      },
+    ],
+  };
+}

--- a/scripts/webpack/bundle-analysis.cjs
+++ b/scripts/webpack/bundle-analysis.cjs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+const process = require('node:process');
 const { RsdoctorWebpackPlugin } = require('@rsdoctor/webpack-plugin');
 
 /**

--- a/scripts/webpack/bundle-analysis.cjs
+++ b/scripts/webpack/bundle-analysis.cjs
@@ -1,0 +1,58 @@
+/*
+Copyright 2026-present The maxGraph project Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+const { RsdoctorWebpackPlugin } = require('@rsdoctor/webpack-plugin');
+
+/**
+ * Adds to the webpack configuration of an example the bundle analysis and the size budget that all of them share.
+ *
+ * The analysis is opt-in and production only: Rsdoctor slows the build down and starts a report server, so it is
+ * enabled by the 'build:analyze' script through the ANALYZE environment variable. Rsdoctor needs a source map to
+ * attribute the bytes of the minified bundle to individual modules, which is what the 'Parsed Size' of a module is;
+ * 'hidden-source-map' emits that map without adding a sourceMappingURL comment to the bundle, so what gets analyzed
+ * stays byte for byte what the regular build produces. The key is only set when analyzing, to keep the webpack defaults
+ * everywhere else, in particular the source maps of the dev server.
+ *
+ * The budget fails the production build when the bundle grows, which is the signal that something new was pulled in.
+ * Development bundles are not minified, so nothing is enforced there, and an analyze run is a diagnostic: reporting a
+ * size error there would only add noise to the very report that was asked for to understand the size.
+ *
+ * @param {{isDevMode: boolean, maxAssetSize: number, maxEntrypointSize: number}} budget the sizes are in bytes, and
+ * each one is the smallest value that passes, that is the current size rounded up to the next kB.
+ * @param {object} config the configuration of the example.
+ * @returns {object} that configuration, with the analysis and the budget added.
+ */
+function withBundleAnalysisAndSizeBudget(
+  { isDevMode, maxAssetSize, maxEntrypointSize },
+  config
+) {
+  const isBundleAnalysisEnabled = !isDevMode && process.env.ANALYZE === 'true';
+
+  return {
+    ...config,
+    ...(isBundleAnalysisEnabled ? { devtool: 'hidden-source-map' } : {}),
+    plugins: (config.plugins ?? []).concat(
+      isBundleAnalysisEnabled ? [new RsdoctorWebpackPlugin()] : []
+    ),
+    performance: {
+      hints: isDevMode || isBundleAnalysisEnabled ? false : 'error',
+      maxAssetSize,
+      maxEntrypointSize,
+    },
+  };
+}
+
+module.exports = { withBundleAnalysisAndSizeBudget };


### PR DESCRIPTION
## Why

The bundled example packages had no way to tell what ends up in their bundle, and no guard against it growing.

The Vite examples declared a `chunkSizeWarningLimit`, but it only makes Vite log a warning and the build still exits 0, so a bundle regression showed up as a single line in a CI log that nobody reads (upstream request: https://github.com/vitejs/vite/issues/18496). The webpack examples had no budget at all.

## What

**Bundle analysis, opt-in, in the six bundled examples.** [Rsdoctor](https://rsdoctor.rs/) for the three webpack examples, [vite-bundle-analyzer](https://github.com/nonzzz/vite-bundle-analyzer) for the three Vite ones, since Rsdoctor supports only webpack and Rspack. Both are enabled by a dedicated `npm run build:analyze` script, which sets `ANALYZE=true` through `cross-env` so the command also works in Windows shells. The regular `npm run build` is untouched: no analyzer, no report server, no source map. A source map is generated for the analyze run only, `hidden-source-map` for webpack and `sourcemap: 'hidden'` for Vite, so the analyzed bundle stays byte for byte the one the regular build produces, content hash included; Rsdoctor needs it to attribute bytes to individual modules.

**The production build now fails when a bundle grows.** The webpack examples get a `performance` budget with `hints: 'error'`. Vite cannot do this on its own, so the examples pass their limit to a shared plugin, `scripts/vite/chunk-size-limit.mjs`, which fails the build naming the chunk and both sizes. Each limit is declared once per example and feeds both `chunkSizeWarningLimit` and the plugin, so the warning and the error cannot drift apart.

Each value is the smallest one that passes, that is the current size rounded up to the next kB. The intent is to follow the size evolution rather than to leave room to grow into, so the incidental headroom is accepted; the convention is recorded in `.claude/rules/tooling/bundle-size-budgets.md`.

**Nothing is enforced during a development build or an analyze run.** Development bundles are not minified, and an analyze run is a diagnostic: failing it would suppress the very report needed to understand the size. On the Vite side the guard and the analyzer are never registered together, because `vite-bundle-analyzer` is a post plugin, so the guard's error would abort the build before any report was written.

**`--fail-at-end` in `scripts/build-all-examples.bash`, used by the CI.** Once a build can fail on size, the first failure would abort the script and hide both the other examples and the size table, so getting the full picture would take one CI run per failing example. With the option, every example is built, the file listing, the markdown table and the CSV are still printed, and the failures are reported after them. The default behavior is unchanged: without the option the script still stops at the first failing build.

**What the examples share lives in `scripts/`.** `scripts/vite/maxgraph-chunk.mjs` holds the `codeSplitting` group that isolates `@maxgraph/core` in a dedicated `maxgraph` chunk, and `scripts/webpack/bundle-analysis.cjs` holds the Rsdoctor registration, the analyze-only source map and the `performance` block. Each family of configurations is therefore identical apart from its calibrated limit: the three `vite.config.js` differ by one line, and so do the three `webpack.config.js`.

**Dependabot.** New `vite` group for `vite` and `vite-*`, and `@rsdoctor/*` added to the existing `webpack` group, so those libraries move together across the examples. `@storybook/html-vite` is deliberately left in the `storybook` group, which owns the Vite version Storybook builds against.

## Sizes and budgets

| Example | current | budget |
| --- | --- | --- |
| js-example | 466,905 B asset, 472,414 B entrypoint | 467,000 / 473,000 |
| js-example-selected-features | 384,964 B asset, 390,473 B entrypoint | 385,000 / 391,000 |
| js-example-without-defaults | 239,112 B asset, 240,095 B entrypoint | 240,000 / 241,000 |
| ts-example | 428,747 B chunk | 429 kB |
| ts-example-selected-features | 361,547 B chunk | 362 kB |
| ts-example-without-defaults | 220,859 B chunk | 221 kB |

No bundle size changed in this PR. The `js-example-without-defaults` budget was initially calibrated against a stale `packages/core/lib`; rebuilding core brings that bundle to 239,112 B, and the budget follows.

## Decisions worth flagging

- **`--list-size-only --fail-at-end` is a documented no-op**, not an error: nothing is built, so nothing can fail, and a caller passing flags generically should not be rejected for a harmless combination.
- **The artifact upload runs with `if: ${{ !cancelled() }}`.** Skipping it on failure would defeat the purpose of `--fail-at-end`, since the `dist` of the examples that did build is what one wants to inspect. This does not weaken the gate: the job still fails, so the jobs depending on it, the release included, do not run.
- **A failed Vite build leaves no `dist`**, so a failing example disappears from the size table and the CSV instead of showing a stale number.
- **Budgets are tight by design**, between 36 B and about 900 B of headroom. A bundler patch bump can therefore turn a build red; the fix is to check the increase is intended and update the value in the same commit.
- **The shared modules are build tooling, not teaching material.** They make the example configurations reference `../../scripts/`, so an example folder is no longer standalone. That was accepted to keep the six configurations in sync and to avoid fixing the same line three times, which happened twice during the review of this PR.

## Validation

- `./scripts/build-all-examples.bash` and `./scripts/build-all-examples.bash --fail-at-end`: exit 0, the six examples below their limits, no webpack performance warning and no Vite chunk warning. Green on ubuntu-24.04, macos-14 and windows-2022.
- Guard proven blocking: with a limit lowered to 10 kB, `RolldownError: Chunk "assets/maxgraph-Be5ReXNy.js" is 361.55 kB, above the 10 kB limit.` and exit 1.
- `--fail-at-end` proven: with two limits lowered, both failures are listed after the size table, the third example still builds, exit code 1.
- Analyze runs verified on both bundlers: report reachable over HTTP, no size error reported, and the emitted bundles unchanged to the byte with identical content hashes.
- Extracting the shared modules verified as pure refactoring: same chunk sizes and same content hashes before and after, for the six examples.
- `npm run lint` clean. Note it only covers `**/*.ts`, so the configuration files and the two new `scripts/` modules are outside its scope; they were linted explicitly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added bundle-analysis commands for JavaScript and TypeScript examples.
  - Added dedicated `maxgraph` chunking and configurable production bundle-size limits.
  - Oversized production bundles now fail builds with clear size details.

- **Bug Fixes**
  - Example builds now continue after individual failures, upload successful results, and provide a final failure summary.

- **Documentation**
  - Expanded guidance for analyzing bundles, interpreting reports, and updating limits after intentional size increases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->