### PR TITLE
feat(typescript)!: support module augmentation of the exposed types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ _**Note:** Yet to be released breaking changes appear here._
   ```
 - The dispatch methods `createHandler` and `createEdgeHandler` are now defined on `SelectionCellsHandler`. If you were overriding them to change the dispatch logic itself (and not only the instantiated class), extend `SelectionCellsHandler` and pass your subclass in the `plugins` option.
 - `SelectionCellsHandler.createHandler` returns a non-nullable `CellHandler` (the new `EdgeHandler | VertexHandler` union type exported from the package), whereas `AbstractGraph.createHandler` was typed as nullable. TypeScript users can drop the now-useless null checks on the returned value.
+- The minimum supported TypeScript version is now **3.9**, up from 3.8. Applications still on TypeScript 3.8 must upgrade to use this release.
+  Module augmentation of the types exposed by the package silently does not work on TypeScript 3.8. TypeScript 3.9 fixes it.
 
 **Other Changes**:
 - The order of the child elements produced by the XML serialization of `<Graph>` and `<BaseGraph>` has changed: `pageFormat` and `warningImage` are now emitted right after `options`, instead of last.
@@ -40,7 +42,7 @@ _**Note:** Yet to be released breaking changes appear here._
   It is mentioned here only for consumers comparing exported XML as text, for instance in golden-file tests.
 - The object types exposed by the package are now declared with `interface` instead of `type`, in particular `CellStyle`, `CellStateStyle`, `EdgeParameters`, `VertexParameters`, `FitOptions`, `FitCenterOptions`, `EdgeStyleMetaData`, `UndoableChange`, `GraphFoldingOptions` and `GraphCollaboratorsOptions`. `CellStyle` in particular is now `interface CellStyle extends CellStateStyle` instead of an intersection.
 
-  This unlocks a new extension point: unlike type aliases, interfaces support [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation), so applications can now declare their own style properties instead of casting or widening the style objects:
+  This unlocks a new extension point: unlike type aliases, interfaces support [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation), so applications can now declare their own style properties instead of casting or widening the style objects. This requires TypeScript 3.9 or higher, see the breaking change above:
   ```typescript
   declare module '@maxgraph/core' {
     interface CellStateStyle {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ _**Note:** Yet to be released breaking changes appear here._
 - `SelectionCellsHandler.createHandler` returns a non-nullable `CellHandler` (the new `EdgeHandler | VertexHandler` union type exported from the package), whereas `AbstractGraph.createHandler` was typed as nullable. TypeScript users can drop the now-useless null checks on the returned value.
 - The minimum supported TypeScript version is now **3.9**, up from 3.8. Applications still on TypeScript 3.8 must upgrade to use this release.
   Module augmentation of the types exposed by the package silently does not work on TypeScript 3.8. TypeScript 3.9 fixes it.
-  TypeScript 3.8.2 was released in February 2020 and 3.9.3 in May 2020. Both are more than six years old, so most applications already use a newer version and the impact of this change should be limited.
+  TypeScript 3.8 was released in February 2020, 3.9 in May 2020 and 4.0 in August 2020. Both 3.8 and 3.9 are more than six years old, and 3.9 was superseded three months after its release, so most applications already use a newer version and the impact of this change should be limited.
 
 **Other Changes**:
 - The order of the child elements produced by the XML serialization of `<Graph>` and `<BaseGraph>` has changed: `pageFormat` and `warningImage` are now emitted right after `options`, instead of last.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ _**Note:** Yet to be released breaking changes appear here._
 - `SelectionCellsHandler.createHandler` returns a non-nullable `CellHandler` (the new `EdgeHandler | VertexHandler` union type exported from the package), whereas `AbstractGraph.createHandler` was typed as nullable. TypeScript users can drop the now-useless null checks on the returned value.
 - The minimum supported TypeScript version is now **3.9**, up from 3.8. Applications still on TypeScript 3.8 must upgrade to use this release.
   Module augmentation of the types exposed by the package silently does not work on TypeScript 3.8. TypeScript 3.9 fixes it.
+  TypeScript 3.8.2 was released in February 2020 and 3.9.3 in May 2020. Both are more than six years old, so most applications already use a newer version and the impact of this change should be limited.
 
 **Other Changes**:
 - The order of the child elements produced by the XML serialization of `<Graph>` and `<BaseGraph>` has changed: `pageFormat` and `warningImage` are now emitted right after `options`, instead of last.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ yarn add @maxgraph/core
 
 Compatibility of the npm package:
 - The JavaScript code conforms to the `ES2020` standard and is available in both CommonJS and ES Module formats
-- TypeScript integration requires **TypeScript 3.8** or higher
+- TypeScript integration requires **TypeScript 3.9** or higher (**TypeScript 3.8** for version 0.24.0 and earlier)
 
 <!-- END OF 'copied into packages/website/docs/getting-started.mdx' -->
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36831,7 +36831,7 @@
         "style-loader": "~4.0.0",
         "webpack": "~5.109.2",
         "webpack-cli": "~7.2.2",
-        "webpack-dev-server": "^6.0.0"
+        "webpack-dev-server": "~6.0.0"
       }
     },
     "packages/js-example-nodejs": {
@@ -36854,7 +36854,7 @@
         "style-loader": "~4.0.0",
         "webpack": "~5.109.2",
         "webpack-cli": "~7.2.2",
-        "webpack-dev-server": "^6.0.0"
+        "webpack-dev-server": "~6.0.0"
       }
     },
     "packages/js-example-selected-features/node_modules/@types/express": {
@@ -37484,7 +37484,7 @@
         "style-loader": "~4.0.0",
         "webpack": "~5.109.2",
         "webpack-cli": "~7.2.2",
-        "webpack-dev-server": "^6.0.0"
+        "webpack-dev-server": "~6.0.0"
       }
     },
     "packages/js-example-without-defaults/node_modules/@types/express": {
@@ -39027,11 +39027,13 @@
     "packages/ts-support": {
       "name": "@maxgraph/ts-support",
       "devDependencies": {
-        "typescript": "3.8.2"
+        "typescript": "3.9.10"
       }
     },
     "packages/ts-support/node_modules/typescript": {
-      "version": "3.8.2",
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/packages/ts-support/package.json
+++ b/packages/ts-support/package.json
@@ -5,6 +5,6 @@
     "test": "tsc --version && tsc"
   },
   "devDependencies": {
-    "typescript": "3.8.2"
+    "typescript": "3.9.10"
   }
 }

