### PR TITLE
refactor(typescript): favor interface over type for object types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,19 @@ _**Note:** Yet to be released breaking changes appear here._
 - The order of the child elements produced by the XML serialization of `<Graph>` and `<BaseGraph>` has changed: `pageFormat` and `warningImage` are now emitted right after `options`, instead of last.
   This is not a breaking change, decoding matches elements by their `as` attribute and is order-independent, so existing documents keep decoding identically and previously exported documents are still valid.
   It is mentioned here only for consumers comparing exported XML as text, for instance in golden-file tests.
+- The object types exposed by the package are now declared with `interface` instead of `type`, in particular `CellStyle`, `CellStateStyle`, `EdgeParameters`, `VertexParameters`, `FitOptions`, `FitCenterOptions`, `EdgeStyleMetaData`, `UndoableChange`, `GraphFoldingOptions` and `GraphCollaboratorsOptions`. `CellStyle` in particular is now `interface CellStyle extends CellStateStyle` instead of an intersection.
+
+  This unlocks a new extension point: unlike type aliases, interfaces support [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation), so applications can now declare their own style properties instead of casting or widening the style objects:
+  ```typescript
+  declare module '@maxgraph/core' {
+    interface CellStateStyle {
+      myCustomStyleProperty?: number;
+    }
+  }
+  ```
+  Since `CellStyle` extends `CellStateStyle`, the declaration above applies to both. Augment `CellStyle` directly when the property only makes sense on the style declared on a cell and not on the computed state style.
+
+  This is not a breaking change for the vast majority of consumers, and JavaScript users are not impacted at all. The only TypeScript behavior that differs is that an interface has no implicit index signature, so a value typed with one of these interfaces is no longer implicitly assignable to `Record<string, unknown>` or to a similar index-signature type. Should you hit this, declare the intermediate variable with an explicit index signature or spread the object.
 
 ## 0.24.0
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -66,6 +66,7 @@ export default tsEslint.config(
       'import/no-absolute-path': 'warn',
       '@typescript-eslint/ban-ts-comment': 'off',
       '@typescript-eslint/ban-types': 'off',
+      '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
       '@typescript-eslint/no-this-alias': 'warn',
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-duplicate-enum-values': 'off', // check the impact of changing enum values if we want to enable this

--- a/packages/core/__tests__/serialization/utils.ts
+++ b/packages/core/__tests__/serialization/utils.ts
@@ -17,10 +17,10 @@ limitations under the License.
 import { expect } from '@jest/globals';
 import type { Cell, CellStyle, Geometry, GraphDataModel } from '../../src';
 
-type ExpectCellProperties = {
+interface ExpectCellProperties {
   geometry?: Geometry;
   style?: CellStyle;
-};
+}
 
 type NullableStringOrObject = string | object | null;
 

--- a/packages/core/__tests__/view/no-global-state-for-mixin-properties.ts
+++ b/packages/core/__tests__/view/no-global-state-for-mixin-properties.ts
@@ -26,7 +26,7 @@ import { type AbstractGraph, Cell, Multiplicity } from '../../src';
 // guarantee down, so moving one of them into a mixin fails here instead of silently corrupting state.
 //
 // When adding a property to that group, add a case here too.
-type PerInstanceProperty = {
+interface PerInstanceProperty {
   name: string;
   /** Reads the property under test on a graph. */
   read: (graph: AbstractGraph) => object;
@@ -34,7 +34,7 @@ type PerInstanceProperty = {
   mutate: (value: never) => void;
   /** Extracts what the mutation is expected to change, to compare two graphs without deep equality. */
   signature: (value: never) => unknown;
-};
+}
 
 const perInstanceProperties: PerInstanceProperty[] = [
   {

--- a/packages/core/__tests__/view/style/StyleSheet.test.ts
+++ b/packages/core/__tests__/view/style/StyleSheet.test.ts
@@ -21,10 +21,10 @@ import { NONE } from '../../../src/util/Constants';
 /**
  * Additional properties to test extension points by extending `CellStyle` and `CustomCellStateStyle`.
  */
-type CustomStyleAdditions = {
+interface CustomStyleAdditions {
   customProp1: number;
   customProp2: string;
-};
+}
 type CustomCellStyle = CellStyle & CustomStyleAdditions;
 type CustomCellStateStyle = CellStateStyle & CustomStyleAdditions;
 
@@ -33,21 +33,21 @@ type CustomCellStateStyle = CellStateStyle & CustomStyleAdditions;
 describe('Default styles', () => {
   test('Default edge style is set', () => {
     expect(new Stylesheet().getDefaultEdgeStyle()).toEqual(
-      expect.objectContaining(<CellStyle>{
+      expect.objectContaining({
         align: 'center',
         endArrow: 'classic',
         shape: 'connector',
-      })
+      } satisfies CellStyle)
     );
   });
 
   test('Default vertex style is set', () => {
     expect(new Stylesheet().getDefaultVertexStyle()).toEqual(
-      expect.objectContaining(<CellStyle>{
+      expect.objectContaining({
         align: 'center',
         fillColor: '#C3D9FF',
         shape: 'rectangle',
-      })
+      } satisfies CellStyle)
     );
   });
 });

--- a/packages/core/__tests__/view/style/StyleSheet.test.ts
+++ b/packages/core/__tests__/view/style/StyleSheet.test.ts
@@ -19,14 +19,27 @@ import { CellStateStyle, CellStyle, Stylesheet } from '../../../src';
 import { NONE } from '../../../src/util/Constants';
 
 /**
- * Additional properties to test extension points by extending `CellStyle` and `CustomCellStateStyle`.
+ * Additional properties to test extension points by extending `CellStyle` and `CellStateStyle`.
+ *
+ * An application would declare such properties with module augmentation, which is possible now that `CellStyle` and
+ * `CellStateStyle` are interfaces:
+ * ```typescript
+ * declare module '@maxgraph/core' {
+ *   interface CellStateStyle {
+ *     customProp1: number;
+ *   }
+ * }
+ * ```
+ * This is deliberately not done here: an augmentation applies to the whole TypeScript program, so the custom
+ * properties would leak into every other test of the package and weaken them. The `ts-support` package checks the
+ * augmentation itself, in a program of its own.
  */
 interface CustomStyleAdditions {
   customProp1: number;
   customProp2: string;
 }
-type CustomCellStyle = CellStyle & CustomStyleAdditions;
-type CustomCellStateStyle = CellStateStyle & CustomStyleAdditions;
+interface CustomCellStyle extends CellStyle, CustomStyleAdditions {}
+interface CustomCellStateStyle extends CellStateStyle, CustomStyleAdditions {}
 
 // Here we just check that the default styles are initialized, and some properties set
 // We don't test all properties on purpose

--- a/packages/core/__tests__/view/undoable-change/SelectionChange.test.ts
+++ b/packages/core/__tests__/view/undoable-change/SelectionChange.test.ts
@@ -18,7 +18,10 @@ import { describe, expect, test } from '@jest/globals';
 import { Cell, EventObject, InternalEvent, SelectionChange } from '../../../src';
 import type { AbstractGraph } from '../../../src';
 
-type CallLog = { kind: 'added' | 'removed'; cell: Cell };
+interface CallLog {
+  kind: 'added' | 'removed';
+  cell: Cell;
+}
 
 const createGraphStub = () => {
   const calls: CallLog[] = [];

--- a/packages/core/src/i18n/config.ts
+++ b/packages/core/src/i18n/config.ts
@@ -21,11 +21,11 @@ function getNavigatorLanguage() {
   return typeof window !== 'undefined' ? navigator.language : 'en';
 }
 
-type TranslationsConfigValuesType = {
+interface TranslationsConfigValuesType {
   defaultLanguage: string;
   language: string;
   languages: string[];
-};
+}
 
 const values: TranslationsConfigValuesType = {
   defaultLanguage: 'en',

--- a/packages/core/src/internal/types.ts
+++ b/packages/core/src/internal/types.ts
@@ -17,11 +17,11 @@ limitations under the License.
 /**
  * @private
  */
-export type UserObject = {
+export interface UserObject {
   nodeType?: number;
   getAttribute?: (name: string) => string | null;
   hasAttribute?: (name: string) => boolean;
   setAttribute?: (name: string, value: string) => void;
   clone?: () => UserObject;
   cloneNode?: (deep: boolean) => UserObject;
-};
+}

--- a/packages/core/src/serialization/ModelXmlSerializer.ts
+++ b/packages/core/src/serialization/ModelXmlSerializer.ts
@@ -28,13 +28,13 @@ import type GraphDataModel from '../view/GraphDataModel.js';
  * @since 0.6.0
  * @category Serialization with Codecs
  */
-export type ModelExportOptions = {
+export interface ModelExportOptions {
   /**
    * If `true`, prettify the exported xml.
    * @default true
    */
   pretty?: boolean;
-};
+}
 
 /**
  * Convenient utility class using {@link Codec} to manage maxGraph model import and export.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -37,11 +37,11 @@ import type VertexHandler from './view/handler/VertexHandler.js';
 export type FilterFunction = (cell: Cell) => boolean;
 
 /** @category Change */
-export type UndoableChange = {
+export interface UndoableChange {
   execute: () => void;
   undo?: () => void;
   redo?: () => void;
-};
+}
 
 /** @category Style */
 export type StyleValue = string | number;
@@ -49,7 +49,7 @@ export type StyleValue = string | number;
 export type Properties = Record<string, any>;
 
 /** @category Style */
-export type CellStyle = CellStateStyle & {
+export interface CellStyle extends CellStateStyle {
   /**
    * Names of styles used to fill properties before applying the specific properties defined in {@link CellStateStyle}.
    *
@@ -74,10 +74,10 @@ export type CellStyle = CellStateStyle & {
    * @since 0.11.0
    */
   ignoreDefaultStyle?: boolean;
-};
+}
 
 /** @category Style */
-export type CellStateStyle = {
+export interface CellStateStyle {
   /**
    * This specifies if {@link arcSize} for rectangles is absolute or relative.
    * @default false
@@ -974,7 +974,7 @@ export type CellStateStyle = {
    * @default 'nowrap'
    */
   whiteSpace?: WhiteSpaceValue;
-};
+}
 
 /** @category Style */
 export type NumericCellStateStyleKeys = NonNullable<
@@ -1095,7 +1095,7 @@ export type ShapeValue =
  */
 export type StyleShapeValue = ShapeValue | (string & Record<never, never>);
 
-export type CanvasState = {
+export interface CanvasState {
   alpha: number;
   dashPattern: string;
   dashed: boolean;
@@ -1133,7 +1133,7 @@ export type CanvasState = {
   strokeColor: ColorValue;
   strokeWidth: number;
   transform: string | null;
-};
+}
 
 export interface Gradient extends SVGLinearGradientElement {
   mxRefCount: number;
@@ -1142,7 +1142,7 @@ export interface Gradient extends SVGLinearGradientElement {
 export type GradientMap = Record<string, Gradient>;
 
 export type EdgeParametersValue = Record<string | number | symbol, any> | string;
-export type EdgeParameters = {
+export interface EdgeParameters {
   /**
    * Optional string that defines the id of the new edge. If not set, the id is auto-generated when creating the vertex.
    */
@@ -1164,9 +1164,9 @@ export type EdgeParameters = {
    * Object to be used as the user object which is generally used to display the label of the vertex. The default implementation handles `string` object.
    */
   value?: EdgeParametersValue;
-};
+}
 
-export type VertexParameters = {
+export interface VertexParameters {
   /**
    * Class reference to a class derived from {@link Geometry}.
    * This can be useful for defining custom constraints.
@@ -1222,7 +1222,7 @@ export type VertexParameters = {
    * If not set, falls back to the {@link position} property.
    */
   y?: number;
-};
+}
 
 /**
  * The ids of all built-in {@link GraphPlugin} provided by maxGraph.
@@ -1261,15 +1261,15 @@ export interface GraphPlugin {
 
 // Events
 /** @category Event */
-export type Listener = {
+export interface Listener {
   name: string;
   f: MouseEventListener | KeyboardEventListener;
-};
+}
 
 /** @category Event */
-export type ListenerTarget = {
+export interface ListenerTarget {
   mxListenerList?: Listener[];
-};
+}
 
 /** @category Event */
 export type Listenable = (EventTarget | (Window & typeof globalThis)) & ListenerTarget;
@@ -1287,11 +1287,11 @@ export type GestureEvent = Event &
   };
 
 /** @category Event */
-export type MouseListenerSet = {
+export interface MouseListenerSet {
   mouseDown: (sender: EventSource, me: InternalMouseEvent) => void;
   mouseMove: (sender: EventSource, me: InternalMouseEvent) => void;
   mouseUp: (sender: EventSource, me: InternalMouseEvent) => void;
-};
+}
 
 /** @category Event */
 export type EventCache = GestureEvent[];
@@ -1326,10 +1326,10 @@ export type IdentityObject = {
   [IDENTITY_FIELD_NAME]?: string;
 } & Record<string, any>;
 
-export type IdentityFunction = {
+export interface IdentityFunction {
   (): any;
   [IDENTITY_FIELD_NAME]?: string;
-};
+}
 
 /**
  * Describes a perimeter for the given bounds.
@@ -1517,7 +1517,7 @@ export interface I18nProvider {
 /**
  * @category Graph
  */
-export type GraphFoldingOptions = {
+export interface GraphFoldingOptions {
   /**
    * Specifies if folding (collapse and expand via an image icon in the graph should be enabled).
    * @default true
@@ -1538,7 +1538,7 @@ export type GraphFoldingOptions = {
    * @default true
    */
   collapseToPreferredSize: boolean;
-};
+}
 
 /**
  * Represents a constructor function for a class that produces instances of type `T`.
@@ -1570,13 +1570,13 @@ export type GraphOptions = {
  * @since 0.18.0
  * @category Graph
  */
-export type GraphCollaboratorsOptions = {
+export interface GraphCollaboratorsOptions {
   cellRenderer?: CellRenderer;
   model?: GraphDataModel;
   selectionModel?: (graph: AbstractGraph) => GraphSelectionModel;
   stylesheet?: Stylesheet;
   view?: (graph: AbstractGraph) => GraphView;
-};
+}
 
 /**
  * @since 0.20.0
@@ -1637,7 +1637,7 @@ export type EdgeStyleHandlerKind =
  * @category Style
  * @category Configuration
  */
-export type EdgeStyleMetaData = {
+export interface EdgeStyleMetaData {
   /**
    * The kind of {@link EdgeHandler} to use for this edge style.
    * This value is used to select the implementation of the edge handler to use to manage the underlying edge.
@@ -1656,7 +1656,7 @@ export type EdgeStyleMetaData = {
    * @since 0.24.0
    */
   allowIntermediateHandles?: boolean;
-};
+}
 
 /**
  * The definition of a registry that stores the {@link EdgeStyleFunction}s and their configuration.

--- a/packages/core/src/view/event/EventSource.ts
+++ b/packages/core/src/view/event/EventSource.ts
@@ -18,10 +18,10 @@ limitations under the License.
 
 import EventObject from './EventObject.js';
 
-type EventListenerObject = {
+interface EventListenerObject {
   funct: Function;
   name: string;
-};
+}
 
 /**
  * Base class for objects that dispatch named events.

--- a/packages/core/src/view/handler/config.ts
+++ b/packages/core/src/view/handler/config.ts
@@ -37,7 +37,7 @@ import { shallowCopy } from '../../internal/clone-utils.js';
  * @since 0.14.0
  * @category Configuration
  */
-export type EdgeHandlerConfigType = {
+export interface EdgeHandlerConfigType {
   /**
    * Specifies if adding bends by shift-click is enabled.
    *
@@ -116,7 +116,7 @@ export type EdgeHandlerConfigType = {
    * @since 0.15.0
    */
   virtualBendsEnabled: boolean;
-};
+}
 
 /**
  * Global configuration for {@link EdgeHandler} (including subclasses).

--- a/packages/core/src/view/image/ImageBundle.ts
+++ b/packages/core/src/view/image/ImageBundle.ts
@@ -16,12 +16,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-type ImageMap = {
+interface ImageMap {
   [key: string]: {
     value: string;
     fallback?: string;
   };
-};
+}
 
 /**
  * Maps from keys to base64 encoded images or file locations. All values must

--- a/packages/core/src/view/plugin/FitPlugin.ts
+++ b/packages/core/src/view/plugin/FitPlugin.ts
@@ -27,20 +27,20 @@ function keep2digits(value: number): number {
  * @since 0.17.0
  * @category Navigation
  */
-export type FitCenterOptions = {
+export interface FitCenterOptions {
   /**
    * Margin between the graph and the container.
    * @default 2
    */
   margin?: number;
-};
+}
 
 /**
  * Options of the {@link FitPlugin.fit} method.
  * @since 0.21.0
  * @category Navigation
  */
-export type FitOptions = {
+export interface FitOptions {
   /**
    * Optional number that specifies the border.
    * @default{@link Graph.getBorder}
@@ -76,7 +76,7 @@ export type FitOptions = {
    * @default null
    */
   maxHeight?: number | null;
-};
+}
 
 /**
  * A plugin providing methods to fit the graph within its container.

--- a/packages/core/src/view/style/config.ts
+++ b/packages/core/src/view/style/config.ts
@@ -93,7 +93,7 @@ export const resetOrthogonalConnectorConfig = (): void => {
  * @category Configuration
  * @category EdgeStyle
  */
-export type ManhattanConnectorConfigType = {
+export interface ManhattanConnectorConfigType {
   /**
    * Limit for directions change when searching route.
    * @default 90
@@ -121,7 +121,7 @@ export type ManhattanConnectorConfigType = {
    * @default 12
    */
   step: number;
-};
+}
 
 const allDirections = (): DirectionValue[] => {
   return ['north', 'south', 'east', 'west'];

--- a/packages/html/stories/UserObject.stories.ts
+++ b/packages/html/stories/UserObject.stories.ts
@@ -269,10 +269,10 @@ const Template = ({ label, ...args }: Record<string, string>) => {
     }
   }
 
-  type CellValueAttribute = {
+  interface CellValueAttribute {
     nodeName: string;
     nodeValue: string;
-  };
+  }
 
   /**
    * Creates the textfield for the given property.

--- a/packages/website/src/components/HomepageFeatures/index.tsx
+++ b/packages/website/src/components/HomepageFeatures/index.tsx
@@ -2,11 +2,11 @@ import clsx from 'clsx';
 import Heading from '@theme/Heading';
 import styles from './styles.module.css';
 
-type FeatureItem = {
+interface FeatureItem {
   title: string;
   Svg: React.ComponentType<React.ComponentProps<'svg'>>;
   description: JSX.Element;
-};
+}
 
 const FeatureList: FeatureItem[] = [
   {


### PR DESCRIPTION
## Problem

Object types exposed by the package were declared with `type` aliases. Beyond the inconsistency with the declarations already using `interface`, a type alias cannot be extended with [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation): a consumer trying to declare an extra style property gets a `TS2300 Duplicate identifier` error. The only workarounds were casting or widening the style objects at every call site.

## Changes

Enable [`@typescript-eslint/consistent-type-definitions`](https://typescript-eslint.io/rules/consistent-type-definitions/) with the `interface` option in `eslint.config.mjs`. The rule sits in the shared rules block, so it applies to every package, not only `core`.

Convert the declarations it reports, 27 across 14 files, mostly in `packages/core/src/types.ts`. The conversion is mechanical and was produced with `eslint --fix`.

`CellStyle` is converted by hand: it was an intersection (`CellStateStyle & { ... }`), a form the rule does not flag, and it is now `interface CellStyle extends CellStateStyle`. Two other intersections, `GraphOptions` and `IdentityObject`, are left as type aliases.

## New extension point

Applications can now declare their own style properties:

```typescript
declare module '@maxgraph/core' {
  interface CellStateStyle {
    myCustomStyleProperty?: number;
  }
}
```

Since `CellStyle` extends `CellStateStyle`, the declaration above applies to both. `CellStyle` can also be augmented on its own when the property only makes sense on the style declared on a cell and not on the computed state style. The inheritance stays one-way, so such a property does not leak onto `CellStateStyle`.

Both directions were checked by compiling an augmentation against the generated `.d.ts` files, including a `@ts-expect-error` on the leak case.

## Impact for consumers

Not a breaking change for the vast majority of consumers, and JavaScript users are not impacted at all. This is documented in the CHANGELOG under **Other Changes**.

The only TypeScript behavior that differs is that an interface has no implicit index signature, so these types are no longer implicitly assignable to `Record<string, unknown>` or to a similar index-signature type.

The single occurrence in this repository is in `StyleSheet.test.ts`, where the `CellStyle` cast passed to `expect.objectContaining` becomes a `satisfies` clause. This keeps the literal checked against `CellStyle` while leaving it with the index signature the matcher requires.

## Validation

The full CI chain was run locally: `build -w packages/core`, `test-check -w packages/core`, 561 tests in `packages/core`, `test -w packages/ts-support`, `build-all-examples.bash`, `build -w packages/html`, `check:circular-dependencies`, `check:npm-package` and `lint`. Example bundle sizes are unchanged.

## Note on scope

`packages/website` contains one `.tsx` file with a violation, which is fixed here. It is not covered by the CI though: the `lint` script glob is `**/*.ts`, which does not match `.tsx`. Extending it would surface 3 unrelated pre-existing `@typescript-eslint/no-require-imports` errors in that same file, so it is left for a separate change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the unreleased changelog with details about TypeScript interface usage and compatibility considerations.
  * Documented support for extending custom style properties through module augmentation.

* **Developer Experience**
  * Improved TypeScript API declarations by representing exported object-shaped types as interfaces.
  * Style-related types now support clearer extension patterns while preserving existing properties and behavior.
  * Added consistency checks to encourage interface-based type definitions across the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->