--- a/packages/ts-support/src/module-augmentation.ts
+++ b/packages/ts-support/src/module-augmentation.ts
@@ -1,0 +1,25 @@
+// Checks that the types exposed by maxGraph can be extended with module augmentation.
+//
+// This works only because they are declared with `interface` and not with `type`: augmenting a type alias fails with
+// "TS2300: Duplicate identifier". It also requires TypeScript 3.9 or higher. Older versions override the declaration
+// instead of merging with it when the augmented type reaches the entry point through an `export *` re-export, which
+// silently leaves the augmented type with the added property only.
+import { CellStyle, Stylesheet } from '@maxgraph/core';
+
+declare module '@maxgraph/core' {
+  interface CellStyle {
+    myCustomStyleProperty?: number;
+  }
+}
+
+const stylesheet = new Stylesheet();
+
+// The augmented property is accepted, both in the type annotation and when the style is passed to the API.
+const customStyle: CellStyle = { shape: 'rectangle', myCustomStyleProperty: 42 };
+stylesheet.putCellStyle('aCustomVertexStyle', customStyle);
+
+// A property that the augmentation does not declare is still rejected. Without this check, the statements above would
+// also compile if `CellStyle` accepted arbitrary properties, and the test would prove nothing.
+// @ts-expect-error 'anUndeclaredStyleProperty' does not exist in type 'CellStyle'
+const invalidStyle: CellStyle = { shape: 'rectangle', anUndeclaredStyleProperty: 42 };
+stylesheet.putCellStyle('anInvalidVertexStyle', invalidStyle);

--- a/packages/ts-support/src/module-augmentation.ts
+++ b/packages/ts-support/src/module-augmentation.ts
@@ -7,7 +7,9 @@
 import { CellStyle, Stylesheet } from '@maxgraph/core';
 
 declare module '@maxgraph/core' {
-  interface CellStyle {
+  // Augment CellStateStyle rather than CellStyle: CellStyle extends CellStateStyle, so the added property is available
+  // on both, and on everything else built on CellStateStyle (CellState.style, the Stylesheet default and named styles).
+  interface CellStateStyle {
     myCustomStyleProperty?: number;
   }
 }

--- a/packages/website/docs/getting-started.mdx
+++ b/packages/website/docs/getting-started.mdx
@@ -41,7 +41,7 @@ Install the latest version of `maxGraph` from the [npm registry](https://www.npm
 
 Compatibility of the npm package:
 - The JavaScript code conforms to the `ES2020` standard and is available in both CommonJS and ES Module formats
-- TypeScript integration requires **TypeScript 3.8** or higher
+- TypeScript integration requires **TypeScript 3.9** or higher (**TypeScript 3.8** for version 0.24.0 and earlier)
 :::
 
 [//]: # (END OF 'extract of <rootdir>/README.md')

--- a/packages/website/docs/intro.md
+++ b/packages/website/docs/intro.md
@@ -75,7 +75,7 @@ Active development ensures continuous bug fixes and new capabilities.
 - **Undo/redo**: Full history tracking for all operations with UndoManager
 
 ### Developer Experience
-- Written in TypeScript with complete type definitions. TypeScript integration requires **TypeScript 3.8** or higher
+- Written in TypeScript with complete type definitions. TypeScript integration requires **TypeScript 3.9** or higher (**TypeScript 3.8** for version 0.24.0 and earlier)
 - Zero third-party dependencies
 - [Tree-shakable](./usage/tree-shaking.md): use [`BaseGraph`](./usage/graph.md#basegraph) to import only what you need and reduce bundle size
 - Available as both ES Module and CommonJS. The JavaScript code conforms to the `ES2020` standard


### PR DESCRIPTION
Module augmentation of the maxGraph types silently does not work on TypeScript 3.8, where the augmentation overrides the declaration instead of merging with it. TypeScript 3.9 fixes it, so the minimum supported version moves from 3.8 to 3.9, in `ts-support` as well as in the README and on the website.

TypeScript 3.8 was released in February 2020, 3.9 in May 2020 and 4.0 in August 2020. Both 3.8 and 3.9 are more than six years old, and 3.9 was superseded three months after its release, so most applications already use a newer version and the impact of this breaking change should be limited.

Adds a `ts-support` check that augments `CellStateStyle` with a custom style property and passes it to the `Stylesheet` API through a `CellStyle`. `CellStyle` extends `CellStateStyle`, so augmenting the base interface makes the property available on both, and on everything else built on `CellStateStyle` (`CellState.style`, the `Stylesheet` default and named styles). The check fails if these types go back to being aliases, and a `@ts-expect-error` on an undeclared property makes sure the augmentation is what lets the rest compile.

**BREAKING CHANGE**: applications on TypeScript 3.8 must upgrade to 3.9.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated TypeScript compatibility guidance: current versions require TypeScript 3.9 or newer.
  * Clarified that version 0.24.0 and earlier support TypeScript 3.8 or newer.
  * Added guidance for applications using TypeScript module augmentation.

* **Tests**
  * Added coverage confirming custom cell style properties can be safely extended while undeclared properties remain rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

